### PR TITLE
fix(securities): preserve exact listing identity

### DIFF
--- a/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
+++ b/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
@@ -10,7 +10,8 @@ public class CommonStocksModuleConfiguration : Equibles.Data.IFinancialModule
     {
         var commonStock = builder.Entity<CommonStock>();
         commonStock.Property(stock => stock.Active).HasDefaultValue(true);
-        commonStock.Property(stock => stock.ReferenceTickers)
+        commonStock
+            .Property(stock => stock.ReferenceTickers)
             .IsRequired()
             .HasDefaultValueSql("'{}'::text[]");
         commonStock.HasIndex(stock => stock.Ticker).IsUnique().HasFilter("\"Active\"");

--- a/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
+++ b/src/Equibles.CommonStocks.Data/CommonStocksModuleConfiguration.cs
@@ -10,6 +10,9 @@ public class CommonStocksModuleConfiguration : Equibles.Data.IFinancialModule
     {
         var commonStock = builder.Entity<CommonStock>();
         commonStock.Property(stock => stock.Active).HasDefaultValue(true);
+        commonStock.Property(stock => stock.ReferenceTickers)
+            .IsRequired()
+            .HasDefaultValueSql("'{}'::text[]");
         commonStock.HasIndex(stock => stock.Ticker).IsUnique().HasFilter("\"Active\"");
         builder.Entity<CommonStockCusipAlias>();
         builder.Entity<CommonStockDelistedListing>();

--- a/src/Equibles.CommonStocks.Data/Helpers/SecondaryTickerPolicy.cs
+++ b/src/Equibles.CommonStocks.Data/Helpers/SecondaryTickerPolicy.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Equibles.CommonStocks.Data.Models;
 
 namespace Equibles.CommonStocks.Data.Helpers;
@@ -15,13 +16,22 @@ namespace Equibles.CommonStocks.Data.Helpers;
 /// through to BRK-B.
 /// </para>
 /// <para>
-/// Surfaces reading FILER-level data (filings, 13F holdings, insider transactions) remain
-/// attached to the <see cref="CommonStock"/> row. Price surfaces use
-/// <see cref="ResolveListedTicker"/> so their identity is the traded symbol instead.
+/// Filer-level SEC documents remain attached to the <see cref="CommonStock"/> row. Market data,
+/// congressional trades, and 13F positions retain their exact listed symbol and must be read
+/// through <see cref="ResolveListedTicker"/> so sibling securities never bleed together.
 /// </para>
 /// </summary>
 public static class SecondaryTickerPolicy
 {
+    /// <summary>
+    /// Authoritative primary operating-company universe. A primary ticker explicitly present in
+    /// the exchange-traded reference feed belongs on the ETF surface and must not consume issuer
+    /// financials, shares outstanding, derived short models, or stock rankings.
+    /// </summary>
+    public static readonly Expression<Func<CommonStock, bool>> PrimaryOperatingCompany = stock =>
+        !stock.ReferenceTickers.Contains(stock.Ticker)
+        && !stock.ReferenceTickers.Contains(stock.Ticker.Replace(".", "-"));
+
     /// <summary>
     /// Resolves a caller's spelling to the exact canonical ticker carried by the filer.
     /// The dot class-share notation is mechanically folded to the stored dash form
@@ -66,6 +76,34 @@ public static class SecondaryTickerPolicy
         var resolved = ResolveListedTicker(stock, requestedTicker);
         return resolved != null && !string.Equals(resolved, stock.Ticker, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// Whether the exact resolved listing is an authoritative exchange-traded product.
+    /// ReferenceTickers is populated from the provider's ETF/ETN/ETV/ETS reference feed;
+    /// never infer this classification from a ticker or issuer name.
+    /// </summary>
+    public static bool IsExchangeTradedListing(CommonStock stock, string requestedTicker)
+    {
+        var requested = TickerNormalizer.NormalizeDashListed(requestedTicker);
+        return stock != null
+            && requested != null
+            && (stock.ReferenceTickers ?? []).Any(reference =>
+                string.Equals(
+                    TickerNormalizer.NormalizeDashListed(reference),
+                    requested,
+                    StringComparison.OrdinalIgnoreCase
+                )
+            );
+    }
+
+    /// <summary>
+    /// Whether a filer-wide stock read would merge the requested security with a sibling.
+    /// Primary operating-company stocks retain their established filer-wide read models;
+    /// ETFs and every secondary security require the exact listed ticker.
+    /// </summary>
+    public static bool RequiresExactListingScope(CommonStock stock, string requestedTicker) =>
+        IsSecondarySymbol(stock, requestedTicker)
+        || IsExchangeTradedListing(stock, requestedTicker);
 
     /// <summary>
     /// Legacy refusal text retained for binary-compatible callers. Secondary listings now have

--- a/src/Equibles.CommonStocks.Data/Models/ListedSecurityKey.cs
+++ b/src/Equibles.CommonStocks.Data/Models/ListedSecurityKey.cs
@@ -1,0 +1,7 @@
+namespace Equibles.CommonStocks.Data.Models;
+
+/// <summary>
+/// Exact exchange listing identity. A CommonStock is the SEC filer, so one filer can own many
+/// separately traded securities whose market datasets must never be combined.
+/// </summary>
+public readonly record struct ListedSecurityKey(Guid CommonStockId, string ListedTicker);

--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -275,7 +275,7 @@ public class CommonStockRepository : BaseRepository<CommonStock>
         DbContext.Set<CommonStockListedCusip>().Remove(listedCusip);
     }
 
-    public IQueryable<CommonStockDelistedListing> GetDelistedListings()
+    public virtual IQueryable<CommonStockDelistedListing> GetDelistedListings()
     {
         return DbContext.Set<CommonStockDelistedListing>().AsQueryable();
     }

--- a/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
+++ b/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
@@ -16,50 +16,64 @@ public static class CommonStockRepositoryExtensions
         CancellationToken cancellationToken = default
     )
     {
-        var stocks = await repository.GetAll()
-            .Select(stock => new { stock.Id, stock.Ticker, stock.ReferenceTickers })
+        var stocks = await repository
+            .GetAll()
+            .Select(stock => new
+            {
+                stock.Id,
+                stock.Ticker,
+                stock.ReferenceTickers,
+            })
             .ToListAsync(cancellationToken);
         var stockIds = stocks.Select(stock => stock.Id).ToList();
-        var delistedRows = await repository.GetDelistedListings()
+        var delistedRows = await repository
+            .GetDelistedListings()
             .Where(listing => stockIds.Contains(listing.CommonStockId))
-            .Select(listing => new ListedSecurityKey(
-                listing.CommonStockId,
-                listing.ListedTicker
-            ))
+            .Select(listing => new ListedSecurityKey(listing.CommonStockId, listing.ListedTicker))
             .ToListAsync(cancellationToken);
         var primaryByStock = stocks.ToDictionary(stock => stock.Id, stock => stock.Ticker);
-        var delisted = delistedRows.Select(listing =>
-        {
-            var primary = primaryByStock.GetValueOrDefault(listing.CommonStockId);
-            var listedTicker = primary != null
-                && string.Equals(
-                    TickerNormalizer.NormalizeDashListed(listing.ListedTicker),
-                    TickerNormalizer.NormalizeDashListed(primary),
-                    StringComparison.OrdinalIgnoreCase
-                )
-                    ? primary
-                    : listing.ListedTicker;
-            return new ListedSecurityKey(listing.CommonStockId, listedTicker);
-        }).ToHashSet();
+        var delisted = delistedRows
+            .Select(listing =>
+            {
+                var primary = primaryByStock.GetValueOrDefault(listing.CommonStockId);
+                var listedTicker =
+                    primary != null
+                    && string.Equals(
+                        TickerNormalizer.NormalizeDashListed(listing.ListedTicker),
+                        TickerNormalizer.NormalizeDashListed(primary),
+                        StringComparison.OrdinalIgnoreCase
+                    )
+                        ? primary
+                        : listing.ListedTicker;
+                return new ListedSecurityKey(listing.CommonStockId, listedTicker);
+            })
+            .ToHashSet();
 
         return stocks
-            .SelectMany(stock => new[] { stock.Ticker }.Concat(stock.ReferenceTickers ?? [])
-                .Where(ticker => !string.IsNullOrWhiteSpace(ticker))
-                .Distinct(StringComparer.Ordinal)
-                .Select(ticker => new KeyValuePair<string, ListedSecurityKey>(
-                    ticker,
-                    new ListedSecurityKey(
-                        stock.Id,
-                        string.Equals(
-                            TickerNormalizer.NormalizeDashListed(ticker),
-                            TickerNormalizer.NormalizeDashListed(stock.Ticker),
-                            StringComparison.OrdinalIgnoreCase
-                        ) ? stock.Ticker : ticker
-                    )
-                )))
+            .SelectMany(stock =>
+                new[] { stock.Ticker }
+                    .Concat(stock.ReferenceTickers ?? [])
+                    .Where(ticker => !string.IsNullOrWhiteSpace(ticker))
+                    .Distinct(StringComparer.Ordinal)
+                    .Select(ticker => new KeyValuePair<string, ListedSecurityKey>(
+                        ticker,
+                        new ListedSecurityKey(
+                            stock.Id,
+                            string.Equals(
+                                TickerNormalizer.NormalizeDashListed(ticker),
+                                TickerNormalizer.NormalizeDashListed(stock.Ticker),
+                                StringComparison.OrdinalIgnoreCase
+                            )
+                                ? stock.Ticker
+                                : ticker
+                        )
+                    ))
+            )
             .Where(claim => !delisted.Contains(claim.Value))
             .GroupBy(claim => claim.Key, StringComparer.Ordinal)
-            .Where(group => group.Select(claim => claim.Value.CommonStockId).Distinct().Count() == 1)
+            .Where(group =>
+                group.Select(claim => claim.Value.CommonStockId).Distinct().Count() == 1
+            )
             .SelectMany(group => group.Select(claim => claim.Value))
             .ToHashSet();
     }
@@ -79,12 +93,19 @@ public static class CommonStockRepositoryExtensions
             .ToList();
         var literal = candidates[0];
         var folded = candidates.Count > 1 ? candidates[1] : literal;
-        var authoritativeOwners = await repository.GetAll()
-            .Where(candidate => candidate.Ticker == literal
+        var authoritativeOwners = await repository
+            .GetAll()
+            .Where(candidate =>
+                candidate.Ticker == literal
                 || candidate.Ticker == folded
-                || (candidate.Active
-                    && (candidate.ReferenceTickers.Contains(literal)
-                        || candidate.ReferenceTickers.Contains(folded))))
+                || (
+                    candidate.Active
+                    && (
+                        candidate.ReferenceTickers.Contains(literal)
+                        || candidate.ReferenceTickers.Contains(folded)
+                    )
+                )
+            )
             .Take(2)
             .ToListAsync();
         if (authoritativeOwners.Select(candidate => candidate.Id).Distinct().Count() > 1)

--- a/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
+++ b/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
@@ -87,30 +87,30 @@ public static class CommonStockRepositoryExtensions
         if (normalized == null)
             return (null, $"Stock '{ticker}' not found.");
 
-        var candidates = new[] { normalized, TickerNormalizer.NormalizeDashListed(normalized) }
-            .Where(value => value != null)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-        var literal = candidates[0];
-        var folded = candidates.Count > 1 ? candidates[1] : literal;
-        var authoritativeOwners = await repository
-            .GetAll()
-            .Where(candidate =>
-                candidate.Ticker == literal
-                || candidate.Ticker == folded
-                || (
-                    candidate.Active
-                    && (
-                        candidate.ReferenceTickers.Contains(literal)
-                        || candidate.ReferenceTickers.Contains(folded)
-                    )
+        var literal = normalized;
+        var folded = TickerNormalizer.NormalizeDashListed(normalized) ?? literal;
+
+        async Task<List<CommonStock>> FindOwners(string listedTicker) =>
+            await repository
+                .GetAll()
+                .Where(candidate =>
+                    candidate.Ticker == listedTicker
+                    || (candidate.Active && candidate.ReferenceTickers.Contains(listedTicker))
                 )
-            )
-            .Take(2)
-            .ToListAsync();
+                .Take(2)
+                .ToListAsync();
+
+        var authoritativeOwners = await FindOwners(literal);
         if (authoritativeOwners.Select(candidate => candidate.Id).Distinct().Count() > 1)
             return (null, $"Listed security '{ticker}' is ambiguous.");
         var stock = authoritativeOwners.SingleOrDefault();
+        if (stock == null && !string.Equals(literal, folded, StringComparison.OrdinalIgnoreCase))
+        {
+            authoritativeOwners = await FindOwners(folded);
+            if (authoritativeOwners.Select(candidate => candidate.Id).Distinct().Count() > 1)
+                return (null, $"Listed security '{ticker}' is ambiguous.");
+            stock = authoritativeOwners.SingleOrDefault();
+        }
         stock ??= await repository.GetByTicker(normalized);
         if (stock == null && normalized.Contains('.'))
             stock = await repository.GetByTicker(normalized.Replace('.', '-'));

--- a/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
+++ b/src/Equibles.CommonStocks.Repositories/Extensions/CommonStockRepositoryExtensions.cs
@@ -6,6 +6,64 @@ namespace Equibles.CommonStocks.Repositories.Extensions;
 
 public static class CommonStockRepositoryExtensions
 {
+    /// <summary>
+    /// The current exact listing identities whose authoritative ticker claim resolves to one
+    /// active filer. Market-wide readers use this after materializing source rows so a stale row
+    /// cannot publish a ticker that became delisted or ambiguously claimed after ingestion.
+    /// </summary>
+    public static async Task<HashSet<ListedSecurityKey>> GetUniqueActiveListingKeys(
+        this CommonStockRepository repository,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var stocks = await repository.GetAll()
+            .Select(stock => new { stock.Id, stock.Ticker, stock.ReferenceTickers })
+            .ToListAsync(cancellationToken);
+        var stockIds = stocks.Select(stock => stock.Id).ToList();
+        var delistedRows = await repository.GetDelistedListings()
+            .Where(listing => stockIds.Contains(listing.CommonStockId))
+            .Select(listing => new ListedSecurityKey(
+                listing.CommonStockId,
+                listing.ListedTicker
+            ))
+            .ToListAsync(cancellationToken);
+        var primaryByStock = stocks.ToDictionary(stock => stock.Id, stock => stock.Ticker);
+        var delisted = delistedRows.Select(listing =>
+        {
+            var primary = primaryByStock.GetValueOrDefault(listing.CommonStockId);
+            var listedTicker = primary != null
+                && string.Equals(
+                    TickerNormalizer.NormalizeDashListed(listing.ListedTicker),
+                    TickerNormalizer.NormalizeDashListed(primary),
+                    StringComparison.OrdinalIgnoreCase
+                )
+                    ? primary
+                    : listing.ListedTicker;
+            return new ListedSecurityKey(listing.CommonStockId, listedTicker);
+        }).ToHashSet();
+
+        return stocks
+            .SelectMany(stock => new[] { stock.Ticker }.Concat(stock.ReferenceTickers ?? [])
+                .Where(ticker => !string.IsNullOrWhiteSpace(ticker))
+                .Distinct(StringComparer.Ordinal)
+                .Select(ticker => new KeyValuePair<string, ListedSecurityKey>(
+                    ticker,
+                    new ListedSecurityKey(
+                        stock.Id,
+                        string.Equals(
+                            TickerNormalizer.NormalizeDashListed(ticker),
+                            TickerNormalizer.NormalizeDashListed(stock.Ticker),
+                            StringComparison.OrdinalIgnoreCase
+                        ) ? stock.Ticker : ticker
+                    )
+                )))
+            .Where(claim => !delisted.Contains(claim.Value))
+            .GroupBy(claim => claim.Key, StringComparer.Ordinal)
+            .Where(group => group.Select(claim => claim.Value.CommonStockId).Distinct().Count() == 1)
+            .SelectMany(group => group.Select(claim => claim.Value))
+            .ToHashSet();
+    }
+
     public static async Task<(CommonStock Stock, string Error)> ResolveByTicker(
         this CommonStockRepository repository,
         string ticker
@@ -15,7 +73,24 @@ public static class CommonStockRepositoryExtensions
         if (normalized == null)
             return (null, $"Stock '{ticker}' not found.");
 
-        var stock = await repository.GetByTicker(normalized);
+        var candidates = new[] { normalized, TickerNormalizer.NormalizeDashListed(normalized) }
+            .Where(value => value != null)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var literal = candidates[0];
+        var folded = candidates.Count > 1 ? candidates[1] : literal;
+        var authoritativeOwners = await repository.GetAll()
+            .Where(candidate => candidate.Ticker == literal
+                || candidate.Ticker == folded
+                || (candidate.Active
+                    && (candidate.ReferenceTickers.Contains(literal)
+                        || candidate.ReferenceTickers.Contains(folded))))
+            .Take(2)
+            .ToListAsync();
+        if (authoritativeOwners.Select(candidate => candidate.Id).Distinct().Count() > 1)
+            return (null, $"Listed security '{ticker}' is ambiguous.");
+        var stock = authoritativeOwners.SingleOrDefault();
+        stock ??= await repository.GetByTicker(normalized);
         if (stock == null && normalized.Contains('.'))
             stock = await repository.GetByTicker(normalized.Replace('.', '-'));
         return stock == null ? (null, $"Stock '{ticker}' not found.") : (stock, null);

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Congress.Data;
@@ -52,7 +53,7 @@ public class CongressTools
         "Get congressional securities transactions for a specific ticker (newest first, last year by default). Shows which members of Congress reported a purchase or sale, with transaction and filing dates; amounts are disclosed ranges, not exact values, and Asset identifies the filed instrument (such as stock, option, or bond). Use GetMemberTrades for one member's transactions across all tickers."
     )]
     public Task<string> GetCongressionalTrades(
-        [Description("Stock ticker symbol (e.g., AAPL, MSFT, NVDA)")] string ticker,
+        [Description("Listed security ticker (e.g., AAPL, VOO, MSFT)")] string ticker,
         [Description(
             "Filter by transaction type: Purchase or Sale; the synonyms Buy/Sell are accepted (defaults to all)"
         )]
@@ -81,7 +82,8 @@ public class CongressTools
                 if (typeError != null)
                     return typeError;
 
-                var query = _tradeRepository.GetByStock(stock, start, end);
+                var listedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, ticker);
+                var query = _tradeRepository.GetByListing(stock, listedTicker, start, end);
                 if (typeFilter != null)
                     query = query.Where(t => t.TransactionType == typeFilter);
 
@@ -100,8 +102,8 @@ public class CongressTools
 
                 var table = MarkdownTable.Render(
                     trades,
-                    $"No congressional trades found for {stock.Ticker} between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
-                    $"Congressional trades for {stock.Ticker} ({stock.Name}), {start:yyyy-MM-dd} to {end:yyyy-MM-dd}:",
+                    $"No congressional trades found for {listedTicker} between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
+                    $"Congressional trades for {ListingLabel(stock, listedTicker)}, {start:yyyy-MM-dd} to {end:yyyy-MM-dd}:",
                     "| Date | Filed | Member | Position | Type | Amount Range | Asset | Asset Type | Owner | Account |",
                     "|------|-------|--------|----------|------|-------------|-------|------------|-------|---------|",
                     t =>
@@ -168,6 +170,7 @@ public class CongressTools
                     return typeError;
 
                 CommonStock stock = null;
+                string listedTicker = null;
                 if (!string.IsNullOrWhiteSpace(ticker))
                 {
                     var (resolvedStock, stockError) = await _commonStockRepository.ResolveByTicker(
@@ -176,6 +179,7 @@ public class CongressTools
                     if (stockError != null)
                         return stockError;
                     stock = resolvedStock;
+                    listedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, ticker);
                 }
 
                 var query = _tradeRepository
@@ -184,7 +188,9 @@ public class CongressTools
                 if (typeFilter != null)
                     query = query.Where(t => t.TransactionType == typeFilter);
                 if (stock != null)
-                    query = query.Where(t => t.CommonStockId == stock.Id);
+                    query = query.Where(t => t.CommonStockId == stock.Id
+                        && (t.FiledTicker == listedTicker
+                            || (t.FiledTicker == "" && listedTicker == stock.Ticker)));
 
                 maxResults = McpLimit.Clamp(maxResults);
                 offset = McpLimit.ClampOffset(offset);
@@ -201,16 +207,18 @@ public class CongressTools
 
                 var table = MarkdownTable.Render(
                     trades,
-                    $"No trades found for {member.Name} ({DescribeMember(member)}){(stock == null ? "" : $" in {stock.Ticker}")} between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
-                    $"Trades by {member.Name} ({DescribeMember(member)}){(stock == null ? "" : $" in {stock.Ticker}")}, {start:yyyy-MM-dd} to {end:yyyy-MM-dd}:",
+                    $"No trades found for {member.Name} ({DescribeMember(member)}){(stock == null ? "" : $" in {listedTicker}")} between {start:yyyy-MM-dd} and {end:yyyy-MM-dd}.",
+                    $"Trades by {member.Name} ({DescribeMember(member)}){(stock == null ? "" : $" in {listedTicker}")}, {start:yyyy-MM-dd} to {end:yyyy-MM-dd}:",
                     "| Date | Filed | Ticker | Type | Amount Range | Asset | Asset Type | Owner | Account |",
                     "|------|-------|--------|------|-------------|-------|------------|-------|---------|",
                     t =>
                     {
                         var type = t.TransactionType.NameForHumans();
                         var amount = FormatAmountRange(t);
-                        var ticker = t.CommonStock?.Ticker ?? t.FiledTicker;
-                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.FilingDate:yyyy-MM-dd} | {ticker} | {type} | {amount} | {EscapeCell(t.AssetName)} | {EscapeCell(t.AssetType)} | {FormatOwner(t.OwnerType)} | {EscapeCell(t.Subholding)} |";
+                        var filedTicker = string.IsNullOrWhiteSpace(t.FiledTicker)
+                            ? t.CommonStock?.Ticker
+                            : t.FiledTicker;
+                        return $"| {t.TransactionDate:yyyy-MM-dd} | {t.FilingDate:yyyy-MM-dd} | {filedTicker} | {type} | {amount} | {EscapeCell(t.AssetName)} | {EscapeCell(t.AssetType)} | {FormatOwner(t.OwnerType)} | {EscapeCell(t.Subholding)} |";
                     }
                 );
                 var note = McpOutput.PagedTruncationNote(trades.Count, totalCount, offset);
@@ -220,6 +228,11 @@ public class CongressTools
             $"memberName: {memberName}, ticker: {ticker}, offset: {offset}"
         );
     }
+
+    private static string ListingLabel(CommonStock stock, string listedTicker) =>
+        SecondaryTickerPolicy.RequiresExactListingScope(stock, listedTicker)
+            ? listedTicker
+            : $"{listedTicker} ({stock.Name})";
 
     [McpServerTool(
         Name = "GetMemberNetWorth",

--- a/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
+++ b/src/Equibles.Congress.Mcp/Tools/CongressTools.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Congress.Data;
@@ -188,9 +188,13 @@ public class CongressTools
                 if (typeFilter != null)
                     query = query.Where(t => t.TransactionType == typeFilter);
                 if (stock != null)
-                    query = query.Where(t => t.CommonStockId == stock.Id
-                        && (t.FiledTicker == listedTicker
-                            || (t.FiledTicker == "" && listedTicker == stock.Ticker)));
+                    query = query.Where(t =>
+                        t.CommonStockId == stock.Id
+                        && (
+                            t.FiledTicker == listedTicker
+                            || (t.FiledTicker == "" && listedTicker == stock.Ticker)
+                        )
+                    );
 
                 maxResults = McpLimit.Clamp(maxResults);
                 offset = McpLimit.ClampOffset(offset);

--- a/src/Equibles.Congress.Repositories/CongressionalTradeRepository.cs
+++ b/src/Equibles.Congress.Repositories/CongressionalTradeRepository.cs
@@ -14,6 +14,15 @@ public class CongressionalTradeRepository : BaseRepository<CongressionalTrade>
         return GetAll().Where(t => t.CommonStockId == stock.Id);
     }
 
+    public IQueryable<CongressionalTrade> GetByListing(CommonStock stock, string listedTicker)
+    {
+        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
+        return GetAll().Where(t =>
+            t.CommonStockId == stock.Id
+            && (t.FiledTicker == listedTicker || (isPrimary && t.FiledTicker == ""))
+        );
+    }
+
     public IQueryable<CongressionalTrade> GetByStock(CommonStock stock, DateOnly from, DateOnly to)
     {
         return GetAll()
@@ -21,6 +30,14 @@ public class CongressionalTradeRepository : BaseRepository<CongressionalTrade>
                 t.CommonStockId == stock.Id && t.TransactionDate >= from && t.TransactionDate <= to
             );
     }
+
+    public IQueryable<CongressionalTrade> GetByListing(
+        CommonStock stock,
+        string listedTicker,
+        DateOnly from,
+        DateOnly to
+    ) => GetByListing(stock, listedTicker)
+        .Where(t => t.TransactionDate >= from && t.TransactionDate <= to);
 
     public IQueryable<CongressionalTrade> GetByMember(CongressMember member)
     {

--- a/src/Equibles.Congress.Repositories/CongressionalTradeRepository.cs
+++ b/src/Equibles.Congress.Repositories/CongressionalTradeRepository.cs
@@ -16,11 +16,16 @@ public class CongressionalTradeRepository : BaseRepository<CongressionalTrade>
 
     public IQueryable<CongressionalTrade> GetByListing(CommonStock stock, string listedTicker)
     {
-        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
-        return GetAll().Where(t =>
-            t.CommonStockId == stock.Id
-            && (t.FiledTicker == listedTicker || (isPrimary && t.FiledTicker == ""))
+        var isPrimary = string.Equals(
+            listedTicker,
+            stock.Ticker,
+            StringComparison.OrdinalIgnoreCase
         );
+        return GetAll()
+            .Where(t =>
+                t.CommonStockId == stock.Id
+                && (t.FiledTicker == listedTicker || (isPrimary && t.FiledTicker == ""))
+            );
     }
 
     public IQueryable<CongressionalTrade> GetByStock(CommonStock stock, DateOnly from, DateOnly to)
@@ -36,8 +41,9 @@ public class CongressionalTradeRepository : BaseRepository<CongressionalTrade>
         string listedTicker,
         DateOnly from,
         DateOnly to
-    ) => GetByListing(stock, listedTicker)
-        .Where(t => t.TransactionDate >= from && t.TransactionDate <= to);
+    ) =>
+        GetByListing(stock, listedTicker)
+            .Where(t => t.TransactionDate >= from && t.TransactionDate <= to);
 
     public IQueryable<CongressionalTrade> GetByMember(CongressMember member)
     {

--- a/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
@@ -9,8 +9,8 @@ using Microsoft.EntityFrameworkCore;
 namespace Equibles.CorporateActions.BusinessLogic;
 
 // Upserts captured split events into StockSplit. The manager locks and revalidates
-// the exact current primary listing before writing, so a company-sync reorder cannot
-// attach one security's action to another. Idempotent by (stock, EffectiveDate): a
+// the exact current listing before writing, so a company-sync reorder cannot attach one
+// security's action to another. Idempotent by (stock, listed ticker, EffectiveDate): a
 // re-run with the same events writes nothing. A changed ratio for the same exact
 // source series clears PriceAdjustmentAppliedTime for another reconciliation.
 [Service]
@@ -44,10 +44,7 @@ public class StockSplitCaptureManager
         );
         var stock = await _stockRepository.GetForUpdate(commonStockId, cancellationToken);
         var resolvedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, listedTicker);
-        if (
-            resolvedTicker == null
-            || !string.Equals(resolvedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase)
-        )
+        if (resolvedTicker == null)
         {
             await transaction.RollbackAsync(cancellationToken);
             return 0;
@@ -61,35 +58,37 @@ public class StockSplitCaptureManager
             if (split.Numerator <= 0 || split.Denominator <= 0)
                 continue;
 
-            var match = existing.FirstOrDefault(s => s.EffectiveDate == split.EffectiveDate);
-            if (match == null)
-            {
-                _splitRepository.Add(
-                    new StockSplit
-                    {
-                        CommonStockId = stock.Id,
-                        PriceSeriesTicker = resolvedTicker,
-                        EffectiveDate = split.EffectiveDate,
-                        Numerator = split.Numerator,
-                        Denominator = split.Denominator,
-                        Source = split.Source,
-                    }
-                );
-                changes++;
-            }
-            else if (
-                match.PriceSeriesTicker != null
-                && !string.Equals(
-                    match.PriceSeriesTicker,
+            var isPrimary = string.Equals(
+                resolvedTicker,
+                stock.Ticker,
+                StringComparison.OrdinalIgnoreCase
+            );
+            var match = existing.FirstOrDefault(s =>
+                s.EffectiveDate == split.EffectiveDate
+                && string.Equals(
+                    s.PriceSeriesTicker,
                     resolvedTicker,
                     StringComparison.OrdinalIgnoreCase
                 )
-            )
+            );
+            match ??= isPrimary
+                ? existing.FirstOrDefault(s =>
+                    s.EffectiveDate == split.EffectiveDate && s.PriceSeriesTicker == null)
+                : null;
+            if (match == null)
             {
-                // The issuer-level table cannot represent two securities splitting on the same
-                // date. Preserve the already-attributed action; each price series is rebased
-                // independently by the Yahoo lane before capture reaches this manager.
-                continue;
+                match = new StockSplit
+                {
+                    CommonStockId = stock.Id,
+                    PriceSeriesTicker = resolvedTicker,
+                    EffectiveDate = split.EffectiveDate,
+                    Numerator = split.Numerator,
+                    Denominator = split.Denominator,
+                    Source = split.Source,
+                };
+                _splitRepository.Add(match);
+                existing.Add(match);
+                changes++;
             }
             else if (
                 match.PriceSeriesTicker == null

--- a/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
@@ -73,7 +73,8 @@ public class StockSplitCaptureManager
             );
             match ??= isPrimary
                 ? existing.FirstOrDefault(s =>
-                    s.EffectiveDate == split.EffectiveDate && s.PriceSeriesTicker == null)
+                    s.EffectiveDate == split.EffectiveDate && s.PriceSeriesTicker == null
+                )
                 : null;
             if (match == null)
             {

--- a/src/Equibles.CorporateActions.Data/CorporateActionsModuleConfiguration.cs
+++ b/src/Equibles.CorporateActions.Data/CorporateActionsModuleConfiguration.cs
@@ -9,10 +9,17 @@ public class CorporateActionsModuleConfiguration : Equibles.Data.IFinancialModul
     {
         var stockSplit = builder.Entity<StockSplit>();
         stockSplit.Property(s => s.Source).HasConversion<string>();
-        stockSplit.HasIndex(s => new { s.CommonStockId, s.PriceSeriesTicker, s.EffectiveDate })
+        stockSplit
+            .HasIndex(s => new
+            {
+                s.CommonStockId,
+                s.PriceSeriesTicker,
+                s.EffectiveDate,
+            })
             .IsUnique()
             .HasFilter("\"PriceSeriesTicker\" IS NOT NULL");
-        stockSplit.HasIndex(s => new { s.CommonStockId, s.EffectiveDate })
+        stockSplit
+            .HasIndex(s => new { s.CommonStockId, s.EffectiveDate })
             .IsUnique()
             .HasFilter("\"PriceSeriesTicker\" IS NULL");
         builder.Entity<CashDividend>().Property(d => d.Source).HasConversion<string>();

--- a/src/Equibles.CorporateActions.Data/CorporateActionsModuleConfiguration.cs
+++ b/src/Equibles.CorporateActions.Data/CorporateActionsModuleConfiguration.cs
@@ -7,7 +7,14 @@ public class CorporateActionsModuleConfiguration : Equibles.Data.IFinancialModul
 {
     public void ConfigureEntities(ModelBuilder builder)
     {
-        builder.Entity<StockSplit>().Property(s => s.Source).HasConversion<string>();
+        var stockSplit = builder.Entity<StockSplit>();
+        stockSplit.Property(s => s.Source).HasConversion<string>();
+        stockSplit.HasIndex(s => new { s.CommonStockId, s.PriceSeriesTicker, s.EffectiveDate })
+            .IsUnique()
+            .HasFilter("\"PriceSeriesTicker\" IS NOT NULL");
+        stockSplit.HasIndex(s => new { s.CommonStockId, s.EffectiveDate })
+            .IsUnique()
+            .HasFilter("\"PriceSeriesTicker\" IS NULL");
         builder.Entity<CashDividend>().Property(d => d.Source).HasConversion<string>();
         builder
             .Entity<CorporateActionPriceReconciliationCursor>()

--- a/src/Equibles.CorporateActions.Data/Models/StockSplit.cs
+++ b/src/Equibles.CorporateActions.Data/Models/StockSplit.cs
@@ -12,7 +12,6 @@ namespace Equibles.CorporateActions.Data.Models;
 /// back-adjustment pass. The marker is applied only when its UTC date is after the effective
 /// date; null or older legacy markers remain pending.
 /// </summary>
-[Index(nameof(CommonStockId), nameof(EffectiveDate), IsUnique = true)]
 [Index(nameof(PriceAdjustmentAppliedTime))]
 public class StockSplit
 {

--- a/src/Equibles.Finra.BusinessLogic/FinraTickerScope.cs
+++ b/src/Equibles.Finra.BusinessLogic/FinraTickerScope.cs
@@ -4,8 +4,8 @@ using Equibles.CommonStocks.Data.Models;
 namespace Equibles.Finra.BusinessLogic;
 
 /// <summary>
-/// FINRA rows currently carry issuer identity, not exact listed-symbol identity. A secondary
-/// listing must therefore be refused instead of being relabelled with the issuer's primary data.
+/// Guards models whose inputs still carry issuer identity even though raw FINRA rows now retain
+/// exact listed-symbol identity.
 /// </summary>
 public static class FinraTickerScope
 {
@@ -22,5 +22,20 @@ public static class FinraTickerScope
         return $"No exact {dataset} series is available for {listedTicker}. It is a separate "
             + $"listing on the same SEC filer as {stock.Ticker} ({stock.Name}); {stock.Ticker}'s "
             + "FINRA rows are not substituted.";
+    }
+
+    public static string IssuerDerivedModelUnavailable(
+        CommonStock stock,
+        string requestedTicker,
+        string dataset
+    )
+    {
+        var listedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, requestedTicker);
+        if (!SecondaryTickerPolicy.RequiresExactListingScope(stock, listedTicker))
+            return null;
+
+        return $"No {dataset} model is available for {listedTicker}. Its raw FINRA series is "
+            + "listing-specific, but this model still depends on issuer-level shares outstanding "
+            + "and primary-listing market factors.";
     }
 }

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -1,6 +1,6 @@
 using System.Linq.Expressions;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.CorporateActions.Data;
@@ -263,8 +263,10 @@ public class ShortSqueezeScoreManager
         var splitsByStock = (
             await _stockSplitRepository
                 .GetEffective(DateOnly.FromDateTime(DateTime.UtcNow))
-                .Where(s => stockIds.Contains(s.CommonStockId)
-                    && (s.PriceSeriesTicker == null || s.PriceSeriesTicker == s.CommonStock.Ticker))
+                .Where(s =>
+                    stockIds.Contains(s.CommonStockId)
+                    && (s.PriceSeriesTicker == null || s.PriceSeriesTicker == s.CommonStock.Ticker)
+                )
                 .ToListAsync(cancellationToken)
         )
             .GroupBy(s => s.CommonStockId)

--- a/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
+++ b/src/Equibles.Finra.BusinessLogic/ShortSqueezeScoreManager.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Equibles.CorporateActions.Data;
@@ -45,7 +46,7 @@ namespace Equibles.Finra.BusinessLogic;
 /// <see cref="IEarningsProximitySource"/>).</para>
 ///
 /// <para>Factors a stock has no data for drop out and their weight is redistributed over
-/// the rest. The universe is every stock reporting short interest at the latest
+/// the rest. The universe is every primary operating-company stock reporting short interest at the latest
 /// settlement date with a known shares-outstanding count and a physically credible
 /// short-interest ratio (see <see cref="MaxCredibleShortInterestRatio"/>).</para>
 /// </summary>
@@ -224,6 +225,7 @@ public class ShortSqueezeScoreManager
         // FINRA omits days-to-cover.
         var shortInterests = await _shortInterestRepository
             .GetBySettlementDate(settlementDate)
+            .Where(s => s.ListedTicker == s.CommonStock.Ticker || s.ListedTicker == "")
             .Select(s => new
             {
                 s.CommonStockId,
@@ -241,6 +243,7 @@ public class ShortSqueezeScoreManager
             .GetAll()
             .Where(s => stockIds.Contains(s.Id) && s.SharesOutStanding > 0)
             .Where(SqueezeCandidateListing)
+            .Where(SecondaryTickerPolicy.PrimaryOperatingCompany)
             .Select(s => new
             {
                 s.Id,
@@ -260,7 +263,8 @@ public class ShortSqueezeScoreManager
         var splitsByStock = (
             await _stockSplitRepository
                 .GetEffective(DateOnly.FromDateTime(DateTime.UtcNow))
-                .Where(s => stockIds.Contains(s.CommonStockId))
+                .Where(s => stockIds.Contains(s.CommonStockId)
+                    && (s.PriceSeriesTicker == null || s.PriceSeriesTicker == s.CommonStock.Ticker))
                 .ToListAsync(cancellationToken)
         )
             .GroupBy(s => s.CommonStockId)
@@ -406,6 +410,7 @@ public class ShortSqueezeScoreManager
             .Where(v =>
                 v.Date > farCutoff && v.Date <= settlementDate && stockIds.Contains(v.CommonStockId)
             )
+            .Where(v => v.ListedTicker == v.CommonStock.Ticker || v.ListedTicker == "")
             .GroupBy(v => new { v.CommonStockId, Recent = v.Date > midCutoff })
             .Select(g => new
             {
@@ -462,6 +467,7 @@ public class ShortSqueezeScoreManager
                 f.SettlementDate > windowStart
                 && f.SettlementDate <= latestDate
                 && stockIds.Contains(f.CommonStockId)
+                && (f.ListedTicker == f.CommonStock.Ticker || f.ListedTicker == "")
             )
             .Select(f => new
             {

--- a/src/Equibles.Finra.Data/Models/DailyShortVolume.cs
+++ b/src/Equibles.Finra.Data/Models/DailyShortVolume.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Finra.Data.Models;

--- a/src/Equibles.Finra.Data/Models/DailyShortVolume.cs
+++ b/src/Equibles.Finra.Data/Models/DailyShortVolume.cs
@@ -1,10 +1,11 @@
 using System.ComponentModel.DataAnnotations;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Helpers;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Finra.Data.Models;
 
-[Index(nameof(CommonStockId), nameof(Date), IsUnique = true)]
+[Index(nameof(CommonStockId), nameof(ListedTicker), nameof(Date), IsUnique = true)]
 [Index(nameof(Date))]
 public class DailyShortVolume
 {
@@ -12,6 +13,10 @@ public class DailyShortVolume
 
     public Guid CommonStockId { get; set; }
     public virtual CommonStock CommonStock { get; set; }
+
+    [Required]
+    [MaxLength(TickerNormalizer.MaxListedLength)]
+    public string ListedTicker { get; set; } = "";
 
     public DateOnly Date { get; set; }
 

--- a/src/Equibles.Finra.Data/Models/OffExchangeVolume.cs
+++ b/src/Equibles.Finra.Data/Models/OffExchangeVolume.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Finra.Data.Models;

--- a/src/Equibles.Finra.Data/Models/OffExchangeVolume.cs
+++ b/src/Equibles.Finra.Data/Models/OffExchangeVolume.cs
@@ -1,9 +1,11 @@
+using System.ComponentModel.DataAnnotations;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Helpers;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Finra.Data.Models;
 
-[Index(nameof(CommonStockId), nameof(WeekStartDate), IsUnique = true)]
+[Index(nameof(CommonStockId), nameof(ListedTicker), nameof(WeekStartDate), IsUnique = true)]
 [Index(nameof(WeekStartDate))]
 public class OffExchangeVolume
 {
@@ -11,6 +13,10 @@ public class OffExchangeVolume
 
     public Guid CommonStockId { get; set; }
     public virtual CommonStock CommonStock { get; set; }
+
+    [Required]
+    [MaxLength(TickerNormalizer.MaxListedLength)]
+    public string ListedTicker { get; set; } = "";
 
     public DateOnly WeekStartDate { get; set; }
 

--- a/src/Equibles.Finra.Data/Models/ShortInterest.cs
+++ b/src/Equibles.Finra.Data/Models/ShortInterest.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Finra.Data.Models;

--- a/src/Equibles.Finra.Data/Models/ShortInterest.cs
+++ b/src/Equibles.Finra.Data/Models/ShortInterest.cs
@@ -1,9 +1,11 @@
+using System.ComponentModel.DataAnnotations;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Helpers;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Finra.Data.Models;
 
-[Index(nameof(CommonStockId), nameof(SettlementDate), IsUnique = true)]
+[Index(nameof(CommonStockId), nameof(ListedTicker), nameof(SettlementDate), IsUnique = true)]
 [Index(nameof(SettlementDate))]
 public class ShortInterest
 {
@@ -11,6 +13,10 @@ public class ShortInterest
 
     public Guid CommonStockId { get; set; }
     public virtual CommonStock CommonStock { get; set; }
+
+    [Required]
+    [MaxLength(TickerNormalizer.MaxListedLength)]
+    public string ListedTicker { get; set; } = "";
 
     public DateOnly SettlementDate { get; set; }
 

--- a/src/Equibles.Finra.HostedService/Services/FinraClassShareSymbols.cs
+++ b/src/Equibles.Finra.HostedService/Services/FinraClassShareSymbols.cs
@@ -26,12 +26,12 @@ public static class FinraClassShareSymbols
     /// tickers collide on, resolves to NOTHING — the identity is then ambiguous and absent
     /// beats wrong.
     /// </summary>
-    public static Dictionary<string, Guid> BuildCompressedIndex(
-        IReadOnlyDictionary<string, Guid> tickerMap,
+    public static Dictionary<string, T> BuildCompressedIndex<T>(
+        IReadOnlyDictionary<string, T> tickerMap,
         StringComparer comparer
     )
     {
-        var index = new Dictionary<string, Guid>(comparer);
+        var index = new Dictionary<string, T>(comparer);
         var ambiguous = new HashSet<string>(comparer);
         foreach (var (ticker, stockId) in tickerMap)
         {
@@ -52,22 +52,22 @@ public static class FinraClassShareSymbols
     /// Resolves a FINRA-spelled symbol to a stored stock: exact ticker first, then the dotted
     /// spelling mapped onto the dash convention, then the compressed index.
     /// </summary>
-    public static bool TryResolve(
-        IReadOnlyDictionary<string, Guid> tickerMap,
-        IReadOnlyDictionary<string, Guid> compressedIndex,
+    public static bool TryResolve<T>(
+        IReadOnlyDictionary<string, T> tickerMap,
+        IReadOnlyDictionary<string, T> compressedIndex,
         string symbol,
-        out Guid stockId
+        out T identity
     )
     {
-        stockId = default;
+        identity = default;
         if (string.IsNullOrEmpty(symbol))
             return false;
-        if (tickerMap.TryGetValue(symbol, out stockId))
+        if (tickerMap.TryGetValue(symbol, out identity))
             return true;
         var dashed = DotToDash(symbol);
-        if (!ReferenceEquals(dashed, symbol) && tickerMap.TryGetValue(dashed, out stockId))
+        if (!ReferenceEquals(dashed, symbol) && tickerMap.TryGetValue(dashed, out identity))
             return true;
-        return compressedIndex.TryGetValue(symbol, out stockId);
+        return compressedIndex.TryGetValue(symbol, out identity);
     }
 
     /// <summary>

--- a/src/Equibles.Finra.HostedService/Services/FinraImportScope.cs
+++ b/src/Equibles.Finra.HostedService/Services/FinraImportScope.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using Equibles.CommonStocks.Data.Models;
 
 namespace Equibles.Finra.HostedService.Services;
 
@@ -36,5 +37,50 @@ public static class FinraImportScope
         );
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
         return $"stocks:{Convert.ToHexString(hash).ToLowerInvariant()}";
+    }
+
+    public static string ResolveListingUniverse(
+        IReadOnlyDictionary<string, ListedSecurityKey> listings
+    )
+    {
+        ArgumentNullException.ThrowIfNull(listings);
+
+        var payload = string.Join(
+            '\n',
+            listings
+                .OrderBy(listing => listing.Key, StringComparer.Ordinal)
+                .Select(listing => $"{listing.Key}\0{listing.Value.CommonStockId:N}\0{listing.Value.ListedTicker}")
+        );
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
+        return $"listings:{Convert.ToHexString(hash).ToLowerInvariant()}";
+    }
+
+    public static string ResolveListingImportScope(
+        IReadOnlyDictionary<string, ListedSecurityKey> listings,
+        IReadOnlyCollection<string> configuredTickers
+    )
+    {
+        ArgumentNullException.ThrowIfNull(listings);
+        ArgumentNullException.ThrowIfNull(configuredTickers);
+
+        var normalizedTickers = configuredTickers
+            .Select(ticker => ticker?.Trim().ToUpperInvariant())
+            .Where(ticker => !string.IsNullOrEmpty(ticker))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(ticker => ticker, StringComparer.Ordinal)
+            .ToList();
+        if (normalizedTickers.Count == 0)
+            return ResolveListingUniverse(listings);
+
+        var payload = string.Join('\n', normalizedTickers)
+            + "\n--resolved-listings--\n"
+            + string.Join(
+                '\n',
+                listings
+                    .OrderBy(listing => listing.Key, StringComparer.Ordinal)
+                    .Select(listing => $"{listing.Key}\0{listing.Value.CommonStockId:N}\0{listing.Value.ListedTicker}")
+            );
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
+        return $"listing-filter:{Convert.ToHexString(hash).ToLowerInvariant()}";
     }
 }

--- a/src/Equibles.Finra.HostedService/Services/FinraImportScope.cs
+++ b/src/Equibles.Finra.HostedService/Services/FinraImportScope.cs
@@ -49,7 +49,9 @@ public static class FinraImportScope
             '\n',
             listings
                 .OrderBy(listing => listing.Key, StringComparer.Ordinal)
-                .Select(listing => $"{listing.Key}\0{listing.Value.CommonStockId:N}\0{listing.Value.ListedTicker}")
+                .Select(listing =>
+                    $"{listing.Key}\0{listing.Value.CommonStockId:N}\0{listing.Value.ListedTicker}"
+                )
         );
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
         return $"listings:{Convert.ToHexString(hash).ToLowerInvariant()}";
@@ -72,13 +74,16 @@ public static class FinraImportScope
         if (normalizedTickers.Count == 0)
             return ResolveListingUniverse(listings);
 
-        var payload = string.Join('\n', normalizedTickers)
+        var payload =
+            string.Join('\n', normalizedTickers)
             + "\n--resolved-listings--\n"
             + string.Join(
                 '\n',
                 listings
                     .OrderBy(listing => listing.Key, StringComparer.Ordinal)
-                    .Select(listing => $"{listing.Key}\0{listing.Value.CommonStockId:N}\0{listing.Value.ListedTicker}")
+                    .Select(listing =>
+                        $"{listing.Key}\0{listing.Value.CommonStockId:N}\0{listing.Value.ListedTicker}"
+                    )
             );
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
         return $"listing-filter:{Convert.ToHexString(hash).ToLowerInvariant()}";

--- a/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
@@ -1,5 +1,5 @@
-using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;

--- a/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeImportService.cs
@@ -1,4 +1,5 @@
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
@@ -25,7 +26,8 @@ public class OffExchangeVolumeImportService
     // v3: class-share symbol resolution (dot/compressed spellings onto stored dash tickers,
     // #4369) — the bump re-imports every week FINRA still publishes so dual-class weeks fill
     // in; weeks aged out of the ~1-year rolling window are unhealable and stay as stored.
-    private const string Dataset = "off-exchange-weekly-v3";
+    // v4 carries exact listing identity and replays FINRA's retained weekly window.
+    private const string Dataset = "off-exchange-weekly-v4";
     private const int CorrectionLookbackWeeks = 8;
     private static readonly TimeSpan RecentPartitionRefreshInterval = TimeSpan.FromHours(24);
     private static readonly HashSet<string> CompletePublicationTiers = new(
@@ -82,7 +84,23 @@ public class OffExchangeVolumeImportService
             return;
         }
 
-        var scopeKey = FinraImportScope.Resolve(_workerOptions.TickersToSync);
+        // Ordinal for the same reason as the daily lane: FINRA symbol casing is identity
+        // (lowercase suffix = a different security), so a case-insensitive map merges two
+        // securities' weekly volumes. The dataset-key bump above re-imports every week FINRA
+        // still publishes; only weeks that have aged out of the rolling window stay corrupt.
+        var tickerMap = await _tickerMapService.BuildListed(
+            _workerOptions.TickersToSync,
+            cancellationToken,
+            StringComparer.Ordinal
+        );
+        var compressedIndex = FinraClassShareSymbols.BuildCompressedIndex(
+            tickerMap,
+            StringComparer.Ordinal
+        );
+        var scopeKey = FinraImportScope.ResolveListingImportScope(
+            tickerMap,
+            _workerOptions.TickersToSync
+        );
         var completed = await _partitionTracker.GetCompleted(
             Dataset,
             scopeKey,
@@ -99,20 +117,6 @@ public class OffExchangeVolumeImportService
             endWeek,
             completed.Count,
             scopeKey
-        );
-
-        // Ordinal for the same reason as the daily lane: FINRA symbol casing is identity
-        // (lowercase suffix = a different security), so a case-insensitive map merges two
-        // securities' weekly volumes. The dataset-key bump above re-imports every week FINRA
-        // still publishes; only weeks that have aged out of the rolling window stay corrupt.
-        var tickerMap = await _tickerMapService.Build(
-            _workerOptions.TickersToSync,
-            cancellationToken,
-            StringComparer.Ordinal
-        );
-        var compressedIndex = FinraClassShareSymbols.BuildCompressedIndex(
-            tickerMap,
-            StringComparer.Ordinal
         );
         foreach (var week in weeks)
         {
@@ -153,8 +157,8 @@ public class OffExchangeVolumeImportService
 
     private async Task ImportWeek(
         DateOnly weekStartDate,
-        IReadOnlyDictionary<string, Guid> tickerMap,
-        IReadOnlyDictionary<string, Guid> compressedIndex,
+        IReadOnlyDictionary<string, ListedSecurityKey> tickerMap,
+        IReadOnlyDictionary<string, ListedSecurityKey> compressedIndex,
         string scopeKey,
         DateTime importedAt,
         CancellationToken cancellationToken
@@ -271,7 +275,10 @@ public class OffExchangeVolumeImportService
         LogDroppedRows(batch.Count - validBatch.Count, weekStartDate);
 
         var existing = await repo.GetByWeek(weekStartDate)
-            .ToDictionaryAsync(volume => volume.CommonStockId, cancellationToken);
+            .ToDictionaryAsync(
+                volume => new ListedSecurityKey(volume.CommonStockId, volume.ListedTicker),
+                cancellationToken
+            );
         foreach (var volume in validBatch)
             UpsertVolume(repo, existing, volume);
 
@@ -292,11 +299,12 @@ public class OffExchangeVolumeImportService
 
     private static void UpsertVolume(
         OffExchangeVolumeRepository repository,
-        IReadOnlyDictionary<Guid, OffExchangeVolume> existing,
+        IReadOnlyDictionary<ListedSecurityKey, OffExchangeVolume> existing,
         OffExchangeVolume volume
     )
     {
-        if (!existing.TryGetValue(volume.CommonStockId, out var current))
+        var key = new ListedSecurityKey(volume.CommonStockId, volume.ListedTicker);
+        if (!existing.TryGetValue(key, out var current))
         {
             repository.Add(volume);
             return;

--- a/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeMerger.cs
+++ b/src/Equibles.Finra.HostedService/Services/OffExchangeVolumeMerger.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Finra.Data.Models;
 using Equibles.Integrations.Finra.Models;
 
@@ -8,14 +9,14 @@ internal static class OffExchangeVolumeMerger
     private const string AtsSummaryTypeCode = "ATS_W_SMBL";
     private const string NonAtsOtcSummaryTypeCode = "OTC_W_SMBL";
 
-    public static Dictionary<Guid, OffExchangeVolume> Merge(
+    public static Dictionary<ListedSecurityKey, OffExchangeVolume> Merge(
         IEnumerable<OffExchangeWeeklyRecord> records,
-        IReadOnlyDictionary<string, Guid> tickerMap,
-        IReadOnlyDictionary<string, Guid> compressedIndex,
+        IReadOnlyDictionary<string, ListedSecurityKey> tickerMap,
+        IReadOnlyDictionary<string, ListedSecurityKey> compressedIndex,
         DateOnly weekStartDate
     )
     {
-        var merged = new Dictionary<Guid, OffExchangeVolume>();
+        var merged = new Dictionary<ListedSecurityKey, OffExchangeVolume>();
         foreach (var record in records)
         {
             // The weekly feed spells class shares with a dot ("BRK.B"); resolution bridges
@@ -27,21 +28,22 @@ internal static class OffExchangeVolumeMerger
                     tickerMap,
                     compressedIndex,
                     record.Symbol,
-                    out var commonStockId
+                    out var listing
                 )
             )
             {
                 continue;
             }
 
-            if (!merged.TryGetValue(commonStockId, out var volume))
+            if (!merged.TryGetValue(listing, out var volume))
             {
                 volume = new OffExchangeVolume
                 {
-                    CommonStockId = commonStockId,
+                    CommonStockId = listing.CommonStockId,
+                    ListedTicker = listing.ListedTicker,
                     WeekStartDate = weekStartDate,
                 };
-                merged[commonStockId] = volume;
+                merged[listing] = volume;
             }
 
             AddRecord(volume, record);

--- a/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
@@ -1,5 +1,5 @@
-using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;

--- a/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortInterestImportService.cs
@@ -1,4 +1,5 @@
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.AutoWiring;
 using Equibles.Core.Configuration;
@@ -48,7 +49,7 @@ public class ShortInterestImportService
         // Above this, bulk-fetch all symbols (cheaper than a huge domainFilters payload with unknown API limits)
         const int filteredFetchThreshold = 500;
 
-        var tickerMap = await _tickerMapService.Build(
+        var tickerMap = await _tickerMapService.BuildListed(
             _workerOptions.TickersToSync,
             cancellationToken,
             StringComparer.Ordinal
@@ -59,8 +60,13 @@ public class ShortInterestImportService
             return;
         }
 
-        var trackedStockIds = tickerMap.Values.ToHashSet();
-        var reverseMap = tickerMap.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+        var trackedListings = tickerMap.Values.ToHashSet();
+        var reverseMap = tickerMap
+            .GroupBy(kvp => kvp.Value)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(kvp => kvp.Key).Distinct(StringComparer.Ordinal).ToList()
+            );
         // FINRA's consolidated short-interest API spells class shares compressed ("BRKB" for
         // BRK-B), so a raw ticker lookup dropped every class-share record — whole issuers had
         // zero rows across all history (#4369). The per-date missing-stock check below makes
@@ -156,7 +162,7 @@ public class ShortInterestImportService
                 tickerMap,
                 compressedIndex,
                 reverseMap,
-                trackedStockIds,
+                trackedListings,
                 filteredFetchThreshold,
                 cancellationToken
             );
@@ -177,34 +183,34 @@ public class ShortInterestImportService
     /// <returns>Number of records imported, or -1 if the date was already complete.</returns>
     private async Task<int> ImportDate(
         DateOnly date,
-        Dictionary<string, Guid> tickerMap,
-        Dictionary<string, Guid> compressedIndex,
-        Dictionary<Guid, string> reverseMap,
-        HashSet<Guid> trackedStockIds,
+        Dictionary<string, ListedSecurityKey> tickerMap,
+        Dictionary<string, ListedSecurityKey> compressedIndex,
+        Dictionary<ListedSecurityKey, List<string>> reverseMap,
+        HashSet<ListedSecurityKey> trackedListings,
         int filteredFetchThreshold,
         CancellationToken cancellationToken
     )
     {
         try
         {
-            HashSet<Guid> existingStockIds;
+            HashSet<ListedSecurityKey> existingListings;
             using (var scope = _scopeFactory.CreateScope())
             {
                 var repo = scope.ServiceProvider.GetRequiredService<ShortInterestRepository>();
-                var ids = await repo.GetStockIdsBySettlementDate(date)
+                var ids = await repo.GetListingKeysBySettlementDate(date)
                     .ToListAsync(cancellationToken);
-                existingStockIds = ids.ToHashSet();
+                existingListings = ids.ToHashSet();
             }
 
-            var missingStockIds = trackedStockIds.Except(existingStockIds).ToHashSet();
+            var missingListings = trackedListings.Except(existingListings).ToHashSet();
 
-            if (missingStockIds.Count == 0)
+            if (missingListings.Count == 0)
                 return -1;
 
             var records = await FetchMissingRecords(
                 date,
-                missingStockIds,
-                trackedStockIds,
+                missingListings,
+                trackedListings,
                 reverseMap,
                 filteredFetchThreshold
             );
@@ -219,20 +225,21 @@ public class ShortInterestImportService
                 .Select(r =>
                     (
                         Record: r,
-                        StockId: FinraClassShareSymbols.TryResolve(
+                        Listing: FinraClassShareSymbols.TryResolve(
                             tickerMap,
                             compressedIndex,
                             r.Symbol,
-                            out var stockId
+                            out var listing
                         )
-                            ? (Guid?)stockId
+                            ? (ListedSecurityKey?)listing
                             : null
                     )
                 )
-                .Where(x => x.StockId is { } id && missingStockIds.Contains(id))
+                .Where(x => x.Listing is { } listing && missingListings.Contains(listing))
                 .Select(x => new ShortInterest
                 {
-                    CommonStockId = x.StockId.Value,
+                    CommonStockId = x.Listing.Value.CommonStockId,
+                    ListedTicker = x.Listing.Value.ListedTicker,
                     SettlementDate = date,
                     CurrentShortPosition = x.Record.CurrentShortPosition ?? 0,
                     PreviousShortPosition = x.Record.PreviousShortPosition ?? 0,
@@ -251,7 +258,7 @@ public class ShortInterestImportService
                 "Imported {Count} short interest records for {Date} ({Missing} stocks were missing)",
                 inserted,
                 date,
-                missingStockIds.Count
+                missingListings.Count
             );
 
             return inserted;
@@ -278,15 +285,15 @@ public class ShortInterestImportService
     // stocks are missing, or a symbol-filtered request when only a few need backfilling.
     private Task<List<ShortInterestRecord>> FetchMissingRecords(
         DateOnly date,
-        HashSet<Guid> missingStockIds,
-        HashSet<Guid> trackedStockIds,
-        Dictionary<Guid, string> reverseMap,
+        HashSet<ListedSecurityKey> missingListings,
+        HashSet<ListedSecurityKey> trackedListings,
+        Dictionary<ListedSecurityKey, List<string>> reverseMap,
         int filteredFetchThreshold
     )
     {
         var useBulkFetch =
-            missingStockIds.Count == trackedStockIds.Count
-            || missingStockIds.Count > filteredFetchThreshold;
+            missingListings.Count == trackedListings.Count
+            || missingListings.Count > filteredFetchThreshold;
 
         if (useBulkFetch)
             return _finraClient.GetShortInterest(date);
@@ -295,9 +302,10 @@ public class ShortInterestImportService
         // API) — an unmatched filter returns nothing, and responses map back through the
         // compressed index, so over-asking is harmless while under-asking silently returns
         // zero rows for exactly the stocks being healed.
-        var missingSymbols = missingStockIds
-            .Where(id => reverseMap.ContainsKey(id))
-            .SelectMany(id => FinraClassShareSymbols.RequestSpellings(reverseMap[id]))
+        var missingSymbols = missingListings
+            .Where(listing => reverseMap.ContainsKey(listing))
+            .SelectMany(listing => reverseMap[listing])
+            .SelectMany(FinraClassShareSymbols.RequestSpellings)
             .Distinct()
             .ToList();
         return _finraClient.GetShortInterest(date, missingSymbols);

--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -248,9 +248,11 @@ public class ShortVolumeImportService
             UpsertVolume(repo, existing, volume);
 
         var stale = existing
-            .Values.Where(volume => collisionOnlyListings.Contains(
-                new ListedSecurityKey(volume.CommonStockId, volume.ListedTicker)
-            ))
+            .Values.Where(volume =>
+                collisionOnlyListings.Contains(
+                    new ListedSecurityKey(volume.CommonStockId, volume.ListedTicker)
+                )
+            )
             .ToList();
         if (stale.Count > 0)
         {
@@ -366,7 +368,8 @@ public class ShortVolumeImportService
 
             if (!aggregated.TryGetValue(listing, out var volume))
             {
-                volume = new DailyShortVolume {
+                volume = new DailyShortVolume
+                {
                     CommonStockId = listing.CommonStockId,
                     ListedTicker = listing.ListedTicker,
                     Date = currentDate,

--- a/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
+++ b/src/Equibles.Finra.HostedService/Services/ShortVolumeImportService.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.AutoWiring;
@@ -25,7 +26,9 @@ public class ShortVolumeImportService
     // TPC) — the aggregates are corrupt wherever a case-variant sibling traded. The bump
     // orphans every v1 marker, so CandidateDates re-imports the full history newest-first
     // (bounded per cycle) and the upsert REPLACES the corrupted sums.
-    private const string Dataset = "daily-short-volume-files-v2";
+    // v3 carries exact listing identity, so ETF and other reference tickers no longer collapse
+    // into the filer's primary row. The new partition key replays the bounded history.
+    private const string Dataset = "daily-short-volume-files-v3";
     private const int CorrectionLookbackDays = 7;
     private static readonly DateOnly FirstConsolidatedFileDate = new(2018, 8, 1);
     private static readonly TimeSpan RecentPartitionRefreshInterval = TimeSpan.FromHours(24);
@@ -83,7 +86,7 @@ public class ShortVolumeImportService
         // The resolved universe is part of completeness identity. A date checked before a stock
         // was added is not complete for that stock, so a universe change gets a fresh bounded,
         // newest-first pass instead of inheriting the old global "all" markers.
-        var tickerMap = await _tickerMapService.Build(
+        var tickerMap = await _tickerMapService.BuildListed(
             _workerOptions.TickersToSync,
             cancellationToken,
             StringComparer.Ordinal
@@ -96,7 +99,10 @@ public class ShortVolumeImportService
             return;
         }
 
-        var scopeKey = FinraImportScope.ResolveStockUniverse(tickerMap);
+        var scopeKey = FinraImportScope.ResolveListingImportScope(
+            tickerMap,
+            _workerOptions.TickersToSync
+        );
         var completed = await _partitionTracker.GetCompleted(
             Dataset,
             scopeKey,
@@ -152,7 +158,7 @@ public class ShortVolumeImportService
 
     private async Task<bool> ImportSingleDay(
         DateOnly date,
-        IReadOnlyDictionary<string, Guid> tickerMap,
+        IReadOnlyDictionary<string, ListedSecurityKey> tickerMap,
         string scopeKey,
         DateTime importedAt,
         CancellationToken cancellationToken
@@ -216,7 +222,7 @@ public class ShortVolumeImportService
 
     private async Task<int> UpsertDay(
         IEnumerable<DailyShortVolume> volumes,
-        IReadOnlySet<Guid> collisionOnlyStocks,
+        IReadOnlySet<ListedSecurityKey> collisionOnlyListings,
         DateOnly date,
         CancellationToken cancellationToken
     )
@@ -234,12 +240,17 @@ public class ShortVolumeImportService
         LogDroppedRows(batch.Count - validBatch.Count, date);
 
         var existing = await repo.GetByDate(date)
-            .ToDictionaryAsync(volume => volume.CommonStockId, cancellationToken);
+            .ToDictionaryAsync(
+                volume => new ListedSecurityKey(volume.CommonStockId, volume.ListedTicker),
+                cancellationToken
+            );
         foreach (var volume in validBatch)
             UpsertVolume(repo, existing, volume);
 
         var stale = existing
-            .Values.Where(volume => collisionOnlyStocks.Contains(volume.CommonStockId))
+            .Values.Where(volume => collisionOnlyListings.Contains(
+                new ListedSecurityKey(volume.CommonStockId, volume.ListedTicker)
+            ))
             .ToList();
         if (stale.Count > 0)
         {
@@ -266,10 +277,10 @@ public class ShortVolumeImportService
     /// partition date (a renamed ticker whose OLD file happens to carry a case-variant of the
     /// NEW symbol would lose that day — measured exposure in production is near zero).
     /// </summary>
-    private static HashSet<Guid> CollisionOnlyStocks(
+    private static HashSet<ListedSecurityKey> CollisionOnlyStocks(
         List<ShortVolumeRecord> records,
-        IReadOnlyDictionary<string, Guid> tickerMap,
-        IReadOnlyDictionary<Guid, DailyShortVolume> aggregated
+        IReadOnlyDictionary<string, ListedSecurityKey> tickerMap,
+        IReadOnlyDictionary<ListedSecurityKey, DailyShortVolume> aggregated
     )
     {
         var fileSymbolsOrdinal = new HashSet<string>(StringComparer.Ordinal);
@@ -282,10 +293,10 @@ public class ShortVolumeImportService
             fileSymbolsCaseInsensitive.Add(record.Symbol);
         }
 
-        var collisionOnly = new HashSet<Guid>();
-        foreach (var (ticker, stockId) in tickerMap)
+        var collisionOnly = new HashSet<ListedSecurityKey>();
+        foreach (var (ticker, listing) in tickerMap)
         {
-            if (aggregated.ContainsKey(stockId))
+            if (aggregated.ContainsKey(listing))
                 continue;
             // Deletion is unrecoverable, so it is confined to the population the case-fold
             // could actually corrupt: all-uppercase tickers (every stored ticker today). A
@@ -299,7 +310,7 @@ public class ShortVolumeImportService
             // filter records (e.g. dropping zero-volume rows), a filtered-but-present exact
             // symbol must still protect the stock from deletion.
             if (fileSymbolsCaseInsensitive.Contains(ticker) && !fileSymbolsOrdinal.Contains(ticker))
-                collisionOnly.Add(stockId);
+                collisionOnly.Add(listing);
         }
 
         return collisionOnly;
@@ -319,11 +330,12 @@ public class ShortVolumeImportService
 
     private static void UpsertVolume(
         DailyShortVolumeRepository repository,
-        IReadOnlyDictionary<Guid, DailyShortVolume> existing,
+        IReadOnlyDictionary<ListedSecurityKey, DailyShortVolume> existing,
         DailyShortVolume volume
     )
     {
-        if (!existing.TryGetValue(volume.CommonStockId, out var current))
+        var key = new ListedSecurityKey(volume.CommonStockId, volume.ListedTicker);
+        if (!existing.TryGetValue(key, out var current))
         {
             repository.Add(volume);
             return;
@@ -335,27 +347,31 @@ public class ShortVolumeImportService
         current.Market = volume.Market;
     }
 
-    private static Dictionary<Guid, DailyShortVolume> AggregateVolumesByStock(
+    private static Dictionary<ListedSecurityKey, DailyShortVolume> AggregateVolumesByStock(
         List<ShortVolumeRecord> records,
-        IReadOnlyDictionary<string, Guid> tickerMap,
+        IReadOnlyDictionary<string, ListedSecurityKey> tickerMap,
         DateOnly currentDate
     )
     {
-        var aggregated = new Dictionary<Guid, DailyShortVolume>();
+        var aggregated = new Dictionary<ListedSecurityKey, DailyShortVolume>();
         foreach (var record in records)
         {
             if (
                 string.IsNullOrEmpty(record.Symbol)
-                || !tickerMap.TryGetValue(record.Symbol, out var commonStockId)
+                || !tickerMap.TryGetValue(record.Symbol, out var listing)
             )
             {
                 continue;
             }
 
-            if (!aggregated.TryGetValue(commonStockId, out var volume))
+            if (!aggregated.TryGetValue(listing, out var volume))
             {
-                volume = new DailyShortVolume { CommonStockId = commonStockId, Date = currentDate };
-                aggregated[commonStockId] = volume;
+                volume = new DailyShortVolume {
+                    CommonStockId = listing.CommonStockId,
+                    ListedTicker = listing.ListedTicker,
+                    Date = currentDate,
+                };
+                aggregated[listing] = volume;
             }
 
             volume.ShortVolume += record.ShortVolume ?? 0;

--- a/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
@@ -1,6 +1,10 @@
 using System.ComponentModel;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories.Extensions;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.BusinessLogic.Extensions;
 using Equibles.Finra.BusinessLogic;
@@ -19,17 +23,20 @@ public class OffExchangeVolumeTools
 {
     private readonly OffExchangeVolumeRepository _offExchangeVolumeRepository;
     private readonly CommonStockRepository _commonStockRepository;
+    private readonly StockSplitRepository _stockSplitRepository;
     private readonly McpToolRunner _runner;
 
     public OffExchangeVolumeTools(
         OffExchangeVolumeRepository offExchangeVolumeRepository,
         CommonStockRepository commonStockRepository,
+        StockSplitRepository stockSplitRepository,
         ErrorManager errorManager,
         ILogger<OffExchangeVolumeTools> logger
     )
     {
         _offExchangeVolumeRepository = offExchangeVolumeRepository;
         _commonStockRepository = commonStockRepository;
+        _stockSplitRepository = stockSplitRepository;
         _runner = new McpToolRunner(logger, errorManager.AsMcpErrorReporter());
     }
 
@@ -39,7 +46,7 @@ public class OffExchangeVolumeTools
         ReadOnly = true
     )]
     [Description(
-        "Get weekly off-exchange (dark pool / OTC) trading volume for a stock from the FINRA OTC/ATS Transparency data. "
+        "Get weekly off-exchange (dark pool / OTC) trading volume for an exact stock or ETF listing from the FINRA OTC/ATS Transparency data. "
             + "Each week shows ATS (alternative trading system / dark pool) volume and trade count, non-ATS OTC volume and trade count, "
             + "and the total off-exchange volume (ATS + non-ATS OTC). The FINRA file does not include consolidated tape volume, so the "
             + "off-exchange share of total market volume is not reported here; compute that share elsewhere against a consolidated-volume source. "
@@ -48,7 +55,7 @@ public class OffExchangeVolumeTools
             + "FINRA publishes each week on a delay (2 weeks for Tier 1 NMS stocks, longer for other tiers), so the latest week lags today."
     )]
     public Task<string> GetOffExchangeVolume(
-        [Description("Stock ticker symbol (e.g., AAPL, GME, TSLA)")] string ticker,
+        [Description("Listed security ticker (e.g., AAPL, VOO, GME)")] string ticker,
         [Description("Start date in YYYY-MM-DD format (defaults to 6 months ago)")]
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
@@ -65,13 +72,7 @@ public class OffExchangeVolumeTools
                 var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
-                var listingError = FinraTickerScope.SecondaryListingUnavailable(
-                    stock,
-                    ticker,
-                    "off-exchange-volume"
-                );
-                if (listingError != null)
-                    return listingError;
+                var listedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, ticker);
 
                 var (startWeek, endWeek, rangeError) = ParseStrictDateRange(
                     startDate,
@@ -84,7 +85,7 @@ public class OffExchangeVolumeTools
                 maxResults = McpLimit.Clamp(maxResults);
 
                 var query = _offExchangeVolumeRepository
-                    .GetHistoryByStock(stock)
+                    .GetHistoryByListing(stock, listedTicker)
                     .Where(d => d.WeekStartDate >= startWeek && d.WeekStartDate <= endWeek);
 
                 var total = await query.CountAsync();
@@ -92,14 +93,22 @@ public class OffExchangeVolumeTools
                     .OrderByDescending(d => d.WeekStartDate)
                     .Take(maxResults)
                     .ToListAsync();
+                var splits = await _stockSplitRepository
+                    .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
+                    .ToListAsync();
+                splits = PriceSeriesSplitScope.ForListing(splits, stock.Ticker, listedTicker);
 
                 var table = MarkdownTable.Render(
                     records.OrderBy(r => r.WeekStartDate).ToList(),
-                    $"No off-exchange volume data found for {stock.Ticker} in the specified date range.",
-                    $"Weekly off-exchange (dark pool / OTC) volume for {stock.Ticker} ({stock.Name}):",
+                    $"No off-exchange volume data found for {listedTicker} in the specified date range.",
+                    $"Weekly off-exchange (dark pool / OTC) volume for {listedTicker}{ListingName(stock, listedTicker)}:",
                     "| Week Start | ATS Volume | ATS Trades | Non-ATS OTC Volume | Non-ATS OTC Trades | Total Off-Exchange Volume |",
                     "|------------|-----------|-----------|-------------------|-------------------|--------------------------|",
-                    r => RenderOffExchangeRow($"{r.WeekStartDate:yyyy-MM-dd}", r)
+                    r => RenderOffExchangeRow(
+                        $"{r.WeekStartDate:yyyy-MM-dd}",
+                        r,
+                        SplitAdjustment.ShareCountFactor(r.WeekStartDate, splits)
+                    )
                 );
 
                 var notes = new[]
@@ -113,6 +122,11 @@ public class OffExchangeVolumeTools
             $"ticker: {ticker}"
         );
     }
+
+    private static string ListingName(CommonStock stock, string listedTicker) =>
+        !SecondaryTickerPolicy.RequiresExactListingScope(stock, listedTicker)
+            ? $" ({stock.Name})"
+            : string.Empty;
 
     // Strict replacement for McpToolExecutor.ParseDateRange: a supplied date must be ISO
     // yyyy-MM-dd (no silent fallback onto the default window) and the range must not be
@@ -186,9 +200,14 @@ public class OffExchangeVolumeTools
     // locale (e.g. de-DE would render 5.000.000 instead of 5,000,000). Total off-exchange
     // volume is the sum of ATS and non-ATS OTC volume; the share of consolidated tape volume
     // is intentionally omitted because the FINRA file carries no consolidated total.
-    private static string RenderOffExchangeRow(string leadCell, OffExchangeVolume r)
+    private static string RenderOffExchangeRow(
+        string leadCell,
+        OffExchangeVolume r,
+        decimal shareFactor = 1m
+    )
     {
-        var totalOffExchangeVolume = r.AtsVolume + r.NonAtsOtcVolume;
-        return $"| {leadCell} | {McpFormat.WholeNumber(r.AtsVolume)} | {McpFormat.WholeNumber(r.AtsTradeCount)} | {McpFormat.WholeNumber(r.NonAtsOtcVolume)} | {McpFormat.WholeNumber(r.NonAtsOtcTradeCount)} | {McpFormat.WholeNumber(totalOffExchangeVolume)} |";
+        var ats = SplitAdjustment.AdjustShareCount(r.AtsVolume, shareFactor);
+        var nonAts = SplitAdjustment.AdjustShareCount(r.NonAtsOtcVolume, shareFactor);
+        return $"| {leadCell} | {McpFormat.WholeNumber(ats)} | {McpFormat.WholeNumber(r.AtsTradeCount)} | {McpFormat.WholeNumber(nonAts)} | {McpFormat.WholeNumber(r.NonAtsOtcTradeCount)} | {McpFormat.WholeNumber(ats + nonAts)} |";
     }
 }

--- a/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/OffExchangeVolumeTools.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
-using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.CorporateActions.Data;
 using Equibles.CorporateActions.Repositories;
@@ -104,11 +104,12 @@ public class OffExchangeVolumeTools
                     $"Weekly off-exchange (dark pool / OTC) volume for {listedTicker}{ListingName(stock, listedTicker)}:",
                     "| Week Start | ATS Volume | ATS Trades | Non-ATS OTC Volume | Non-ATS OTC Trades | Total Off-Exchange Volume |",
                     "|------------|-----------|-----------|-------------------|-------------------|--------------------------|",
-                    r => RenderOffExchangeRow(
-                        $"{r.WeekStartDate:yyyy-MM-dd}",
-                        r,
-                        SplitAdjustment.ShareCountFactor(r.WeekStartDate, splits)
-                    )
+                    r =>
+                        RenderOffExchangeRow(
+                            $"{r.WeekStartDate:yyyy-MM-dd}",
+                            r,
+                            SplitAdjustment.ShareCountFactor(r.WeekStartDate, splits)
+                        )
                 );
 
                 var notes = new[]

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.CorporateActions.Data;
@@ -68,10 +69,10 @@ public class ShortDataTools
 
     [McpServerTool(Name = "GetShortVolume", Title = "Daily Short Sale Volume", ReadOnly = true)]
     [Description(
-        "Get daily short sale volume history for a stock from FINRA's short sale volume files. Shows short volume, short-exempt volume, total volume, and short volume percentage per trading day. Volumes cover trades reported to FINRA facilities (off-exchange/TRF) only — NOT consolidated tape volume — and a 40-50% Short % is the normal baseline from market-maker liquidity provision, so it must not be quoted as a share of the stock's total traded volume. This daily flow metric is distinct from bi-monthly short interest positions: use GetShortInterest for positions, GetLargestShortVolume for a market-wide single-day ranking, and GetShortSqueezeScores for squeeze candidates."
+        "Get daily short sale volume history for an exact stock or ETF listing from FINRA's short sale volume files. Shows short volume, short-exempt volume, total volume, and short volume percentage per trading day. Volumes cover trades reported to FINRA facilities (off-exchange/TRF) only — NOT consolidated tape volume — and a 40-50% Short % is the normal baseline from market-maker liquidity provision, so it must not be quoted as a share of the stock's total traded volume. This daily flow metric is distinct from bi-monthly short interest positions: use GetShortInterest for positions, GetLargestShortVolume for a market-wide single-day ranking, and GetShortSqueezeScores for squeeze candidates."
     )]
     public Task<string> GetShortVolume(
-        [Description("Stock ticker symbol (e.g., AAPL, GME, AMC)")] string ticker,
+        [Description("Listed security ticker (e.g., AAPL, VOO, GME)")] string ticker,
         [Description("Start date in YYYY-MM-DD format (defaults to 3 months ago)")]
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
@@ -88,13 +89,7 @@ public class ShortDataTools
                 var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
-                var listingError = FinraTickerScope.SecondaryListingUnavailable(
-                    stock,
-                    ticker,
-                    "short-volume"
-                );
-                if (listingError != null)
-                    return listingError;
+                var listedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, ticker);
 
                 var (start, end, rangeError) = ParseStrictDateRange(
                     startDate,
@@ -105,7 +100,7 @@ public class ShortDataTools
                     return rangeError;
 
                 var query = _shortVolumeRepository
-                    .GetHistoryByStock(stock)
+                    .GetHistoryByListing(stock, listedTicker)
                     .Where(d => d.Date >= start && d.Date <= end);
 
                 maxResults = McpLimit.Clamp(maxResults);
@@ -123,13 +118,13 @@ public class ShortDataTools
                     // floor, so an older range would otherwise read as a false factual
                     // "this stock had no short volume" claim.
                     var earliest = await _shortVolumeRepository
-                        .GetHistoryByStock(stock)
+                        .GetHistoryByListing(stock, listedTicker)
                         .OrderBy(d => d.Date)
                         .Select(d => (DateOnly?)d.Date)
                         .FirstOrDefaultAsync();
                     if (earliest != null && end < earliest.Value)
-                        return $"No short volume data for {stock.Ticker} before {earliest:yyyy-MM-dd} — coverage starts on {earliest:yyyy-MM-dd}. Adjust the date range.";
-                    return $"No short volume data found for {stock.Ticker} in the specified date range.";
+                        return $"No short volume data for {listedTicker} before {earliest:yyyy-MM-dd} — coverage starts on {earliest:yyyy-MM-dd}. Adjust the date range.";
+                    return $"No short volume data found for {listedTicker} in the specified date range.";
                 }
 
                 // Restate each day's volumes onto today's split basis so the series is
@@ -139,11 +134,12 @@ public class ShortDataTools
                 var splits = await _stockSplitRepository
                     .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
                     .ToListAsync();
+                splits = PriceSeriesSplitScope.ForListing(splits, stock.Ticker, listedTicker);
 
                 var table = MarkdownTable.Render(
                     records.OrderBy(r => r.Date).ToList(),
-                    $"No short volume data found for {stock.Ticker} in the specified date range.",
-                    $"Daily short volume for {stock.Ticker} ({stock.Name}):",
+                    $"No short volume data found for {listedTicker} in the specified date range.",
+                    $"Daily short volume for {listedTicker}{ListingName(stock, listedTicker)}:",
                     "_Volumes are trades reported to FINRA facilities (off-exchange/TRF) only — not consolidated tape volume; a 40-50% Short % is the normal baseline. Short Exempt = short sales exempt from Reg SHO price-test restrictions. Share counts are restated onto today's split basis._",
                     "| Date | Short Volume | Short Exempt | Total Volume | Short % |",
                     "|------|-------------|--------------|-------------|---------|",
@@ -164,10 +160,10 @@ public class ShortDataTools
 
     [McpServerTool(Name = "GetShortInterest", Title = "Short Interest History", ReadOnly = true)]
     [Description(
-        "Get bi-monthly short interest history for a stock from FINRA. Shows the reported short position, change from the previous settlement, average daily volume, and days to cover per settlement date. Share counts are restated onto today's split basis so the series stays continuous across stock splits; days to cover is as reported (FINRA caps it at 999.99). High days-to-cover (>5) suggests a potential short squeeze — for short interest as a % of shares outstanding and an actual squeeze-candidate ranking use GetShortSqueezeScores; for the market-wide latest settlement use GetShortInterestSnapshot. FINRA publishes each file weeks after it measures the position, so the answer may also carry an estimate of the settlement that has not been reported yet — it appears BELOW the table, labelled as an estimate, and is a model prediction rather than reported data; never present it as a FINRA figure."
+        "Get bi-monthly short interest history for an exact stock or ETF listing from FINRA. Shows the reported short position, change from the previous settlement, average daily volume, and days to cover per settlement date. Share counts are restated onto today's split basis so the series stays continuous across stock splits; days to cover is as reported (FINRA caps it at 999.99). High days-to-cover (>5) suggests a potential short squeeze — for short interest as a % of shares outstanding and an actual squeeze-candidate ranking use GetShortSqueezeScores; for the market-wide latest settlement use GetShortInterestSnapshot. For primary operating-company stocks only, the answer may also carry a model estimate of the settlement FINRA has not published yet; it appears BELOW the table and must never be presented as a FINRA figure."
     )]
     public Task<string> GetShortInterest(
-        [Description("Stock ticker symbol (e.g., AAPL, GME, TSLA)")] string ticker,
+        [Description("Listed security ticker (e.g., AAPL, VOO, GME)")] string ticker,
         [Description("Start date in YYYY-MM-DD format (defaults to 1 year ago)")]
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
@@ -186,13 +182,7 @@ public class ShortDataTools
                 var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
-                var listingError = FinraTickerScope.SecondaryListingUnavailable(
-                    stock,
-                    ticker,
-                    "short-interest"
-                );
-                if (listingError != null)
-                    return listingError;
+                var listedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, ticker);
 
                 var (start, end, rangeError) = ParseStrictDateRange(
                     startDate,
@@ -202,20 +192,29 @@ public class ShortDataTools
                 if (rangeError != null)
                     return rangeError;
 
-                var query = _shortInterestRepository
-                    .GetHistoryByStock(stock)
+                var history = _shortInterestRepository
+                    .GetHistoryByListing(stock, listedTicker);
+                var query = history
                     .Where(s => s.SettlementDate >= start && s.SettlementDate <= end);
 
                 var total = await query.CountAsync();
 
-                // One extra settlement past the window so the oldest DISPLAYED row still has
-                // its predecessor available for the split-consistent Change computation below.
-                var fetched = await query
+                var display = await query
                     .OrderByDescending(s => s.SettlementDate)
-                    .Take(maxResults + 1)
+                    .Take(maxResults)
                     .ToListAsync();
-
-                var display = fetched.Take(maxResults).OrderBy(r => r.SettlementDate).ToList();
+                var calculationRows = display.ToList();
+                if (display.Count > 0)
+                {
+                    var oldestDisplayed = display.Min(record => record.SettlementDate);
+                    var predecessor = await history
+                        .Where(record => record.SettlementDate < oldestDisplayed)
+                        .OrderByDescending(record => record.SettlementDate)
+                        .FirstOrDefaultAsync();
+                    if (predecessor != null)
+                        calculationRows.Add(predecessor);
+                }
+                display = display.OrderBy(record => record.SettlementDate).ToList();
 
                 // Restate each settlement's share counts (short position, change, average
                 // daily volume) onto today's split basis so the series is continuous across a
@@ -225,6 +224,7 @@ public class ShortDataTools
                 var splits = await _stockSplitRepository
                     .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
                     .ToListAsync();
+                splits = PriceSeriesSplitScope.ForListing(splits, stock.Ticker, listedTicker);
 
                 // FINRA's raw change is (current − previous) where the previous position is on
                 // the PREVIOUS settlement's split basis, so scaling it by the current factor
@@ -232,7 +232,7 @@ public class ShortDataTools
                 // the predecessor settlement is on file (and FINRA's change really references
                 // it), display the difference of the two restated positions instead, so the
                 // Change column reconciles row-to-row across a split boundary.
-                var ascAll = fetched.OrderBy(r => r.SettlementDate).ToList();
+                var ascAll = calculationRows.OrderBy(r => r.SettlementDate).ToList();
                 var changeById = new Dictionary<Guid, long>(ascAll.Count);
                 for (var i = 0; i < ascAll.Count; i++)
                 {
@@ -251,8 +251,8 @@ public class ShortDataTools
 
                 var table = MarkdownTable.Render(
                     display,
-                    $"No short interest data found for {stock.Ticker} in the specified date range.",
-                    $"Short interest for {stock.Ticker} ({stock.Name}):",
+                    $"No short interest data found for {listedTicker} in the specified date range.",
+                    $"Short interest for {listedTicker}{ListingName(stock, listedTicker)}:",
                     "_Share counts are restated onto today's split basis so the series is continuous across splits; Days to Cover is as reported by FINRA (capped at 999.99)._",
                     "| Settlement Date | Short Position | Change | Avg Daily Volume | Days to Cover |",
                     "|----------------|---------------|--------|-----------------|---------------|",
@@ -268,6 +268,8 @@ public class ShortDataTools
                 var answer = AppendNote(table, NewestKeptNote(display.Count, total, "settlements"));
                 if (!WindowReachesPresent(end))
                     return answer;
+                if (SecondaryTickerPolicy.RequiresExactListingScope(stock, listedTicker))
+                    return answer;
 
                 var estimate =
                     _estimateSource == null ? null : await _estimateSource.Describe(stock);
@@ -278,13 +280,18 @@ public class ShortDataTools
         );
     }
 
+    private static string ListingName(CommonStock stock, string listedTicker) =>
+        !SecondaryTickerPolicy.RequiresExactListingScope(stock, listedTicker)
+            ? $" ({stock.Name})"
+            : string.Empty;
+
     [McpServerTool(
         Name = "GetShortInterestSnapshot",
         Title = "Market-Wide Short Interest Snapshot",
         ReadOnly = true
     )]
     [Description(
-        "Market-wide snapshot of the latest FINRA bi-monthly short interest settlement — one row per stock, sorted by days to cover (descending) by default. FINRA caps days to cover at 999.99: capped rows are a sentinel (almost always illiquid names with a tiny average-daily-volume denominator) and are ranked after real readings; pass minAvgDailyVolume (e.g. 100000) to drop illiquid names entirely. This is the raw FINRA snapshot — for genuine short-squeeze candidate ranking use GetShortSqueezeScores; for one stock's history use GetShortInterest; for daily short-sale flow use GetShortVolume/GetLargestShortVolume."
+        "Market-wide snapshot of the latest FINRA bi-monthly short interest settlement — one row per exact listed security, sorted by days to cover (descending) by default. FINRA caps days to cover at 999.99: capped rows are a sentinel (almost always illiquid names with a tiny average-daily-volume denominator) and are ranked after real readings; pass minAvgDailyVolume (e.g. 100000) to drop illiquid names entirely. This is the raw FINRA snapshot — for genuine short-squeeze candidate ranking use GetShortSqueezeScores; for one stock or ETF's history use GetShortInterest; for daily short-sale flow use GetShortVolume/GetLargestShortVolume."
     )]
     public Task<string> GetShortInterestSnapshot(
         [Description("Minimum days to cover filter (default: 0)")] decimal minDaysToCover = 0,
@@ -324,41 +331,10 @@ public class ShortDataTools
                     query = query.Where(s => s.DaysToCover >= minDaysToCover);
                 }
 
-                if (minAvgDailyVolume > 0)
-                {
-                    query = query.Where(s => s.AverageDailyVolume >= minAvgDailyVolume);
-                }
-
-                // Every ordering ends on the ticker so the ranking is deterministic — the
-                // 999.99 cap tier alone holds ~180 tied rows, and an ORDER BY that ends on a
-                // tie lets Postgres return a different "top" set on every call.
                 var sortKey = string.IsNullOrWhiteSpace(sortBy) ? "daysToCover" : sortBy.Trim();
-                IOrderedQueryable<ShortInterest> ordered;
-                if (sortKey.Equals("daysToCover", StringComparison.OrdinalIgnoreCase))
-                {
-                    // Rows at FINRA's cap are a sentinel tier, not real readings — rank them
-                    // after genuine values so the default view is not 100% illiquid capped
-                    // names (which would bury every actionable row).
-                    ordered = query
-                        .OrderBy(s => s.DaysToCover >= FinraDaysToCoverCap ? 1 : 0)
-                        .ThenByDescending(s => s.DaysToCover)
-                        .ThenByDescending(s => s.CurrentShortPosition)
-                        .ThenBy(s => s.CommonStock.Ticker);
-                }
-                else if (sortKey.Equals("shortPosition", StringComparison.OrdinalIgnoreCase))
-                {
-                    ordered = query
-                        .OrderByDescending(s => s.CurrentShortPosition)
-                        .ThenBy(s => s.CommonStock.Ticker);
-                }
-                else if (sortKey.Equals("change", StringComparison.OrdinalIgnoreCase))
-                {
-                    ordered = query
-                        .OrderByDescending(s => s.ChangeInShortPosition)
-                        .ThenByDescending(s => s.CurrentShortPosition)
-                        .ThenBy(s => s.CommonStock.Ticker);
-                }
-                else
+                if (!sortKey.Equals("daysToCover", StringComparison.OrdinalIgnoreCase)
+                    && !sortKey.Equals("shortPosition", StringComparison.OrdinalIgnoreCase)
+                    && !sortKey.Equals("change", StringComparison.OrdinalIgnoreCase))
                 {
                     return McpOutput.InvalidArgument(
                         "sortBy",
@@ -368,11 +344,63 @@ public class ShortDataTools
                 }
 
                 offset = McpLimit.ClampOffset(offset);
-                var total = await query.CountAsync();
-                var records = await ordered
+                var rawRecords = await query.ToListAsync();
+                var validListings = await _commonStockRepository.GetUniqueActiveListingKeys();
+                rawRecords = rawRecords.Where(row => validListings.Contains(
+                    new ListedSecurityKey(
+                        row.CommonStockId,
+                        ListingTicker(row.CommonStock, row.ListedTicker)
+                    )
+                )).ToList();
+                var stockIds = rawRecords.Select(row => row.CommonStockId).Distinct().ToList();
+                var splitRows = await _stockSplitRepository
+                    .GetEffective(DateOnly.FromDateTime(DateTime.UtcNow))
+                    .Where(split => stockIds.Contains(split.CommonStockId))
+                    .ToListAsync();
+                var previousDate = await _shortInterestRepository.GetAllSettlementDates()
+                    .Where(day => day < latestDate)
+                    .OrderByDescending(day => day)
+                    .FirstOrDefaultAsync();
+                var adjusted = rawRecords.Select(row =>
+                {
+                    var listedTicker = ListingTicker(row.CommonStock, row.ListedTicker);
+                    var scoped = PriceSeriesSplitScope.ForListing(
+                        splitRows.Where(split => split.CommonStockId == row.CommonStockId),
+                        row.CommonStock.Ticker,
+                        listedTicker
+                    );
+                    var factor = SplitAdjustment.ShareCountFactor(latestDate, scoped);
+                    var previousFactor = SplitAdjustment.ShareCountFactor(previousDate, scoped);
+                    var position = SplitAdjustment.AdjustShareCount(row.CurrentShortPosition, factor);
+                    var previous = SplitAdjustment.AdjustShareCount(row.PreviousShortPosition, previousFactor);
+                    return new
+                    {
+                        Row = row,
+                        ListedTicker = listedTicker,
+                        Factor = factor,
+                        Position = position,
+                        Change = position - previous,
+                    };
+                }).Where(row => minAvgDailyVolume <= 0
+                    || SplitAdjustment.AdjustShareCount(
+                        row.Row.AverageDailyVolume.Value,
+                        row.Factor
+                    ) >= minAvgDailyVolume);
+                adjusted = sortKey.Equals("shortPosition", StringComparison.OrdinalIgnoreCase)
+                    ? adjusted.OrderByDescending(row => row.Position).ThenBy(row => row.ListedTicker)
+                    : sortKey.Equals("change", StringComparison.OrdinalIgnoreCase)
+                        ? adjusted.OrderByDescending(row => row.Change)
+                            .ThenByDescending(row => row.Position)
+                            .ThenBy(row => row.ListedTicker)
+                        : adjusted.OrderBy(row => row.Row.DaysToCover >= FinraDaysToCoverCap ? 1 : 0)
+                            .ThenByDescending(row => row.Row.DaysToCover)
+                            .ThenByDescending(row => row.Position)
+                            .ThenBy(row => row.ListedTicker);
+                var total = adjusted.Count();
+                var records = adjusted
                     .Skip(offset)
                     .Take(McpLimit.Clamp(maxResults))
-                    .ToListAsync();
+                    .ToList();
                 if (records.Count == 0 && offset > 0)
                     return $"No results at offset {offset} - only {total} rows match; lower offset.";
 
@@ -387,7 +415,7 @@ public class ShortDataTools
                     "_FINRA caps Days to Cover at 999.99 — \">=999.99 (FINRA cap)\" rows are that sentinel (true value unknown, typically illiquid names) and rank after real readings in the default sort._",
                     "| Ticker | Short Position | Change | Avg Daily Volume | Days to Cover |",
                     "|--------|---------------|--------|-----------------|---------------|",
-                    r => RenderShortInterestRow(r.CommonStock.Ticker, r)
+                    r => RenderShortInterestRow(r.ListedTicker, r.Row, r.Factor, r.Change)
                 );
 
                 return AppendNote(
@@ -406,7 +434,7 @@ public class ShortDataTools
         ReadOnly = true
     )]
     [Description(
-        "Get the stocks with the largest daily short sale volume for a single trading day (defaults to the latest available), from FINRA's daily short sale volume files, sorted by short volume descending. Short % is the share of that day's FINRA-facility (off-exchange/TRF) volume sold short — 40-50% is a normal market-making baseline — NOT short interest (the open short position; use GetShortInterest/GetShortInterestSnapshot for positions and GetShortSqueezeScores for squeeze candidates; use GetShortVolume for one stock's daily history). Pass sortBy=shortPercent with a minTotalVolume floor to rank by short intensity instead of raw size."
+        "Get the exact listed securities, including ETFs, with the largest daily short sale volume for a single trading day (defaults to the latest available), from FINRA's daily short sale volume files, sorted by short volume descending. Short % is the share of that day's FINRA-facility (off-exchange/TRF) volume sold short — 40-50% is a normal market-making baseline — NOT short interest (the open short position; use GetShortInterest/GetShortInterestSnapshot for positions and GetShortSqueezeScores for operating-stock squeeze candidates; use GetShortVolume for one listed security's daily history). Pass sortBy=shortPercent with a minTotalVolume floor to rank by short intensity instead of raw size."
     )]
     public Task<string> GetLargestShortVolume(
         [Description("Trading day in YYYY-MM-DD format (defaults to the latest available day)")]
@@ -448,44 +476,56 @@ public class ShortDataTools
                     .Include(d => d.CommonStock)
                     .Where(d => d.TotalVolume > 0);
 
-                if (minShortVolume > 0)
-                {
-                    query = query.Where(d => d.ShortVolume >= minShortVolume);
-                }
-
-                if (minTotalVolume > 0)
-                {
-                    query = query.Where(d => d.TotalVolume >= minTotalVolume);
-                }
-
-                // Orderings end on the ticker so a re-call pages the same ranking even when
-                // rows tie on the sort key.
                 var sortKey = string.IsNullOrWhiteSpace(sortBy) ? "shortVolume" : sortBy.Trim();
-                IOrderedQueryable<DailyShortVolume> ordered;
-                if (sortKey.Equals("shortVolume", StringComparison.OrdinalIgnoreCase))
-                {
-                    ordered = query
-                        .OrderByDescending(d => d.ShortVolume)
-                        .ThenBy(d => d.CommonStock.Ticker);
-                }
-                else if (sortKey.Equals("shortPercent", StringComparison.OrdinalIgnoreCase))
-                {
-                    ordered = query
-                        .OrderByDescending(d => d.ShortVolume / d.TotalVolume)
-                        .ThenByDescending(d => d.ShortVolume)
-                        .ThenBy(d => d.CommonStock.Ticker);
-                }
-                else
+                if (!sortKey.Equals("shortVolume", StringComparison.OrdinalIgnoreCase)
+                    && !sortKey.Equals("shortPercent", StringComparison.OrdinalIgnoreCase))
                 {
                     return McpOutput.InvalidArgument("sortBy", sortBy, "shortVolume, shortPercent");
                 }
 
                 offset = McpLimit.ClampOffset(offset);
-                var total = await query.CountAsync();
-                var records = await ordered
+                var rawRecords = await query.ToListAsync();
+                var validListings = await _commonStockRepository.GetUniqueActiveListingKeys();
+                rawRecords = rawRecords.Where(row => validListings.Contains(
+                    new ListedSecurityKey(
+                        row.CommonStockId,
+                        ListingTicker(row.CommonStock, row.ListedTicker)
+                    )
+                )).ToList();
+                var stockIds = rawRecords.Select(row => row.CommonStockId).Distinct().ToList();
+                var splitRows = await _stockSplitRepository
+                    .GetEffective(DateOnly.FromDateTime(DateTime.UtcNow))
+                    .Where(split => stockIds.Contains(split.CommonStockId))
+                    .ToListAsync();
+                var adjusted = rawRecords.Select(row =>
+                {
+                    var listedTicker = ListingTicker(row.CommonStock, row.ListedTicker);
+                    var scoped = PriceSeriesSplitScope.ForListing(
+                        splitRows.Where(split => split.CommonStockId == row.CommonStockId),
+                        row.CommonStock.Ticker,
+                        listedTicker
+                    );
+                    var factor = SplitAdjustment.ShareCountFactor(row.Date, scoped);
+                    return new
+                    {
+                        Row = row,
+                        ListedTicker = listedTicker,
+                        Factor = factor,
+                        ShortVolume = SplitAdjustment.AdjustShareCount(row.ShortVolume, factor),
+                        TotalVolume = SplitAdjustment.AdjustShareCount(row.TotalVolume, factor),
+                    };
+                })
+                    .Where(row => row.ShortVolume >= minShortVolume && row.TotalVolume >= minTotalVolume);
+                adjusted = sortKey.Equals("shortPercent", StringComparison.OrdinalIgnoreCase)
+                    ? adjusted.OrderByDescending(row => row.Row.ShortVolume / row.Row.TotalVolume)
+                        .ThenByDescending(row => row.ShortVolume)
+                        .ThenBy(row => row.ListedTicker)
+                    : adjusted.OrderByDescending(row => row.ShortVolume).ThenBy(row => row.ListedTicker);
+                var total = adjusted.Count();
+                var records = adjusted
                     .Skip(offset)
                     .Take(McpLimit.Clamp(maxResults))
-                    .ToListAsync();
+                    .ToList();
                 if (records.Count == 0 && offset > 0)
                     return $"No results at offset {offset} - only {total} rows match; lower offset.";
 
@@ -502,7 +542,11 @@ public class ShortDataTools
                     "|--------|---------|-------------|--------------|-------------|---------|",
                     // The lead "cell" carries both the ticker and company columns — the shared
                     // renderer splices it in front of the volume cells verbatim.
-                    r => RenderShortVolumeRow($"{r.CommonStock.Ticker} | {r.CommonStock.Name}", r)
+                    r => RenderShortVolumeRow(
+                        $"{r.ListedTicker} | {ListingCompany(r.Row.CommonStock, r.ListedTicker)}",
+                        r.Row,
+                        r.Factor
+                    )
                 );
 
                 return AppendNote(
@@ -532,6 +576,15 @@ public class ShortDataTools
         var totalVolume = SplitAdjustment.AdjustShareCount(r.TotalVolume, shareFactor);
         return $"| {leadCell} | {McpFormat.WholeNumber(shortVolume)} | {McpFormat.WholeNumber(exemptVolume)} | {McpFormat.WholeNumber(totalVolume)} | {McpFormat.Invariant(shortPct, "F1")}% |";
     }
+
+    private static string ListingTicker(CommonStock stock, string listedTicker) =>
+        string.IsNullOrWhiteSpace(listedTicker) ? stock.Ticker : listedTicker;
+
+    private static string ListingCompany(CommonStock stock, string listedTicker) =>
+        SecondaryTickerPolicy.RequiresExactListingScope(
+            stock,
+            ListingTicker(stock, listedTicker)
+        ) ? "-" : stock.Name;
 
     // Render with InvariantCulture so the MCP markdown does not fork the separators by host
     // locale (e.g. de-DE would render 1.234.567 / 12,3). `shareFactor` restates the share
@@ -675,7 +728,7 @@ public class ShortDataTools
 
     [McpServerTool(Name = "GetShortSqueezeScores", Title = "Short Squeeze Scores", ReadOnly = true)]
     [Description(
-        "Rank stocks by a peer-relative 0-100 short-squeeze score using short interest, capped days to cover, price versus trailing VWAP, short-volume trend, short-interest change, fails-to-deliver pressure, and bounded price/volume/earnings catalyst boosts. Optional liquidity floors filter the board without changing scores. Pass ticker for one stock's factor breakdown and universe rank. Exchange-traded commodity and currency trusts are excluded; use GetShortInterest for the underlying FINRA series."
+        "Rank primary operating-company stocks by a peer-relative 0-100 short-squeeze score using short interest, capped days to cover, price versus trailing VWAP, short-volume trend, short-interest change, fails-to-deliver pressure, and bounded price/volume/earnings catalyst boosts. Optional liquidity floors filter the board without changing scores. Pass ticker for one stock's factor breakdown and universe rank. Exchange-traded products are excluded because issuer shares outstanding and earnings are not product-level facts; use GetShortInterest for an ETF's exact FINRA series."
     )]
     public Task<string> GetShortSqueezeScores(
         [Description(
@@ -709,7 +762,7 @@ public class ShortDataTools
                     var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                     if (stockError != null)
                         return stockError;
-                    var listingError = FinraTickerScope.SecondaryListingUnavailable(
+                    var listingError = FinraTickerScope.IssuerDerivedModelUnavailable(
                         stock,
                         ticker,
                         "short-squeeze score"

--- a/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
+++ b/src/Equibles.Finra.Mcp/Tools/ShortDataTools.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using System.Globalization;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.CorporateActions.Data;
@@ -192,10 +192,10 @@ public class ShortDataTools
                 if (rangeError != null)
                     return rangeError;
 
-                var history = _shortInterestRepository
-                    .GetHistoryByListing(stock, listedTicker);
-                var query = history
-                    .Where(s => s.SettlementDate >= start && s.SettlementDate <= end);
+                var history = _shortInterestRepository.GetHistoryByListing(stock, listedTicker);
+                var query = history.Where(s =>
+                    s.SettlementDate >= start && s.SettlementDate <= end
+                );
 
                 var total = await query.CountAsync();
 
@@ -332,9 +332,11 @@ public class ShortDataTools
                 }
 
                 var sortKey = string.IsNullOrWhiteSpace(sortBy) ? "daysToCover" : sortBy.Trim();
-                if (!sortKey.Equals("daysToCover", StringComparison.OrdinalIgnoreCase)
+                if (
+                    !sortKey.Equals("daysToCover", StringComparison.OrdinalIgnoreCase)
                     && !sortKey.Equals("shortPosition", StringComparison.OrdinalIgnoreCase)
-                    && !sortKey.Equals("change", StringComparison.OrdinalIgnoreCase))
+                    && !sortKey.Equals("change", StringComparison.OrdinalIgnoreCase)
+                )
                 {
                     return McpOutput.InvalidArgument(
                         "sortBy",
@@ -346,61 +348,78 @@ public class ShortDataTools
                 offset = McpLimit.ClampOffset(offset);
                 var rawRecords = await query.ToListAsync();
                 var validListings = await _commonStockRepository.GetUniqueActiveListingKeys();
-                rawRecords = rawRecords.Where(row => validListings.Contains(
-                    new ListedSecurityKey(
-                        row.CommonStockId,
-                        ListingTicker(row.CommonStock, row.ListedTicker)
+                rawRecords = rawRecords
+                    .Where(row =>
+                        validListings.Contains(
+                            new ListedSecurityKey(
+                                row.CommonStockId,
+                                ListingTicker(row.CommonStock, row.ListedTicker)
+                            )
+                        )
                     )
-                )).ToList();
+                    .ToList();
                 var stockIds = rawRecords.Select(row => row.CommonStockId).Distinct().ToList();
                 var splitRows = await _stockSplitRepository
                     .GetEffective(DateOnly.FromDateTime(DateTime.UtcNow))
                     .Where(split => stockIds.Contains(split.CommonStockId))
                     .ToListAsync();
-                var previousDate = await _shortInterestRepository.GetAllSettlementDates()
+                var previousDate = await _shortInterestRepository
+                    .GetAllSettlementDates()
                     .Where(day => day < latestDate)
                     .OrderByDescending(day => day)
                     .FirstOrDefaultAsync();
-                var adjusted = rawRecords.Select(row =>
-                {
-                    var listedTicker = ListingTicker(row.CommonStock, row.ListedTicker);
-                    var scoped = PriceSeriesSplitScope.ForListing(
-                        splitRows.Where(split => split.CommonStockId == row.CommonStockId),
-                        row.CommonStock.Ticker,
-                        listedTicker
-                    );
-                    var factor = SplitAdjustment.ShareCountFactor(latestDate, scoped);
-                    var previousFactor = SplitAdjustment.ShareCountFactor(previousDate, scoped);
-                    var position = SplitAdjustment.AdjustShareCount(row.CurrentShortPosition, factor);
-                    var previous = SplitAdjustment.AdjustShareCount(row.PreviousShortPosition, previousFactor);
-                    return new
+                var adjusted = rawRecords
+                    .Select(row =>
                     {
-                        Row = row,
-                        ListedTicker = listedTicker,
-                        Factor = factor,
-                        Position = position,
-                        Change = position - previous,
-                    };
-                }).Where(row => minAvgDailyVolume <= 0
-                    || SplitAdjustment.AdjustShareCount(
-                        row.Row.AverageDailyVolume.Value,
-                        row.Factor
-                    ) >= minAvgDailyVolume);
-                adjusted = sortKey.Equals("shortPosition", StringComparison.OrdinalIgnoreCase)
-                    ? adjusted.OrderByDescending(row => row.Position).ThenBy(row => row.ListedTicker)
+                        var listedTicker = ListingTicker(row.CommonStock, row.ListedTicker);
+                        var scoped = PriceSeriesSplitScope.ForListing(
+                            splitRows.Where(split => split.CommonStockId == row.CommonStockId),
+                            row.CommonStock.Ticker,
+                            listedTicker
+                        );
+                        var factor = SplitAdjustment.ShareCountFactor(latestDate, scoped);
+                        var previousFactor = SplitAdjustment.ShareCountFactor(previousDate, scoped);
+                        var position = SplitAdjustment.AdjustShareCount(
+                            row.CurrentShortPosition,
+                            factor
+                        );
+                        var previous = SplitAdjustment.AdjustShareCount(
+                            row.PreviousShortPosition,
+                            previousFactor
+                        );
+                        return new
+                        {
+                            Row = row,
+                            ListedTicker = listedTicker,
+                            Factor = factor,
+                            Position = position,
+                            Change = position - previous,
+                        };
+                    })
+                    .Where(row =>
+                        minAvgDailyVolume <= 0
+                        || SplitAdjustment.AdjustShareCount(
+                            row.Row.AverageDailyVolume.Value,
+                            row.Factor
+                        ) >= minAvgDailyVolume
+                    );
+                adjusted =
+                    sortKey.Equals("shortPosition", StringComparison.OrdinalIgnoreCase)
+                        ? adjusted
+                            .OrderByDescending(row => row.Position)
+                            .ThenBy(row => row.ListedTicker)
                     : sortKey.Equals("change", StringComparison.OrdinalIgnoreCase)
-                        ? adjusted.OrderByDescending(row => row.Change)
+                        ? adjusted
+                            .OrderByDescending(row => row.Change)
                             .ThenByDescending(row => row.Position)
                             .ThenBy(row => row.ListedTicker)
-                        : adjusted.OrderBy(row => row.Row.DaysToCover >= FinraDaysToCoverCap ? 1 : 0)
-                            .ThenByDescending(row => row.Row.DaysToCover)
-                            .ThenByDescending(row => row.Position)
-                            .ThenBy(row => row.ListedTicker);
+                    : adjusted
+                        .OrderBy(row => row.Row.DaysToCover >= FinraDaysToCoverCap ? 1 : 0)
+                        .ThenByDescending(row => row.Row.DaysToCover)
+                        .ThenByDescending(row => row.Position)
+                        .ThenBy(row => row.ListedTicker);
                 var total = adjusted.Count();
-                var records = adjusted
-                    .Skip(offset)
-                    .Take(McpLimit.Clamp(maxResults))
-                    .ToList();
+                var records = adjusted.Skip(offset).Take(McpLimit.Clamp(maxResults)).ToList();
                 if (records.Count == 0 && offset > 0)
                     return $"No results at offset {offset} - only {total} rows match; lower offset.";
 
@@ -477,8 +496,10 @@ public class ShortDataTools
                     .Where(d => d.TotalVolume > 0);
 
                 var sortKey = string.IsNullOrWhiteSpace(sortBy) ? "shortVolume" : sortBy.Trim();
-                if (!sortKey.Equals("shortVolume", StringComparison.OrdinalIgnoreCase)
-                    && !sortKey.Equals("shortPercent", StringComparison.OrdinalIgnoreCase))
+                if (
+                    !sortKey.Equals("shortVolume", StringComparison.OrdinalIgnoreCase)
+                    && !sortKey.Equals("shortPercent", StringComparison.OrdinalIgnoreCase)
+                )
                 {
                     return McpOutput.InvalidArgument("sortBy", sortBy, "shortVolume, shortPercent");
                 }
@@ -486,46 +507,53 @@ public class ShortDataTools
                 offset = McpLimit.ClampOffset(offset);
                 var rawRecords = await query.ToListAsync();
                 var validListings = await _commonStockRepository.GetUniqueActiveListingKeys();
-                rawRecords = rawRecords.Where(row => validListings.Contains(
-                    new ListedSecurityKey(
-                        row.CommonStockId,
-                        ListingTicker(row.CommonStock, row.ListedTicker)
+                rawRecords = rawRecords
+                    .Where(row =>
+                        validListings.Contains(
+                            new ListedSecurityKey(
+                                row.CommonStockId,
+                                ListingTicker(row.CommonStock, row.ListedTicker)
+                            )
+                        )
                     )
-                )).ToList();
+                    .ToList();
                 var stockIds = rawRecords.Select(row => row.CommonStockId).Distinct().ToList();
                 var splitRows = await _stockSplitRepository
                     .GetEffective(DateOnly.FromDateTime(DateTime.UtcNow))
                     .Where(split => stockIds.Contains(split.CommonStockId))
                     .ToListAsync();
-                var adjusted = rawRecords.Select(row =>
-                {
-                    var listedTicker = ListingTicker(row.CommonStock, row.ListedTicker);
-                    var scoped = PriceSeriesSplitScope.ForListing(
-                        splitRows.Where(split => split.CommonStockId == row.CommonStockId),
-                        row.CommonStock.Ticker,
-                        listedTicker
-                    );
-                    var factor = SplitAdjustment.ShareCountFactor(row.Date, scoped);
-                    return new
+                var adjusted = rawRecords
+                    .Select(row =>
                     {
-                        Row = row,
-                        ListedTicker = listedTicker,
-                        Factor = factor,
-                        ShortVolume = SplitAdjustment.AdjustShareCount(row.ShortVolume, factor),
-                        TotalVolume = SplitAdjustment.AdjustShareCount(row.TotalVolume, factor),
-                    };
-                })
-                    .Where(row => row.ShortVolume >= minShortVolume && row.TotalVolume >= minTotalVolume);
+                        var listedTicker = ListingTicker(row.CommonStock, row.ListedTicker);
+                        var scoped = PriceSeriesSplitScope.ForListing(
+                            splitRows.Where(split => split.CommonStockId == row.CommonStockId),
+                            row.CommonStock.Ticker,
+                            listedTicker
+                        );
+                        var factor = SplitAdjustment.ShareCountFactor(row.Date, scoped);
+                        return new
+                        {
+                            Row = row,
+                            ListedTicker = listedTicker,
+                            Factor = factor,
+                            ShortVolume = SplitAdjustment.AdjustShareCount(row.ShortVolume, factor),
+                            TotalVolume = SplitAdjustment.AdjustShareCount(row.TotalVolume, factor),
+                        };
+                    })
+                    .Where(row =>
+                        row.ShortVolume >= minShortVolume && row.TotalVolume >= minTotalVolume
+                    );
                 adjusted = sortKey.Equals("shortPercent", StringComparison.OrdinalIgnoreCase)
-                    ? adjusted.OrderByDescending(row => row.Row.ShortVolume / row.Row.TotalVolume)
+                    ? adjusted
+                        .OrderByDescending(row => row.Row.ShortVolume / row.Row.TotalVolume)
                         .ThenByDescending(row => row.ShortVolume)
                         .ThenBy(row => row.ListedTicker)
-                    : adjusted.OrderByDescending(row => row.ShortVolume).ThenBy(row => row.ListedTicker);
+                    : adjusted
+                        .OrderByDescending(row => row.ShortVolume)
+                        .ThenBy(row => row.ListedTicker);
                 var total = adjusted.Count();
-                var records = adjusted
-                    .Skip(offset)
-                    .Take(McpLimit.Clamp(maxResults))
-                    .ToList();
+                var records = adjusted.Skip(offset).Take(McpLimit.Clamp(maxResults)).ToList();
                 if (records.Count == 0 && offset > 0)
                     return $"No results at offset {offset} - only {total} rows match; lower offset.";
 
@@ -542,11 +570,12 @@ public class ShortDataTools
                     "|--------|---------|-------------|--------------|-------------|---------|",
                     // The lead "cell" carries both the ticker and company columns — the shared
                     // renderer splices it in front of the volume cells verbatim.
-                    r => RenderShortVolumeRow(
-                        $"{r.ListedTicker} | {ListingCompany(r.Row.CommonStock, r.ListedTicker)}",
-                        r.Row,
-                        r.Factor
-                    )
+                    r =>
+                        RenderShortVolumeRow(
+                            $"{r.ListedTicker} | {ListingCompany(r.Row.CommonStock, r.ListedTicker)}",
+                            r.Row,
+                            r.Factor
+                        )
                 );
 
                 return AppendNote(
@@ -581,10 +610,9 @@ public class ShortDataTools
         string.IsNullOrWhiteSpace(listedTicker) ? stock.Ticker : listedTicker;
 
     private static string ListingCompany(CommonStock stock, string listedTicker) =>
-        SecondaryTickerPolicy.RequiresExactListingScope(
-            stock,
-            ListingTicker(stock, listedTicker)
-        ) ? "-" : stock.Name;
+        SecondaryTickerPolicy.RequiresExactListingScope(stock, ListingTicker(stock, listedTicker))
+            ? "-"
+            : stock.Name;
 
     // Render with InvariantCulture so the MCP markdown does not fork the separators by host
     // locale (e.g. de-DE would render 1.234.567 / 12,3). `shareFactor` restates the share

--- a/src/Equibles.Finra.Repositories/DailyShortVolumeRepository.cs
+++ b/src/Equibles.Finra.Repositories/DailyShortVolumeRepository.cs
@@ -12,11 +12,12 @@ public class DailyShortVolumeRepository : BaseRepository<DailyShortVolume>
 
     public IQueryable<DailyShortVolume> GetByStock(CommonStock stock, DateOnly date)
     {
-        return GetAll().Where(d =>
-            d.CommonStockId == stock.Id
-            && (d.ListedTicker == stock.Ticker || d.ListedTicker == "")
-            && d.Date == date
-        );
+        return GetAll()
+            .Where(d =>
+                d.CommonStockId == stock.Id
+                && (d.ListedTicker == stock.Ticker || d.ListedTicker == "")
+                && d.Date == date
+            );
     }
 
     public IQueryable<DailyShortVolume> GetByListing(
@@ -25,29 +26,40 @@ public class DailyShortVolumeRepository : BaseRepository<DailyShortVolume>
         DateOnly date
     )
     {
-        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
-        return GetAll().Where(d =>
-            d.CommonStockId == stock.Id
-            && (d.ListedTicker == listedTicker || (isPrimary && d.ListedTicker == ""))
-            && d.Date == date
+        var isPrimary = string.Equals(
+            listedTicker,
+            stock.Ticker,
+            StringComparison.OrdinalIgnoreCase
         );
+        return GetAll()
+            .Where(d =>
+                d.CommonStockId == stock.Id
+                && (d.ListedTicker == listedTicker || (isPrimary && d.ListedTicker == ""))
+                && d.Date == date
+            );
     }
 
     public IQueryable<DailyShortVolume> GetHistoryByStock(CommonStock stock)
     {
-        return GetAll().Where(d =>
-            d.CommonStockId == stock.Id
-            && (d.ListedTicker == stock.Ticker || d.ListedTicker == "")
-        );
+        return GetAll()
+            .Where(d =>
+                d.CommonStockId == stock.Id
+                && (d.ListedTicker == stock.Ticker || d.ListedTicker == "")
+            );
     }
 
     public IQueryable<DailyShortVolume> GetHistoryByListing(CommonStock stock, string listedTicker)
     {
-        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
-        return GetAll().Where(d =>
-            d.CommonStockId == stock.Id
-            && (d.ListedTicker == listedTicker || (isPrimary && d.ListedTicker == ""))
+        var isPrimary = string.Equals(
+            listedTicker,
+            stock.Ticker,
+            StringComparison.OrdinalIgnoreCase
         );
+        return GetAll()
+            .Where(d =>
+                d.CommonStockId == stock.Id
+                && (d.ListedTicker == listedTicker || (isPrimary && d.ListedTicker == ""))
+            );
     }
 
     public IQueryable<DateOnly> GetLatestDate()

--- a/src/Equibles.Finra.Repositories/DailyShortVolumeRepository.cs
+++ b/src/Equibles.Finra.Repositories/DailyShortVolumeRepository.cs
@@ -12,12 +12,42 @@ public class DailyShortVolumeRepository : BaseRepository<DailyShortVolume>
 
     public IQueryable<DailyShortVolume> GetByStock(CommonStock stock, DateOnly date)
     {
-        return GetAll().Where(d => d.CommonStockId == stock.Id && d.Date == date);
+        return GetAll().Where(d =>
+            d.CommonStockId == stock.Id
+            && (d.ListedTicker == stock.Ticker || d.ListedTicker == "")
+            && d.Date == date
+        );
+    }
+
+    public IQueryable<DailyShortVolume> GetByListing(
+        CommonStock stock,
+        string listedTicker,
+        DateOnly date
+    )
+    {
+        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
+        return GetAll().Where(d =>
+            d.CommonStockId == stock.Id
+            && (d.ListedTicker == listedTicker || (isPrimary && d.ListedTicker == ""))
+            && d.Date == date
+        );
     }
 
     public IQueryable<DailyShortVolume> GetHistoryByStock(CommonStock stock)
     {
-        return GetAll().Where(d => d.CommonStockId == stock.Id);
+        return GetAll().Where(d =>
+            d.CommonStockId == stock.Id
+            && (d.ListedTicker == stock.Ticker || d.ListedTicker == "")
+        );
+    }
+
+    public IQueryable<DailyShortVolume> GetHistoryByListing(CommonStock stock, string listedTicker)
+    {
+        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
+        return GetAll().Where(d =>
+            d.CommonStockId == stock.Id
+            && (d.ListedTicker == listedTicker || (isPrimary && d.ListedTicker == ""))
+        );
     }
 
     public IQueryable<DateOnly> GetLatestDate()

--- a/src/Equibles.Finra.Repositories/OffExchangeVolumeRepository.cs
+++ b/src/Equibles.Finra.Repositories/OffExchangeVolumeRepository.cs
@@ -12,12 +12,42 @@ public class OffExchangeVolumeRepository : BaseRepository<OffExchangeVolume>
 
     public IQueryable<OffExchangeVolume> GetByStock(CommonStock stock, DateOnly weekStartDate)
     {
-        return GetAll().Where(d => d.CommonStockId == stock.Id && d.WeekStartDate == weekStartDate);
+        return GetAll().Where(d =>
+            d.CommonStockId == stock.Id
+            && (d.ListedTicker == stock.Ticker || d.ListedTicker == "")
+            && d.WeekStartDate == weekStartDate
+        );
+    }
+
+    public IQueryable<OffExchangeVolume> GetByListing(
+        CommonStock stock,
+        string listedTicker,
+        DateOnly weekStartDate
+    )
+    {
+        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
+        return GetAll().Where(d =>
+            d.CommonStockId == stock.Id
+            && (d.ListedTicker == listedTicker || (isPrimary && d.ListedTicker == ""))
+            && d.WeekStartDate == weekStartDate
+        );
     }
 
     public IQueryable<OffExchangeVolume> GetHistoryByStock(CommonStock stock)
     {
-        return GetAll().Where(d => d.CommonStockId == stock.Id);
+        return GetAll().Where(d =>
+            d.CommonStockId == stock.Id
+            && (d.ListedTicker == stock.Ticker || d.ListedTicker == "")
+        );
+    }
+
+    public IQueryable<OffExchangeVolume> GetHistoryByListing(CommonStock stock, string listedTicker)
+    {
+        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
+        return GetAll().Where(d =>
+            d.CommonStockId == stock.Id
+            && (d.ListedTicker == listedTicker || (isPrimary && d.ListedTicker == ""))
+        );
     }
 
     public IQueryable<DateOnly> GetLatestWeek()

--- a/src/Equibles.Finra.Repositories/OffExchangeVolumeRepository.cs
+++ b/src/Equibles.Finra.Repositories/OffExchangeVolumeRepository.cs
@@ -12,11 +12,12 @@ public class OffExchangeVolumeRepository : BaseRepository<OffExchangeVolume>
 
     public IQueryable<OffExchangeVolume> GetByStock(CommonStock stock, DateOnly weekStartDate)
     {
-        return GetAll().Where(d =>
-            d.CommonStockId == stock.Id
-            && (d.ListedTicker == stock.Ticker || d.ListedTicker == "")
-            && d.WeekStartDate == weekStartDate
-        );
+        return GetAll()
+            .Where(d =>
+                d.CommonStockId == stock.Id
+                && (d.ListedTicker == stock.Ticker || d.ListedTicker == "")
+                && d.WeekStartDate == weekStartDate
+            );
     }
 
     public IQueryable<OffExchangeVolume> GetByListing(
@@ -25,29 +26,40 @@ public class OffExchangeVolumeRepository : BaseRepository<OffExchangeVolume>
         DateOnly weekStartDate
     )
     {
-        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
-        return GetAll().Where(d =>
-            d.CommonStockId == stock.Id
-            && (d.ListedTicker == listedTicker || (isPrimary && d.ListedTicker == ""))
-            && d.WeekStartDate == weekStartDate
+        var isPrimary = string.Equals(
+            listedTicker,
+            stock.Ticker,
+            StringComparison.OrdinalIgnoreCase
         );
+        return GetAll()
+            .Where(d =>
+                d.CommonStockId == stock.Id
+                && (d.ListedTicker == listedTicker || (isPrimary && d.ListedTicker == ""))
+                && d.WeekStartDate == weekStartDate
+            );
     }
 
     public IQueryable<OffExchangeVolume> GetHistoryByStock(CommonStock stock)
     {
-        return GetAll().Where(d =>
-            d.CommonStockId == stock.Id
-            && (d.ListedTicker == stock.Ticker || d.ListedTicker == "")
-        );
+        return GetAll()
+            .Where(d =>
+                d.CommonStockId == stock.Id
+                && (d.ListedTicker == stock.Ticker || d.ListedTicker == "")
+            );
     }
 
     public IQueryable<OffExchangeVolume> GetHistoryByListing(CommonStock stock, string listedTicker)
     {
-        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
-        return GetAll().Where(d =>
-            d.CommonStockId == stock.Id
-            && (d.ListedTicker == listedTicker || (isPrimary && d.ListedTicker == ""))
+        var isPrimary = string.Equals(
+            listedTicker,
+            stock.Ticker,
+            StringComparison.OrdinalIgnoreCase
         );
+        return GetAll()
+            .Where(d =>
+                d.CommonStockId == stock.Id
+                && (d.ListedTicker == listedTicker || (isPrimary && d.ListedTicker == ""))
+            );
     }
 
     public IQueryable<DateOnly> GetLatestWeek()

--- a/src/Equibles.Finra.Repositories/ShortInterestRepository.cs
+++ b/src/Equibles.Finra.Repositories/ShortInterestRepository.cs
@@ -27,29 +27,40 @@ public class ShortInterestRepository : BaseRepository<ShortInterest>
         DateOnly settlementDate
     )
     {
-        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
-        return GetAll().Where(s =>
-            s.CommonStockId == stock.Id
-            && (s.ListedTicker == listedTicker || (isPrimary && s.ListedTicker == ""))
-            && s.SettlementDate == settlementDate
+        var isPrimary = string.Equals(
+            listedTicker,
+            stock.Ticker,
+            StringComparison.OrdinalIgnoreCase
         );
+        return GetAll()
+            .Where(s =>
+                s.CommonStockId == stock.Id
+                && (s.ListedTicker == listedTicker || (isPrimary && s.ListedTicker == ""))
+                && s.SettlementDate == settlementDate
+            );
     }
 
     public IQueryable<ShortInterest> GetHistoryByStock(CommonStock stock)
     {
-        return GetAll().Where(s =>
-            s.CommonStockId == stock.Id
-            && (s.ListedTicker == stock.Ticker || s.ListedTicker == "")
-        );
+        return GetAll()
+            .Where(s =>
+                s.CommonStockId == stock.Id
+                && (s.ListedTicker == stock.Ticker || s.ListedTicker == "")
+            );
     }
 
     public IQueryable<ShortInterest> GetHistoryByListing(CommonStock stock, string listedTicker)
     {
-        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
-        return GetAll().Where(s =>
-            s.CommonStockId == stock.Id
-            && (s.ListedTicker == listedTicker || (isPrimary && s.ListedTicker == ""))
+        var isPrimary = string.Equals(
+            listedTicker,
+            stock.Ticker,
+            StringComparison.OrdinalIgnoreCase
         );
+        return GetAll()
+            .Where(s =>
+                s.CommonStockId == stock.Id
+                && (s.ListedTicker == listedTicker || (isPrimary && s.ListedTicker == ""))
+            );
     }
 
     public IQueryable<DateOnly> GetLatestSettlementDate()
@@ -107,6 +118,7 @@ public class ShortInterestRepository : BaseRepository<ShortInterest>
     {
         return GetAll().Where(s => s.SettlementDate == settlementDate).Select(s => s.CommonStockId);
     }
+
     public IQueryable<ListedSecurityKey> GetListingKeysBySettlementDate(DateOnly settlementDate) =>
         GetAll()
             .Where(s => s.SettlementDate == settlementDate)

--- a/src/Equibles.Finra.Repositories/ShortInterestRepository.cs
+++ b/src/Equibles.Finra.Repositories/ShortInterestRepository.cs
@@ -14,12 +14,42 @@ public class ShortInterestRepository : BaseRepository<ShortInterest>
     public IQueryable<ShortInterest> GetByStock(CommonStock stock, DateOnly settlementDate)
     {
         return GetAll()
-            .Where(s => s.CommonStockId == stock.Id && s.SettlementDate == settlementDate);
+            .Where(s =>
+                s.CommonStockId == stock.Id
+                && (s.ListedTicker == stock.Ticker || s.ListedTicker == "")
+                && s.SettlementDate == settlementDate
+            );
+    }
+
+    public IQueryable<ShortInterest> GetByListing(
+        CommonStock stock,
+        string listedTicker,
+        DateOnly settlementDate
+    )
+    {
+        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
+        return GetAll().Where(s =>
+            s.CommonStockId == stock.Id
+            && (s.ListedTicker == listedTicker || (isPrimary && s.ListedTicker == ""))
+            && s.SettlementDate == settlementDate
+        );
     }
 
     public IQueryable<ShortInterest> GetHistoryByStock(CommonStock stock)
     {
-        return GetAll().Where(s => s.CommonStockId == stock.Id);
+        return GetAll().Where(s =>
+            s.CommonStockId == stock.Id
+            && (s.ListedTicker == stock.Ticker || s.ListedTicker == "")
+        );
+    }
+
+    public IQueryable<ShortInterest> GetHistoryByListing(CommonStock stock, string listedTicker)
+    {
+        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
+        return GetAll().Where(s =>
+            s.CommonStockId == stock.Id
+            && (s.ListedTicker == listedTicker || (isPrimary && s.ListedTicker == ""))
+        );
     }
 
     public IQueryable<DateOnly> GetLatestSettlementDate()
@@ -77,4 +107,8 @@ public class ShortInterestRepository : BaseRepository<ShortInterest>
     {
         return GetAll().Where(s => s.SettlementDate == settlementDate).Select(s => s.CommonStockId);
     }
+    public IQueryable<ListedSecurityKey> GetListingKeysBySettlementDate(DateOnly settlementDate) =>
+        GetAll()
+            .Where(s => s.SettlementDate == settlementDate)
+            .Select(s => new ListedSecurityKey(s.CommonStockId, s.ListedTicker));
 }

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Numerics;
 using System.Text;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.CorporateActions.Data;
@@ -103,10 +104,10 @@ public class InstitutionalHoldingsTools
 
     [McpServerTool(Name = "GetTopHolders", Title = "Top Institutional Holders", ReadOnly = true)]
     [Description(
-        "Get the top institutional holders (fund managers) of a stock from SEC 13F-HR filings. Returns a ranked list by shares held, including published position value and percentage of total institutional 13F shares (not of shares outstanding). Values normally use report-date closing prices, may fall back to filer values, and can be zero when unavailable. Data is sourced from quarterly 13F filings; while the newest quarter's filing window is open, funds that have not filed yet are carried at their prior-quarter positions (noted in the output). Use position type before treating put/call rows as ownership."
+        "Get the top institutional holders (fund managers) of an exact stock or ETF listing from SEC 13F-HR filings. Returns a ranked list by shares held, including published position value and percentage of total institutional 13F shares (not of shares outstanding). Values normally use report-date closing prices, may fall back to filer values, and can be zero when unavailable. During the newest quarter's filing window, non-ETF primary stocks carry non-filers' prior-quarter positions; ETF listings remain exact and as-filed because carry-forward is filer-wide. Use position type before treating put/call rows as ownership."
     )]
     public Task<string> GetTopHolders(
-        [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Listed security ticker (e.g., AAPL, VOO)")] string ticker,
         [Description(
             "Quarter-end 13F report date in YYYY-MM-DD format, e.g. 2026-03-31 (defaults to the latest available; an off-quarter date snaps to the nearest report on or before it)"
         )]
@@ -124,9 +125,18 @@ public class InstitutionalHoldingsTools
                 if (stockError != null)
                     return stockError;
 
-                var reportDates = await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(
-                    stock
+                var listedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, ticker);
+                var exactListingScope = SecondaryTickerPolicy.RequiresExactListingScope(
+                    stock,
+                    listedTicker
                 );
+
+                var reportDates = exactListingScope
+                    ? await _holdingRepository.Get13FReportDatesByListingSnapshotBacked(
+                        stock,
+                        listedTicker
+                    )
+                    : await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(stock);
                 if (reportDates.Count == 0)
                     return $"No institutional holdings data available for {ticker}.";
 
@@ -137,10 +147,16 @@ public class InstitutionalHoldingsTools
                 if (dateError != null)
                     return dateError;
 
-                // While the newest quarter's filing window is open it only holds the early
-                // filers, so it is presented as the combined view (carry-forward for funds
-                // yet to file) — the same rule every web surface applies.
-                var anchor = await _combinedQuarterService.Resolve(stock);
+                // Combined carry-forward is filer-wide. It can stabilize an operating company's
+                // primary stock but would merge sibling ETF series, so ETFs stay exact/as-filed.
+                var isPrimaryListing = string.Equals(
+                    listedTicker,
+                    stock.Ticker,
+                    StringComparison.OrdinalIgnoreCase
+                );
+                var anchor = isPrimaryListing && !exactListingScope
+                    ? await _combinedQuarterService.Resolve(stock)
+                    : null;
                 var presentCombined =
                     anchor is { IsCombined: true } && targetDate == anchor.ReportDate;
                 var allHoldings = presentCombined
@@ -149,7 +165,13 @@ public class InstitutionalHoldingsTools
                         anchor.ReportDate,
                         RequirePreviousReportDate(anchor)
                     )
-                    : _holdingRepository.Get13FByStockWithHolder(stock, targetDate);
+                    : exactListingScope
+                        ? _holdingRepository.Get13FByListingWithHolder(
+                            stock,
+                            listedTicker,
+                            targetDate
+                        )
+                        : _holdingRepository.Get13FByStockWithHolder(stock, targetDate);
                 // Materialise one compact projection. Exact-listing split factors can change
                 // both rank and denominator, so a separate raw aggregate/page query would scan
                 // the combined-quarter view twice and could rank a sibling class incorrectly.
@@ -289,6 +311,11 @@ public class InstitutionalHoldingsTools
         );
     }
 
+    private static string StockListingLabel(CommonStock stock, string ticker) =>
+        SecondaryTickerPolicy.RequiresExactListingScope(stock, ticker)
+            ? ticker
+            : $"{stock.Name} ({ticker})";
+
     private static string RenderAdjustedTopHoldersTable(
         CommonStock stock,
         string ticker,
@@ -311,7 +338,7 @@ public class InstitutionalHoldingsTools
         if (combinedNote != null)
             subtitle = $"{subtitle}\n{combinedNote}";
         var result = MarkdownTable.Start(
-            $"Top institutional holders of {stock.Name} ({ticker}) as of {FormatDate(targetDate)}:",
+            $"Top institutional holders of {StockListingLabel(stock, ticker)} as of {FormatDate(targetDate)}:",
             subtitle,
             "| # | Institution | Type | Shares | Value ($M) | % of Inst. Total |",
             "|---|------------|------|--------|-----------|-----------|"
@@ -375,10 +402,10 @@ public class InstitutionalHoldingsTools
         ReadOnly = true
     )]
     [Description(
-        "Get the historical trend of aggregate reported 13F exposure for a stock across multiple quarters. The legacy Total Shares field sums reported quantities across common-share rows, put/call notional-underlying rows, and any tracked principal-denominated rows, so it is not a pure share-ownership measure. Shows how total reported quantity, published position value, and filer count changed. Values normally use report-date closing prices, may fall back to filer values, and can include zero when unavailable. While the newest quarter's filing window is open, that quarter is a provisional combined view (funds that have not filed yet carry their prior-quarter positions — flagged in the output)."
+        "Get the historical trend of aggregate reported 13F exposure for an exact stock or ETF listing across multiple quarters. The legacy Total Shares field sums reported quantities across common-share rows, put/call notional-underlying rows, and any tracked principal-denominated rows, so it is not a pure share-ownership measure. Shows how total reported quantity, published position value, and filer count changed. Values normally use report-date closing prices, may fall back to filer values, and can include zero when unavailable. While the newest quarter's filing window is open, non-ETF primary stocks use a provisional combined view; ETF listings remain exact and as-filed because carry-forward is filer-wide."
     )]
     public Task<string> GetInstitutionalOwnershipHistory(
-        [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Listed security ticker (e.g., AAPL, VOO)")] string ticker,
         [Description(
             "Maximum number of quarterly periods to return (default: 8, clamped to 1-500)"
         )]
@@ -392,12 +419,26 @@ public class InstitutionalHoldingsTools
                 if (stockError != null)
                     return stockError;
 
-                var activity =
-                    await _holdingRepository.GetStockActivitySnapshotsByStockSnapshotBacked(stock);
+                var listedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, ticker);
+                var exactListingScope = SecondaryTickerPolicy.RequiresExactListingScope(
+                    stock,
+                    listedTicker
+                );
+
+                var activity = exactListingScope
+                    ? await _holdingRepository.GetListingActivityHistory(stock, listedTicker)
+                    : await _holdingRepository.GetStockActivitySnapshotsByStockSnapshotBacked(stock);
                 if (activity.All(row => row.CurrentFilerCount <= 0))
                     return $"No institutional holdings history available for {ticker}.";
 
-                var anchor = await _combinedQuarterService.Resolve(stock);
+                var isPrimaryListing = string.Equals(
+                    listedTicker,
+                    stock.Ticker,
+                    StringComparison.OrdinalIgnoreCase
+                );
+                var anchor = isPrimaryListing && !exactListingScope
+                    ? await _combinedQuarterService.Resolve(stock)
+                    : null;
                 if (anchor is { IsCombined: true })
                 {
                     var combined = await _holdingRepository.GetCombinedStockActivitySnapshotBacked(
@@ -441,7 +482,7 @@ public class InstitutionalHoldingsTools
     )
     {
         var result = MarkdownTable.Start(
-            $"Institutional ownership history for {stock.Name} ({ticker}):",
+            $"Institutional ownership history for {StockListingLabel(stock, ticker)}:",
             "| Report Date | Institutions | Total Shares | Total Value ($M) | Share Chg (QoQ) |",
             "|------------|-------------|-------------|-----------------|--------|"
         );
@@ -698,14 +739,19 @@ public class InstitutionalHoldingsTools
             holdings,
             (rank, h) =>
             {
+                // The exact listing held: a GOOG position must not render as GOOGL, and a
+                // sibling ETF split must not rescale this row.
+                var listedTicker = h.ListedTicker ?? h.CommonStock.Ticker;
                 var shares = SplitAdjustment.AdjustShareCount(
                     h.Shares,
                     targetDate,
-                    SplitsFor(splitsByStock, h.CommonStockId)
+                    PriceSeriesSplitScope.ForListing(
+                        SplitsFor(splitsByStock, h.CommonStockId),
+                        h.CommonStock.Ticker,
+                        listedTicker
+                    )
                 );
                 var pct = Percentage.Of(h.Value, totalValue);
-                // The exact listing held: a GOOG position must not render as GOOGL.
-                var listedTicker = h.ListedTicker ?? h.CommonStock.Ticker;
                 // Rank is the ABSOLUTE position in the value-ranked rows, so page two
                 // continues 21, 22, … instead of restarting at 1.
                 return $"| {offset + rank} | {listedTicker} | {h.CommonStock.Name} | "
@@ -831,7 +877,7 @@ public class InstitutionalHoldingsTools
         "Get the institutions that moved the needle the most on a stock this quarter — biggest absolute share additions (Top Buyers) and biggest absolute share reductions (Top Sellers) versus the previous 13F report date. Includes new positions (Δ = full position) and sold-out positions (Δ = −prior position); a previous holder counts as a seller only if it filed a 13F for the target quarter, so a fund that stopped filing (CIK migration, deregistration) is not shown as a mass seller. While the newest quarter's filing window is open, results cover only the funds that have already filed (noted in the output). Returns a markdown table with two sections. Use this to surface the most actionable quarterly signal from 13F filings."
     )]
     public Task<string> GetTopInstitutionalBuyersSellers(
-        [Description("Company ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Listed security ticker (e.g., AAPL, VOO)")] string ticker,
         [Description(
             "Quarter-end 13F report date in YYYY-MM-DD format, e.g. 2026-03-31 (defaults to the latest available; an off-quarter date snaps to the nearest report on or before it)"
         )]
@@ -851,9 +897,18 @@ public class InstitutionalHoldingsTools
                 if (stockError != null)
                     return stockError;
 
-                var reportDates = await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(
-                    stock
+                var listedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, ticker);
+                var exactListingScope = SecondaryTickerPolicy.RequiresExactListingScope(
+                    stock,
+                    listedTicker
                 );
+
+                var reportDates = exactListingScope
+                    ? await _holdingRepository.Get13FReportDatesByListingSnapshotBacked(
+                        stock,
+                        listedTicker
+                    )
+                    : await _holdingRepository.Get13FReportDatesByStockSnapshotBacked(stock);
                 if (reportDates.Count == 0)
                     return $"No institutional holdings data available for {ticker}.";
 
@@ -865,8 +920,18 @@ public class InstitutionalHoldingsTools
                     return dateError;
 
                 var previousDate = GetPriorReportDate(reportDates, targetDate);
-                var activity = await _holdingRepository
-                    .Get13FHolderActivityByStock(stock, targetDate, previousDate)
+                var activity = await (exactListingScope
+                        ? _holdingRepository.Get13FHolderActivityByListing(
+                            stock,
+                            listedTicker,
+                            targetDate,
+                            previousDate
+                        )
+                        : _holdingRepository.Get13FHolderActivityByStock(
+                            stock,
+                            targetDate,
+                            previousDate
+                        ))
                     .ToListAsync();
 
                 // A previous holder with no current row only PROVES an exit when it filed a
@@ -954,7 +1019,7 @@ public class InstitutionalHoldingsTools
                     .ToList();
 
                 if (topBuyers.Count == 0 && topSellers.Count == 0)
-                    return $"No quarter-over-quarter movement found for {stock.Name} ({ticker}) as of {FormatDate(targetDate)}.";
+                    return $"No quarter-over-quarter movement found for {StockListingLabel(stock, ticker)} as of {FormatDate(targetDate)}.";
 
                 var topHolderIds = topBuyers
                     .Select(m => m.Id)
@@ -1062,7 +1127,7 @@ public class InstitutionalHoldingsTools
     {
         var result = new StringBuilder();
         result.AppendLine(
-            $"Top buyers and sellers of {stock.Name} ({ticker}) as of {FormatDate(targetDate)}"
+            $"Top buyers and sellers of {StockListingLabel(stock, ticker)} as of {FormatDate(targetDate)}"
         );
         if (previousDate.HasValue)
             result.AppendLine(PriorQuarterSubtitle(previousDate.Value));
@@ -2503,7 +2568,14 @@ public class InstitutionalHoldingsTools
         {
             foreach (var r in rows)
             {
-                var splits = SplitsFor(splitsByStock, r.CommonStockId);
+                var loadedSplits = SplitsFor(splitsByStock, r.CommonStockId);
+                var splits = string.IsNullOrWhiteSpace(r.PrimaryTicker)
+                    ? loadedSplits
+                    : PriceSeriesSplitScope.ForListing(
+                        loadedSplits,
+                        r.PrimaryTicker,
+                        r.ListedTicker ?? r.PrimaryTicker
+                    );
                 r.CurrentShares = SplitAdjustment.AdjustShareCount(
                     r.CurrentShares,
                     currentDate,

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -2,8 +2,8 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Numerics;
 using System.Text;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.CorporateActions.Data;
@@ -154,24 +154,26 @@ public class InstitutionalHoldingsTools
                     stock.Ticker,
                     StringComparison.OrdinalIgnoreCase
                 );
-                var anchor = isPrimaryListing && !exactListingScope
-                    ? await _combinedQuarterService.Resolve(stock)
-                    : null;
+                var anchor =
+                    isPrimaryListing && !exactListingScope
+                        ? await _combinedQuarterService.Resolve(stock)
+                        : null;
                 var presentCombined =
                     anchor is { IsCombined: true } && targetDate == anchor.ReportDate;
-                var allHoldings = presentCombined
-                    ? _holdingRepository.GetCombinedQuarterByStockWithHolder(
-                        stock,
-                        anchor.ReportDate,
-                        RequirePreviousReportDate(anchor)
-                    )
+                var allHoldings =
+                    presentCombined
+                        ? _holdingRepository.GetCombinedQuarterByStockWithHolder(
+                            stock,
+                            anchor.ReportDate,
+                            RequirePreviousReportDate(anchor)
+                        )
                     : exactListingScope
                         ? _holdingRepository.Get13FByListingWithHolder(
                             stock,
                             listedTicker,
                             targetDate
                         )
-                        : _holdingRepository.Get13FByStockWithHolder(stock, targetDate);
+                    : _holdingRepository.Get13FByStockWithHolder(stock, targetDate);
                 // Materialise one compact projection. Exact-listing split factors can change
                 // both rank and denominator, so a separate raw aggregate/page query would scan
                 // the combined-quarter view twice and could rank a sibling class incorrectly.
@@ -427,7 +429,9 @@ public class InstitutionalHoldingsTools
 
                 var activity = exactListingScope
                     ? await _holdingRepository.GetListingActivityHistory(stock, listedTicker)
-                    : await _holdingRepository.GetStockActivitySnapshotsByStockSnapshotBacked(stock);
+                    : await _holdingRepository.GetStockActivitySnapshotsByStockSnapshotBacked(
+                        stock
+                    );
                 if (activity.All(row => row.CurrentFilerCount <= 0))
                     return $"No institutional holdings history available for {ticker}.";
 
@@ -436,9 +440,10 @@ public class InstitutionalHoldingsTools
                     stock.Ticker,
                     StringComparison.OrdinalIgnoreCase
                 );
-                var anchor = isPrimaryListing && !exactListingScope
-                    ? await _combinedQuarterService.Resolve(stock)
-                    : null;
+                var anchor =
+                    isPrimaryListing && !exactListingScope
+                        ? await _combinedQuarterService.Resolve(stock)
+                        : null;
                 if (anchor is { IsCombined: true })
                 {
                     var combined = await _holdingRepository.GetCombinedStockActivitySnapshotBacked(
@@ -920,7 +925,8 @@ public class InstitutionalHoldingsTools
                     return dateError;
 
                 var previousDate = GetPriorReportDate(reportDates, targetDate);
-                var activity = await (exactListingScope
+                var activity = await (
+                    exactListingScope
                         ? _holdingRepository.Get13FHolderActivityByListing(
                             stock,
                             listedTicker,
@@ -931,8 +937,8 @@ public class InstitutionalHoldingsTools
                             stock,
                             targetDate,
                             previousDate
-                        ))
-                    .ToListAsync();
+                        )
+                ).ToListAsync();
 
                 // A previous holder with no current row only PROVES an exit when it filed a
                 // 13F for the target quarter elsewhere. While the filing window is open the

--- a/src/Equibles.Holdings.Repositories/HolderQuarterlyActivityCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/HolderQuarterlyActivityCalculator.cs
@@ -22,24 +22,24 @@ public static class HolderQuarterlyActivityCalculator
             [StockPositionChangeType.Unchanged] = [],
         };
 
-        var currentByStock = AggregateByStock(currentHoldings);
-        var previousByStock = AggregateByStock(previousHoldings);
+        var currentBySecurity = AggregateBySecurity(currentHoldings);
+        var previousBySecurity = AggregateBySecurity(previousHoldings);
 
         // % of portfolio is computed against the holder's current-quarter total value.
         // Anchoring on the current side keeps comparisons consistent for all four
         // movement buckets except Exited; Exited rows show 0% (their current value is 0).
-        var totalCurrentValue = currentByStock.Values.Sum(v => v.Value);
+        var totalCurrentValue = currentBySecurity.Values.Sum(v => v.Value);
 
-        foreach (var (stockId, current) in currentByStock)
+        foreach (var (security, current) in currentBySecurity)
         {
-            previousByStock.TryGetValue(stockId, out var previous);
+            previousBySecurity.TryGetValue(security, out var previous);
             var changeType = ClassifyChange(current.Shares, previous?.Shares ?? 0);
             buckets[changeType].Add(BuildChange(current, previous, totalCurrentValue, changeType));
         }
 
-        foreach (var (stockId, previous) in previousByStock)
+        foreach (var (security, previous) in previousBySecurity)
         {
-            if (currentByStock.ContainsKey(stockId))
+            if (currentBySecurity.ContainsKey(security))
                 continue;
             buckets[StockPositionChangeType.Exited]
                 .Add(BuildExitedChange(previous, totalCurrentValue));
@@ -71,6 +71,8 @@ public static class HolderQuarterlyActivityCalculator
         return new StockPositionChange
         {
             CommonStockId = current.StockId,
+            PrimaryTicker = current.PrimaryTicker,
+            ListedTicker = current.ListedTicker,
             Ticker = current.Ticker,
             Name = current.Name,
             CurrentShares = current.Shares,
@@ -90,6 +92,8 @@ public static class HolderQuarterlyActivityCalculator
         return new StockPositionChange
         {
             CommonStockId = previous.StockId,
+            PrimaryTicker = previous.PrimaryTicker,
+            ListedTicker = previous.ListedTicker,
             Ticker = previous.Ticker,
             Name = previous.Name,
             CurrentShares = 0,
@@ -101,18 +105,22 @@ public static class HolderQuarterlyActivityCalculator
         };
     }
 
-    private static Dictionary<Guid, StockAggregate> AggregateByStock(
+    private static Dictionary<SecurityKey, StockAggregate> AggregateBySecurity(
         IReadOnlyList<InstitutionalHolding> holdings
     )
     {
         return holdings
-            .GroupBy(h => h.CommonStockId)
+            .GroupBy(h =>
+                new SecurityKey(h.CommonStockId, h.ListedTicker ?? h.CommonStock?.Ticker)
+            )
             .ToDictionary(
                 g => g.Key,
                 g => new StockAggregate
                 {
-                    StockId = g.Key,
-                    Ticker = g.First().CommonStock?.Ticker,
+                    StockId = g.Key.CommonStockId,
+                    PrimaryTicker = g.First().CommonStock?.Ticker,
+                    ListedTicker = g.Key.ListedTicker,
+                    Ticker = g.Key.ListedTicker,
                     Name = g.First().CommonStock?.Name,
                     Shares = g.Sum(h => h.Shares),
                     Value = g.Sum(h => h.Value),
@@ -123,9 +131,13 @@ public static class HolderQuarterlyActivityCalculator
     private class StockAggregate
     {
         public Guid StockId { get; set; }
+        public string PrimaryTicker { get; set; }
+        public string ListedTicker { get; set; }
         public string Ticker { get; set; }
         public string Name { get; set; }
         public long Shares { get; set; }
         public long Value { get; set; }
     }
+
+    private readonly record struct SecurityKey(Guid CommonStockId, string ListedTicker);
 }

--- a/src/Equibles.Holdings.Repositories/HolderQuarterlyActivityCalculator.cs
+++ b/src/Equibles.Holdings.Repositories/HolderQuarterlyActivityCalculator.cs
@@ -110,9 +110,7 @@ public static class HolderQuarterlyActivityCalculator
     )
     {
         return holdings
-            .GroupBy(h =>
-                new SecurityKey(h.CommonStockId, h.ListedTicker ?? h.CommonStock?.Ticker)
-            )
+            .GroupBy(h => new SecurityKey(h.CommonStockId, h.ListedTicker ?? h.CommonStock?.Ticker))
             .ToDictionary(
                 g => g.Key,
                 g => new StockAggregate

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -246,13 +246,19 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         string listedTicker
     )
     {
-        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
+        var isPrimary = string.Equals(
+            listedTicker,
+            stock.Ticker,
+            StringComparison.OrdinalIgnoreCase
+        );
         return GetAll()
             .Where(Is13F)
             .Where(h => h.CommonStockId == stock.Id)
-            .Where(h => isPrimary
-                ? h.ListedTicker == null || h.ListedTicker == stock.Ticker
-                : h.ListedTicker == listedTicker);
+            .Where(h =>
+                isPrimary
+                    ? h.ListedTicker == null || h.ListedTicker == stock.Ticker
+                    : h.ListedTicker == listedTicker
+            );
     }
 
     public IQueryable<InstitutionalHolding> GetHistoryByHolder(InstitutionalHolder holder)
@@ -387,11 +393,12 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         CancellationToken cancellationToken = default
     )
     {
-        if (string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase)
-            && !SecondaryTickerPolicy.IsExchangeTradedListing(stock, listedTicker))
+        if (
+            string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase)
+            && !SecondaryTickerPolicy.IsExchangeTradedListing(stock, listedTicker)
+        )
             return await Get13FReportDatesByStockSnapshotBacked(stock, cancellationToken);
-        return await Get13FReportDatesByListing(stock, listedTicker)
-            .ToListAsync(cancellationToken);
+        return await Get13FReportDatesByListing(stock, listedTicker).ToListAsync(cancellationToken);
     }
 
     // Snapshot-backed twin for request paths. The live DISTINCT above scans every historical

--- a/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
+++ b/src/Equibles.Holdings.Repositories/InstitutionalHoldingRepository.cs
@@ -1,4 +1,5 @@
 using System.Linq.Expressions;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Models.Taxonomies;
 using Equibles.CorporateActions.Data;
@@ -47,6 +48,22 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
         return GetByStock(stock, reportDate).Where(Is13F);
     }
 
+    /// <summary>
+    /// Exact listed security at a quarter end. Primary-listing rows historically store null;
+    /// secondary ETF and share-class rows carry ListedTicker from the filed CUSIP resolution.
+    /// </summary>
+    public IQueryable<InstitutionalHolding> Get13FByListing(
+        CommonStock stock,
+        string listedTicker,
+        DateOnly reportDate
+    ) => Get13FHistoryByListing(stock, listedTicker).Where(h => h.ReportDate == reportDate);
+
+    public IQueryable<InstitutionalHolding> Get13FByListingWithHolder(
+        CommonStock stock,
+        string listedTicker,
+        DateOnly reportDate
+    ) => Get13FByListing(stock, listedTicker, reportDate).Include(h => h.InstitutionalHolder);
+
     // Same stock/date 13F-only filter as Get13FByStock, with the InstitutionalHolder navigation
     // eagerly loaded for callers that render holder fields while aggregating rows.
     public IQueryable<InstitutionalHolding> Get13FByStockWithHolder(
@@ -78,6 +95,42 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             {
                 InstitutionalHolderId = g.Key.InstitutionalHolderId,
                 ListedTicker = g.Key.ListedTicker,
+                CurrentShares = g.Sum(h => h.ReportDate == currentReportDate ? h.Shares : 0L),
+                PreviousShares = g.Sum(h =>
+                    previousReportDate.HasValue && h.ReportDate == previousReportDate.Value
+                        ? h.Shares
+                        : 0L
+                ),
+                CurrentValue = g.Sum(h => h.ReportDate == currentReportDate ? h.Value : 0L),
+                PreviousValue = g.Sum(h =>
+                    previousReportDate.HasValue && h.ReportDate == previousReportDate.Value
+                        ? h.Value
+                        : 0L
+                ),
+                CurrentPositionCount = g.Count(h => h.ReportDate == currentReportDate),
+                PreviousPositionCount = g.Count(h =>
+                    previousReportDate.HasValue && h.ReportDate == previousReportDate.Value
+                ),
+            });
+    }
+
+    public IQueryable<HolderStockActivity> Get13FHolderActivityByListing(
+        CommonStock stock,
+        string listedTicker,
+        DateOnly currentReportDate,
+        DateOnly? previousReportDate
+    )
+    {
+        return Get13FHistoryByListing(stock, listedTicker)
+            .Where(h =>
+                h.ReportDate == currentReportDate
+                || (previousReportDate.HasValue && h.ReportDate == previousReportDate.Value)
+            )
+            .GroupBy(h => h.InstitutionalHolderId)
+            .Select(g => new HolderStockActivity
+            {
+                InstitutionalHolderId = g.Key,
+                ListedTicker = listedTicker,
                 CurrentShares = g.Sum(h => h.ReportDate == currentReportDate ? h.Shares : 0L),
                 PreviousShares = g.Sum(h =>
                     previousReportDate.HasValue && h.ReportDate == previousReportDate.Value
@@ -186,6 +239,20 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     public IQueryable<InstitutionalHolding> Get13FHistoryByStock(CommonStock stock)
     {
         return GetHistoryByStock(stock).Where(Is13F);
+    }
+
+    public IQueryable<InstitutionalHolding> Get13FHistoryByListing(
+        CommonStock stock,
+        string listedTicker
+    )
+    {
+        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
+        return GetAll()
+            .Where(Is13F)
+            .Where(h => h.CommonStockId == stock.Id)
+            .Where(h => isPrimary
+                ? h.ListedTicker == null || h.ListedTicker == stock.Ticker
+                : h.ListedTicker == listedTicker);
     }
 
     public IQueryable<InstitutionalHolding> GetHistoryByHolder(InstitutionalHolder holder)
@@ -308,6 +375,24 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     // comparison quarters off this list, so it must stay 13F-only (GH-4449).
     public IQueryable<DateOnly> Get13FReportDatesByStock(CommonStock stock) =>
         Get13FHistoryByStock(stock).DistinctReportDatesDescending();
+
+    public IQueryable<DateOnly> Get13FReportDatesByListing(
+        CommonStock stock,
+        string listedTicker
+    ) => Get13FHistoryByListing(stock, listedTicker).DistinctReportDatesDescending();
+
+    public async Task<List<DateOnly>> Get13FReportDatesByListingSnapshotBacked(
+        CommonStock stock,
+        string listedTicker,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase)
+            && !SecondaryTickerPolicy.IsExchangeTradedListing(stock, listedTicker))
+            return await Get13FReportDatesByStockSnapshotBacked(stock, cancellationToken);
+        return await Get13FReportDatesByListing(stock, listedTicker)
+            .ToListAsync(cancellationToken);
+    }
 
     // Snapshot-backed twin for request paths. The live DISTINCT above scans every historical
     // position for a heavily held stock; under ingest pressure that scan exhausted the 30-second
@@ -794,6 +879,63 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
             snapshots.Add(await GetLiveStockActivityPoint(stock, latest, cancellationToken));
         }
         return snapshots;
+    }
+
+    public async Task<List<StockQuarterlyActivity>> GetListingActivityHistory(
+        CommonStock stock,
+        string listedTicker,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var aggregates = await Get13FHistoryByListing(stock, listedTicker)
+            .GroupBy(holding => holding.ReportDate)
+            .Select(group => new
+            {
+                ReportDate = group.Key,
+                Shares = group.Sum(holding => holding.Shares),
+                Value = group.Sum(holding => holding.Value),
+                FilerCount = group
+                    .Select(holding => holding.InstitutionalHolderId)
+                    .Distinct()
+                    .Count(),
+            })
+            .OrderBy(row => row.ReportDate)
+            .ToListAsync(cancellationToken);
+
+        var result = new List<StockQuarterlyActivity>(aggregates.Count);
+        for (var index = 0; index < aggregates.Count; index++)
+        {
+            var current = aggregates[index];
+            var previous = index > 0 ? aggregates[index - 1] : null;
+            result.Add(
+                new StockQuarterlyActivity
+                {
+                    CommonStockId = stock.Id,
+                    ReportDate = current.ReportDate,
+                    PreviousReportDate = previous?.ReportDate,
+                    CurrentShares = current.Shares,
+                    PreviousShares = previous?.Shares ?? 0,
+                    CurrentValue = current.Value,
+                    PreviousValue = previous?.Value ?? 0,
+                    CurrentFilerCount = current.FilerCount,
+                    PreviousFilerCount = previous?.FilerCount ?? 0,
+                    ListingShares =
+                    [
+                        new StockQuarterlyListingActivity
+                        {
+                            CommonStockId = stock.Id,
+                            ReportDate = current.ReportDate,
+                            IsCombined = false,
+                            PriceSeriesTicker = listedTicker,
+                            CurrentShares = current.Shares,
+                            PreviousShares = previous?.Shares ?? 0,
+                        },
+                    ],
+                }
+            );
+        }
+
+        return result;
     }
 
     // Snapshot-first open-window point for one stock. Ownership-history surfaces replace only
@@ -1728,6 +1870,22 @@ public class InstitutionalHoldingRepository : BaseRepository<InstitutionalHoldin
     {
         return GetAll()
             .Where(h => h.CommonStockId == stock.Id && h.FilingDate >= since)
+            .GroupBy(h => h.CommonStockId)
+            .Select(g => new FilingActivitySummary
+            {
+                FilingCount = g.Select(h => h.AccessionNumber).Distinct().Count(),
+                FilerCount = g.Select(h => h.InstitutionalHolderId).Distinct().Count(),
+            });
+    }
+
+    public IQueryable<FilingActivitySummary> GetFilingActivitySummary(
+        CommonStock stock,
+        string listedTicker,
+        DateOnly since
+    )
+    {
+        return Get13FHistoryByListing(stock, listedTicker)
+            .Where(h => h.FilingDate >= since)
             .GroupBy(h => h.CommonStockId)
             .Select(g => new FilingActivitySummary
             {

--- a/src/Equibles.Holdings.Repositories/Models/StockPositionChange.cs
+++ b/src/Equibles.Holdings.Repositories/Models/StockPositionChange.cs
@@ -12,6 +12,8 @@ public enum StockPositionChangeType
 public class StockPositionChange
 {
     public Guid CommonStockId { get; set; }
+    public string PrimaryTicker { get; set; }
+    public string ListedTicker { get; set; }
     public string Ticker { get; set; }
     public string Name { get; set; }
 

--- a/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
+++ b/src/Equibles.InsiderTrading.Mcp/Tools/InsiderTradingTools.cs
@@ -208,6 +208,7 @@ public class InsiderTradingTools
                 var splits = await _stockSplitRepository
                     .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
                     .ToListAsync();
+                splits = PriceSeriesSplitScope.ForListing(splits, stock.Ticker, stock.Ticker);
 
                 var sb = new StringBuilder();
                 sb.AppendLine($"Recent insider transactions for {stock.Name} ({stock.Ticker}):");
@@ -352,6 +353,7 @@ public class InsiderTradingTools
                 var splits = await _stockSplitRepository
                     .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
                     .ToListAsync();
+                splits = PriceSeriesSplitScope.ForListing(splits, stock.Ticker, stock.Ticker);
                 var positions = latestTransactions
                     .GroupBy(t => t.InsiderOwnerId)
                     .Select(group => BuildOwnershipPosition([.. group], splits))
@@ -547,6 +549,7 @@ public class InsiderTradingTools
                 var splits = await _stockSplitRepository
                     .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
                     .ToListAsync();
+                splits = PriceSeriesSplitScope.ForListing(splits, stock.Ticker, stock.Ticker);
                 var result = MarkdownTable.Start(
                     $"Recent proposed sales (Form 144) for {stock.Name} ({stock.Ticker}):",
                     $"Showing notices {offset + 1}-{offset + filings.Count} of {totalCount}, newest first",

--- a/src/Equibles.Migrations/Migrations/20260904205442_AddExactListedSecurityIdentity.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260904205442_AddExactListedSecurityIdentity.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260904205442_AddExactListedSecurityIdentity")]
+    partial class AddExactListedSecurityIdentity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260904205442_AddExactListedSecurityIdentity.cs
+++ b/src/Equibles.Migrations/Migrations/20260904205442_AddExactListedSecurityIdentity.cs
@@ -1,0 +1,233 @@
+﻿using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExactListedSecurityIdentity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_StockSplit_CommonStockId_EffectiveDate",
+                table: "StockSplit");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ShortInterest_CommonStockId_SettlementDate",
+                table: "ShortInterest");
+
+            migrationBuilder.DropIndex(
+                name: "IX_OffExchangeVolume_CommonStockId_WeekStartDate",
+                table: "OffExchangeVolume");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FailToDeliver_CommonStockId_SettlementDate",
+                table: "FailToDeliver");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DailyShortVolume_CommonStockId_Date",
+                table: "DailyShortVolume");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ListedTicker",
+                table: "ShortInterest",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ListedTicker",
+                table: "OffExchangeVolume",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ListedTicker",
+                table: "FailToDeliver",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ListedTicker",
+                table: "DailyShortVolume",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.Sql(
+                """
+                UPDATE "ShortInterest" AS data SET "ListedTicker" = stock."Ticker" FROM "CommonStock" AS stock WHERE data."CommonStockId" = stock."Id" AND data."ListedTicker" = '';
+                UPDATE "OffExchangeVolume" AS data SET "ListedTicker" = stock."Ticker" FROM "CommonStock" AS stock WHERE data."CommonStockId" = stock."Id" AND data."ListedTicker" = '';
+                UPDATE "FailToDeliver" AS data SET "ListedTicker" = stock."Ticker" FROM "CommonStock" AS stock WHERE data."CommonStockId" = stock."Id" AND data."ListedTicker" = '';
+                UPDATE "DailyShortVolume" AS data SET "ListedTicker" = stock."Ticker" FROM "CommonStock" AS stock WHERE data."CommonStockId" = stock."Id" AND data."ListedTicker" = '';
+                UPDATE "CommonStock" SET "ReferenceTickers" = ARRAY[]::text[] WHERE "ReferenceTickers" IS NULL;
+                """
+            );
+
+            migrationBuilder.AlterColumn<List<string>>(
+                name: "ReferenceTickers",
+                table: "CommonStock",
+                type: "text[]",
+                nullable: false,
+                defaultValueSql: "'{}'::text[]",
+                oldClrType: typeof(List<string>),
+                oldType: "text[]",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StockSplit_CommonStockId_EffectiveDate",
+                table: "StockSplit",
+                columns: new[] { "CommonStockId", "EffectiveDate" },
+                unique: true,
+                filter: "\"PriceSeriesTicker\" IS NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StockSplit_CommonStockId_PriceSeriesTicker_EffectiveDate",
+                table: "StockSplit",
+                columns: new[] { "CommonStockId", "PriceSeriesTicker", "EffectiveDate" },
+                unique: true,
+                filter: "\"PriceSeriesTicker\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShortInterest_CommonStockId_ListedTicker_SettlementDate",
+                table: "ShortInterest",
+                columns: new[] { "CommonStockId", "ListedTicker", "SettlementDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OffExchangeVolume_CommonStockId_ListedTicker_WeekStartDate",
+                table: "OffExchangeVolume",
+                columns: new[] { "CommonStockId", "ListedTicker", "WeekStartDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FailToDeliver_CommonStockId_ListedTicker_SettlementDate",
+                table: "FailToDeliver",
+                columns: new[] { "CommonStockId", "ListedTicker", "SettlementDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DailyShortVolume_CommonStockId_ListedTicker_Date",
+                table: "DailyShortVolume",
+                columns: new[] { "CommonStockId", "ListedTicker", "Date" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                DO $$
+                BEGIN
+                    IF EXISTS (
+                        SELECT 1
+                        FROM "StockSplit"
+                        GROUP BY "CommonStockId", "EffectiveDate"
+                        HAVING COUNT(*) > 1
+                    ) THEN
+                        RAISE EXCEPTION 'Cannot roll back exact listed-security split identity while multiple listing splits share one filer and effective date.';
+                    END IF;
+                END $$;
+                """
+            );
+
+            migrationBuilder.DropIndex(
+                name: "IX_StockSplit_CommonStockId_EffectiveDate",
+                table: "StockSplit");
+
+            migrationBuilder.DropIndex(
+                name: "IX_StockSplit_CommonStockId_PriceSeriesTicker_EffectiveDate",
+                table: "StockSplit");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ShortInterest_CommonStockId_ListedTicker_SettlementDate",
+                table: "ShortInterest");
+
+            migrationBuilder.DropIndex(
+                name: "IX_OffExchangeVolume_CommonStockId_ListedTicker_WeekStartDate",
+                table: "OffExchangeVolume");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FailToDeliver_CommonStockId_ListedTicker_SettlementDate",
+                table: "FailToDeliver");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DailyShortVolume_CommonStockId_ListedTicker_Date",
+                table: "DailyShortVolume");
+
+            migrationBuilder.Sql(
+                """
+                DELETE FROM "ShortInterest" AS data USING "CommonStock" AS stock WHERE data."CommonStockId" = stock."Id" AND data."ListedTicker" <> stock."Ticker";
+                DELETE FROM "OffExchangeVolume" AS data USING "CommonStock" AS stock WHERE data."CommonStockId" = stock."Id" AND data."ListedTicker" <> stock."Ticker";
+                DELETE FROM "FailToDeliver" AS data USING "CommonStock" AS stock WHERE data."CommonStockId" = stock."Id" AND data."ListedTicker" <> stock."Ticker";
+                DELETE FROM "DailyShortVolume" AS data USING "CommonStock" AS stock WHERE data."CommonStockId" = stock."Id" AND data."ListedTicker" <> stock."Ticker";
+                """
+            );
+
+            migrationBuilder.DropColumn(
+                name: "ListedTicker",
+                table: "ShortInterest");
+
+            migrationBuilder.DropColumn(
+                name: "ListedTicker",
+                table: "OffExchangeVolume");
+
+            migrationBuilder.DropColumn(
+                name: "ListedTicker",
+                table: "FailToDeliver");
+
+            migrationBuilder.DropColumn(
+                name: "ListedTicker",
+                table: "DailyShortVolume");
+
+            migrationBuilder.AlterColumn<List<string>>(
+                name: "ReferenceTickers",
+                table: "CommonStock",
+                type: "text[]",
+                nullable: true,
+                oldClrType: typeof(List<string>),
+                oldType: "text[]",
+                oldDefaultValueSql: "'{}'::text[]");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StockSplit_CommonStockId_EffectiveDate",
+                table: "StockSplit",
+                columns: new[] { "CommonStockId", "EffectiveDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShortInterest_CommonStockId_SettlementDate",
+                table: "ShortInterest",
+                columns: new[] { "CommonStockId", "SettlementDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OffExchangeVolume_CommonStockId_WeekStartDate",
+                table: "OffExchangeVolume",
+                columns: new[] { "CommonStockId", "WeekStartDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FailToDeliver_CommonStockId_SettlementDate",
+                table: "FailToDeliver",
+                columns: new[] { "CommonStockId", "SettlementDate" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DailyShortVolume_CommonStockId_Date",
+                table: "DailyShortVolume",
+                columns: new[] { "CommonStockId", "Date" },
+                unique: true);
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/FailToDeliver.cs
+++ b/src/Equibles.Sec.Data/Models/FailToDeliver.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Sec.Data.Models;

--- a/src/Equibles.Sec.Data/Models/FailToDeliver.cs
+++ b/src/Equibles.Sec.Data/Models/FailToDeliver.cs
@@ -1,10 +1,12 @@
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Helpers;
 using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Sec.Data.Models;
 
-[Index(nameof(CommonStockId), nameof(SettlementDate), IsUnique = true)]
+[Index(nameof(CommonStockId), nameof(ListedTicker), nameof(SettlementDate), IsUnique = true)]
 [Index(nameof(SettlementDate))]
 public class FailToDeliver
 {
@@ -13,6 +15,10 @@ public class FailToDeliver
 
     public Guid CommonStockId { get; set; }
     public virtual CommonStock CommonStock { get; set; }
+
+    [Required]
+    [MaxLength(TickerNormalizer.MaxListedLength)]
+    public string ListedTicker { get; set; } = "";
 
     public DateOnly SettlementDate { get; set; }
 

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -6,6 +6,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.Extensions;
+using Equibles.CorporateActions.Data;
 using Equibles.CorporateActions.Data.Models;
 using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
@@ -208,6 +209,7 @@ public class FinancialFactsTools
                         .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
                         .ToListAsync()
                     : [];
+                splits = PriceSeriesSplitScope.ForListing(splits, stock.Ticker, stock.Ticker);
 
                 return RenderFactHistoryTable(
                     concept,
@@ -350,7 +352,13 @@ public class FinancialFactsTools
                         : (
                             await _stockSplitRepository
                                 .GetEffective(DateOnly.FromDateTime(DateTime.UtcNow))
-                                .Where(split => splitAdjustedStockIds.Contains(split.CommonStockId))
+                                .Where(split =>
+                                    splitAdjustedStockIds.Contains(split.CommonStockId)
+                                    && (
+                                        split.PriceSeriesTicker == null
+                                        || split.PriceSeriesTicker == split.CommonStock.Ticker
+                                    )
+                                )
                                 .ToListAsync()
                         )
                             .GroupBy(split => split.CommonStockId)

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -3,6 +3,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Core.Extensions;
+using Equibles.CorporateActions.Data;
 using Equibles.CorporateActions.Data.Models;
 using Equibles.CorporateActions.Repositories;
 using Equibles.Errors.BusinessLogic;
@@ -191,6 +192,7 @@ public class FinancialStatementTools
                         .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
                         .ToListAsync()
                     : [];
+                splits = PriceSeriesSplitScope.ForListing(splits, stock.Ticker, stock.Ticker);
 
                 return RenderStatementTable(
                     stock,

--- a/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
@@ -74,5 +74,9 @@ public class FtdScraperWorker : BaseScraperWorker
         // And the sibling-listing sweep: secondary tickers' CUSIPs (share classes, units)
         // recorded against the exact listed symbol so 13F lines filed under them resolve.
         await ftdService.BackfillListedTickerCusips(stoppingToken);
+
+        // The old data importer admitted primary symbols only. Replay a bounded, durable slice
+        // until historical secondary ETF/listing FTD rows have been restored.
+        await ftdService.BackfillListedRecords(stoppingToken);
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -81,7 +81,6 @@ public class FtdImportService
         );
 
         var tickerMap = await BuildTickerMap(cancellationToken);
-        var listedTickerMap = await BuildListedTickerMap(cancellationToken);
         var replayRecords = new Dictionary<string, List<FtdRecord>>(StringComparer.Ordinal);
         var cusipsSeeded = await ReplayLiveIdentity(
             replayFiles,
@@ -94,6 +93,7 @@ public class FtdImportService
             _logger.LogInformation("Seeded or updated {Count} CUSIPs from FTD data", cusipsSeeded);
         }
 
+        var listedTickerMap = await BuildListedTickerMap(cancellationToken);
         await ImportNewRecords(
             importFiles,
             importStartDate,

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -81,6 +81,7 @@ public class FtdImportService
         );
 
         var tickerMap = await BuildTickerMap(cancellationToken);
+        var listedTickerMap = await BuildListedTickerMap(cancellationToken);
         var replayRecords = new Dictionary<string, List<FtdRecord>>(StringComparer.Ordinal);
         var cusipsSeeded = await ReplayLiveIdentity(
             replayFiles,
@@ -97,7 +98,7 @@ public class FtdImportService
             importFiles,
             importStartDate,
             replayRecords,
-            tickerMap,
+            listedTickerMap,
             cancellationToken
         );
     }
@@ -182,7 +183,7 @@ public class FtdImportService
         List<string> importFiles,
         DateOnly importStartDate,
         Dictionary<string, List<FtdRecord>> replayRecords,
-        Dictionary<string, Guid> tickerMap,
+        Dictionary<string, ListedSecurityKey> tickerMap,
         CancellationToken cancellationToken
     )
     {
@@ -578,6 +579,56 @@ public class FtdImportService
                 fileNames.Count
             );
         }
+    }
+
+    /// <summary>
+    /// Replays the SEC archive into the exact-listing FTD key. The former importer admitted only
+    /// primary tickers, so a schema backfill cannot recover secondary ETF rows that were skipped.
+    /// A durable oldest-first frontier makes the repair bounded and restart-safe.
+    /// </summary>
+    public async Task BackfillListedRecords(CancellationToken cancellationToken)
+    {
+        var fileNames = await NextSweepFiles(ListedRecordSweepCursorName);
+        if (fileNames.Count == 0)
+            return;
+
+        var tickerMap = await BuildListedTickerMap(cancellationToken);
+        if (tickerMap.Count == 0)
+            return;
+
+        string lastCompletedFile = null;
+        foreach (var fileName in fileNames)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var records = await DownloadAndParse(fileName, cancellationToken);
+                await ImportRecords(records, tickerMap, cancellationToken);
+                lastCompletedFile = fileName;
+            }
+            catch (HttpRequestException ex)
+                when (ex.StatusCode == System.Net.HttpStatusCode.NotFound
+                    && !IsRecentFtdFile(fileName))
+            {
+                _logger.LogWarning(
+                    "Listed-record FTD sweep: archive file {File} is unavailable (404), advancing",
+                    fileName
+                );
+                lastCompletedFile = fileName;
+            }
+            catch (Exception ex) when (ex is HttpRequestException or InvalidDataException)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Listed-record FTD sweep: failed to import {File}; retrying from this file",
+                    fileName
+                );
+                break;
+            }
+        }
+
+        if (lastCompletedFile != null)
+            await AdvanceSweepFrontier(ListedRecordSweepCursorName, lastCompletedFile);
     }
 
     private async Task<int> RecordListedCusips(
@@ -1165,6 +1216,7 @@ public class FtdImportService
     // Separate cursor: the alias sweep's frontier has already consumed the archive on
     // long-running deployments, and listed-CUSIP rows were never collected on that pass.
     private const string ListedCusipSweepCursorName = "Ftd.ListedCusipSweep";
+    private const string ListedRecordSweepCursorName = "Ftd.ListedRecordSweepV1";
 
     // Twelve fortnightly files ≈ six months of archive per daily cycle, so the whole
     // 2017→today range is swept in about a fortnight of cycles without ever making the
@@ -1648,9 +1700,9 @@ public class FtdImportService
         DateOnly SettlementDate
     );
 
-    private static bool TryResolveSymbol(
+    private static bool TryResolveSymbol<TValue>(
         string symbol,
-        Dictionary<string, Guid> tickerMap,
+        Dictionary<string, TValue> tickerMap,
         Dictionary<string, string> strippedAliases,
         out string ticker
     )
@@ -1666,29 +1718,30 @@ public class FtdImportService
 
     private async Task<int> ImportRecords(
         List<FtdRecord> records,
-        Dictionary<string, Guid> tickerMap,
+        Dictionary<string, ListedSecurityKey> tickerMap,
         CancellationToken cancellationToken
     )
     {
         // Group by stock+date, keeping the latest record per day (FTD is cumulative)
-        var grouped = new Dictionary<(Guid StockId, DateOnly Date), FailToDeliver>();
+        var grouped = new Dictionary<(Guid StockId, string ListedTicker, DateOnly Date), FailToDeliver>();
 
-        var strippedAliases = BuildStrippedTickerAliases(tickerMap);
+        var strippedAliases = BuildStrippedTickerAliases(tickerMap.Keys);
         foreach (var record in records)
         {
             if (
                 string.IsNullOrEmpty(record.Symbol)
                 || !TryResolveSymbol(record.Symbol, tickerMap, strippedAliases, out var ticker)
-                || !tickerMap.TryGetValue(ticker, out var stockId)
+                || !tickerMap.TryGetValue(ticker, out var listing)
             )
             {
                 continue;
             }
 
-            var key = (stockId, record.SettlementDate);
+            var key = (listing.CommonStockId, listing.ListedTicker, record.SettlementDate);
             grouped[key] = new FailToDeliver
             {
-                CommonStockId = stockId,
+                CommonStockId = listing.CommonStockId,
+                ListedTicker = listing.ListedTicker,
                 SettlementDate = record.SettlementDate,
                 Quantity = record.Quantity,
                 Price = record.Price,
@@ -1725,7 +1778,7 @@ public class FtdImportService
         await dbContext
             .Set<FailToDeliver>()
             .UpsertRange(safeItems)
-            .On(f => new { f.CommonStockId, f.SettlementDate })
+            .On(f => new { f.CommonStockId, f.ListedTicker, f.SettlementDate })
             .WhenMatched(
                 (existing, incoming) =>
                     new FailToDeliver { Quantity = incoming.Quantity, Price = incoming.Price }
@@ -1738,6 +1791,15 @@ public class FtdImportService
         using var scope = _scopeFactory.CreateScope();
         var tickerMapService = scope.ServiceProvider.GetRequiredService<TickerMapService>();
         return await tickerMapService.Build(_workerOptions.TickersToSync, cancellationToken);
+    }
+
+    private async Task<Dictionary<string, ListedSecurityKey>> BuildListedTickerMap(
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var tickerMapService = scope.ServiceProvider.GetRequiredService<TickerMapService>();
+        return await tickerMapService.BuildListed(_workerOptions.TickersToSync, cancellationToken);
     }
 
     private async Task<List<FtdRecord>> DownloadAndParse(

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -608,7 +608,8 @@ public class FtdImportService
             }
             catch (HttpRequestException ex)
                 when (ex.StatusCode == System.Net.HttpStatusCode.NotFound
-                    && !IsRecentFtdFile(fileName))
+                    && !IsRecentFtdFile(fileName)
+                )
             {
                 _logger.LogWarning(
                     "Listed-record FTD sweep: archive file {File} is unavailable (404), advancing",
@@ -1723,7 +1724,8 @@ public class FtdImportService
     )
     {
         // Group by stock+date, keeping the latest record per day (FTD is cumulative)
-        var grouped = new Dictionary<(Guid StockId, string ListedTicker, DateOnly Date), FailToDeliver>();
+        var grouped =
+            new Dictionary<(Guid StockId, string ListedTicker, DateOnly Date), FailToDeliver>();
 
         var strippedAliases = BuildStrippedTickerAliases(tickerMap.Keys);
         foreach (var record in records)
@@ -1778,7 +1780,12 @@ public class FtdImportService
         await dbContext
             .Set<FailToDeliver>()
             .UpsertRange(safeItems)
-            .On(f => new { f.CommonStockId, f.ListedTicker, f.SettlementDate })
+            .On(f => new
+            {
+                f.CommonStockId,
+                f.ListedTicker,
+                f.SettlementDate,
+            })
             .WhenMatched(
                 (existing, incoming) =>
                     new FailToDeliver { Quantity = incoming.Quantity, Price = incoming.Price }

--- a/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/FailToDeliverTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Errors.BusinessLogic;
@@ -39,10 +40,10 @@ public class FailToDeliverTools
 
     [McpServerTool(Name = "GetFailsToDeliver", Title = "Fails-to-Deliver Data", ReadOnly = true)]
     [Description(
-        "Get fails-to-deliver (FTD) data for a stock from the SEC's twice-monthly FTD files. Quantity is the aggregate net fail-to-deliver position OUTSTANDING on each settlement date — a balance, not that day's new fails, so never sum Quantity across dates. Price is the previous trading day's closing price (SEC file convention, not a settlement price) and Value = Quantity × Price. Within the covered window (the output names the earliest fully covered settlement date), dates absent from the table had no reported fails; earlier dates are only partially covered, so their absence is not evidence of no fails. The SEC publishes each half-month batch with roughly a two-week lag, so the newest rows trail today. High or persistent FTD balances may indicate naked short selling or settlement issues."
+        "Get fails-to-deliver (FTD) data for an exact listed stock or exchange-traded fund from the SEC's twice-monthly FTD files. Quantity is the aggregate net fail-to-deliver position OUTSTANDING on each settlement date — a balance, not that day's new fails, so never sum Quantity across dates. Price is the previous trading day's closing price (SEC file convention, not a settlement price) and Value = Quantity × Price. Within the covered window (the output names the earliest fully covered settlement date), dates absent from the table had no reported fails; earlier dates are only partially covered, so their absence is not evidence of no fails. The SEC publishes each half-month batch with roughly a two-week lag, so the newest rows trail today. High or persistent FTD balances may indicate naked short selling or settlement issues."
     )]
     public Task<string> GetFailsToDeliver(
-        [Description("Stock ticker symbol (e.g., AAPL, GME, AMC)")] string ticker,
+        [Description("Exact stock or ETF ticker symbol (e.g., AAPL, GME, SPY)")] string ticker,
         [Description("Start date in YYYY-MM-DD format (defaults to 3 months ago)")]
             string startDate = null,
         [Description("End date in YYYY-MM-DD format (defaults to latest available)")]
@@ -59,6 +60,9 @@ public class FailToDeliverTools
                 var (stock, stockError) = await _commonStockRepository.ResolveByTicker(ticker);
                 if (stockError != null)
                     return stockError;
+                var listedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, ticker);
+                if (listedTicker == null)
+                    return $"Stock '{ticker}' not found.";
 
                 var (start, end, rangeError) = ParseStrictDateRange(
                     startDate,
@@ -71,7 +75,7 @@ public class FailToDeliverTools
                 maxResults = McpLimit.Clamp(maxResults);
 
                 var query = _ftdRepository
-                    .GetByStock(stock)
+                    .GetByListing(stock, listedTicker)
                     .Where(f => f.SettlementDate >= start && f.SettlementDate <= end);
 
                 var total = await query.CountAsync();
@@ -103,8 +107,8 @@ public class FailToDeliverTools
 
                 var table = MarkdownTable.Render(
                     records.OrderBy(f => f.SettlementDate).ToList(),
-                    $"No FTD data found for {stock.Ticker} in the specified date range.",
-                    $"Fails-to-deliver for {stock.Ticker} ({stock.Name}):",
+                    $"No FTD data found for {listedTicker} in the specified date range.",
+                    $"Fails-to-deliver for {listedTicker} ({(listedTicker == stock.Ticker ? stock.Name : listedTicker)}):",
                     footnote,
                     "| Settlement Date | Quantity | Prior Close | Value |",
                     "|----------------|---------|-------------|-------|",

--- a/src/Equibles.Sec.Mcp/Tools/NportTools.cs
+++ b/src/Equibles.Sec.Mcp/Tools/NportTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.CommonStocks.Repositories.Extensions;
 using Equibles.Data;
@@ -40,10 +41,10 @@ public class NportTools
 
     [McpServerTool(Name = "GetFundsHoldingStock", Title = "Funds Holding a Stock", ReadOnly = true)]
     [Description(
-        "Get the registered investment companies (mutual funds and ETFs) holding a given stock, from SEC Form NPORT-P portfolio reports. The stock's CUSIP is matched against the holding rows on each fund series' most recent report (series that stopped filing more than 18 months ago are excluded), so an exited position never shows as current. Returns the fund's registrant and series, the reporting period, the position size, its U.S.-dollar value, its share of the fund's net assets and the payoff profile (Long/Short), largest positions first. Report dates differ per fund series (each files on its own fiscal quarter), so values are as of each row's report date and cross-row totals mix as-of dates. Use this to see which funds and ETFs own a stock and how concentrated each position is."
+        "Get the registered investment companies (mutual funds and ETFs) holding an exact stock or ETF listing, from SEC Form NPORT-P portfolio reports. The listed security's authoritative CUSIP is matched against the holding rows on each fund series' most recent report (series that stopped filing more than 18 months ago are excluded), so an exited position never shows as current. Returns the fund's registrant and series, the reporting period, the position size, its U.S.-dollar value, its share of the fund's net assets and the payoff profile (Long/Short), largest positions first. Report dates differ per fund series (each files on its own fiscal quarter), so values are as of each row's report date and cross-row totals mix as-of dates."
     )]
     public Task<string> GetFundsHoldingStock(
-        [Description("Stock ticker symbol (e.g., AAPL, MSFT)")] string ticker,
+        [Description("Listed security ticker (e.g., AAPL, VOO)")] string ticker,
         [Description(
             "Maximum number of fund positions to return, largest first (default: 20, clamped to 1-500)"
         )]
@@ -65,16 +66,17 @@ public class NportTools
                 if (stockError != null)
                     return MarkdownText(stockError);
 
-                var safeTicker = MarkdownText(ticker);
+                var listedTicker = SecondaryTickerPolicy.ResolveListedTicker(stock, ticker);
+                var safeTicker = MarkdownText(listedTicker);
 
-                if (string.IsNullOrEmpty(stock.Cusip))
+                if (!await _nportRepository.HasCusipIdentity(stock, listedTicker))
                     return $"No CUSIP is on record for {safeTicker}, so its fund ownership cannot be resolved from Form NPORT-P reports.";
 
                 var recencyFloor = DateOnly.FromDateTime(
                     DateTime.UtcNow - CurrentHolderRecencyFloor
                 );
                 var currentPositions = _nportRepository
-                    .GetHoldingsByStockCusip(stock)
+                    .GetHoldingsByListingCusip(stock, listedTicker)
                     .Join(
                         _nportRepository.GetLatestPerSeries(recencyFloor),
                         h => h.NportFilingId,
@@ -129,7 +131,7 @@ public class NportTools
                     ? ""
                     : $" matching '{MarkdownText(registrantOrSeries)}'";
                 var result = MarkdownTable.Start(
-                    $"Funds holding {MarkdownText(stock.Name)} ({safeTicker}) on each series' most recent Form NPORT-P — "
+                    $"Funds holding {safeTicker} on each series' most recent Form NPORT-P — "
                         + $"{totalCount} current fund positions{filterLabel}, showing rows "
                         + $"{offset + 1}-{offset + positions.Count} by value. "
                         + "Report dates differ per series (each fund's own fiscal quarter):",

--- a/src/Equibles.Sec.Repositories/FailToDeliverRepository.cs
+++ b/src/Equibles.Sec.Repositories/FailToDeliverRepository.cs
@@ -12,7 +12,19 @@ public class FailToDeliverRepository : BaseRepository<FailToDeliver>
 
     public IQueryable<FailToDeliver> GetByStock(CommonStock stock)
     {
-        return GetAll().Where(f => f.CommonStockId == stock.Id);
+        return GetAll().Where(f =>
+            f.CommonStockId == stock.Id
+            && (f.ListedTicker == stock.Ticker || f.ListedTicker == "")
+        );
+    }
+
+    public IQueryable<FailToDeliver> GetByListing(CommonStock stock, string listedTicker)
+    {
+        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
+        return GetAll().Where(f =>
+            f.CommonStockId == stock.Id
+            && (f.ListedTicker == listedTicker || (isPrimary && f.ListedTicker == ""))
+        );
     }
 
     public IQueryable<DateOnly> GetLatestDate()

--- a/src/Equibles.Sec.Repositories/FailToDeliverRepository.cs
+++ b/src/Equibles.Sec.Repositories/FailToDeliverRepository.cs
@@ -12,19 +12,25 @@ public class FailToDeliverRepository : BaseRepository<FailToDeliver>
 
     public IQueryable<FailToDeliver> GetByStock(CommonStock stock)
     {
-        return GetAll().Where(f =>
-            f.CommonStockId == stock.Id
-            && (f.ListedTicker == stock.Ticker || f.ListedTicker == "")
-        );
+        return GetAll()
+            .Where(f =>
+                f.CommonStockId == stock.Id
+                && (f.ListedTicker == stock.Ticker || f.ListedTicker == "")
+            );
     }
 
     public IQueryable<FailToDeliver> GetByListing(CommonStock stock, string listedTicker)
     {
-        var isPrimary = string.Equals(listedTicker, stock.Ticker, StringComparison.OrdinalIgnoreCase);
-        return GetAll().Where(f =>
-            f.CommonStockId == stock.Id
-            && (f.ListedTicker == listedTicker || (isPrimary && f.ListedTicker == ""))
+        var isPrimary = string.Equals(
+            listedTicker,
+            stock.Ticker,
+            StringComparison.OrdinalIgnoreCase
         );
+        return GetAll()
+            .Where(f =>
+                f.CommonStockId == stock.Id
+                && (f.ListedTicker == listedTicker || (isPrimary && f.ListedTicker == ""))
+            );
     }
 
     public IQueryable<DateOnly> GetLatestDate()

--- a/src/Equibles.Sec.Repositories/NportFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NportFilingRepository.cs
@@ -1,6 +1,7 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Data;
 using Equibles.Sec.Data.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace Equibles.Sec.Repositories;
 
@@ -62,23 +63,59 @@ public class NportFilingRepository : BaseRepository<NportFiling>
     /// </summary>
     public IQueryable<NportHolding> GetHoldingsByStockCusip(CommonStock stock)
     {
+        return GetHoldingsByListingCusip(stock, stock.Ticker);
+    }
+
+    /// <summary>
+    /// Holdings carrying the exact listed security's authoritative CUSIP identity. A primary
+    /// listing uses the stock's current and retired CUSIPs; a secondary listing uses only its
+    /// <see cref="CommonStockListedCusip"/> rows, so sibling fund series never bleed together.
+    /// </summary>
+    public IQueryable<NportHolding> GetHoldingsByListingCusip(
+        CommonStock stock,
+        string listedTicker
+    )
+    {
         // The explicit not-null filters on both legs let EF's nullability analysis emit the
         // membership test as a plain equality semi-join instead of null-compensating it into
         // "= OR both-null", which would defeat the CUSIP index the same way the OR did.
-        var cusips = DbContext
-            .Set<CommonStockCusipAlias>()
-            .Where(a => a.CommonStockId == stock.Id)
-            .Select(a => a.Cusip)
-            .Union(
-                DbContext
-                    .Set<CommonStock>()
-                    .Where(s => s.Id == stock.Id && s.Cusip != null)
-                    .Select(s => s.Cusip)
-            );
+        var cusips = GetCusipIdentity(stock, listedTicker);
         return DbContext
             .Set<NportHolding>()
             .Where(h => h.Cusip != null && cusips.Contains(h.Cusip));
     }
+
+    private IQueryable<string> GetCusipIdentity(CommonStock stock, string listedTicker)
+    {
+        var isPrimary = string.Equals(
+            listedTicker,
+            stock.Ticker,
+            StringComparison.OrdinalIgnoreCase
+        );
+        return isPrimary
+            ? DbContext
+                .Set<CommonStockCusipAlias>()
+                .Where(a => a.CommonStockId == stock.Id)
+                .Select(a => a.Cusip)
+                .Union(
+                    DbContext
+                        .Set<CommonStock>()
+                        .Where(s => s.Id == stock.Id && s.Cusip != null)
+                        .Select(s => s.Cusip)
+                )
+            : DbContext
+                .Set<CommonStockListedCusip>()
+                .Where(c =>
+                    c.CommonStockId == stock.Id && c.ListedTicker == listedTicker
+                )
+                .Select(c => c.Cusip);
+    }
+
+    public Task<bool> HasCusipIdentity(
+        CommonStock stock,
+        string listedTicker,
+        CancellationToken cancellationToken = default
+    ) => GetCusipIdentity(stock, listedTicker).AnyAsync(cancellationToken);
 
     /// <summary>
     /// Filings of a sweep-discovered series, identified by registrant CIK and series id (an id-less

--- a/src/Equibles.Sec.Repositories/NportFilingRepository.cs
+++ b/src/Equibles.Sec.Repositories/NportFilingRepository.cs
@@ -105,9 +105,7 @@ public class NportFilingRepository : BaseRepository<NportFiling>
                 )
             : DbContext
                 .Set<CommonStockListedCusip>()
-                .Where(c =>
-                    c.CommonStockId == stock.Id && c.ListedTicker == listedTicker
-                )
+                .Where(c => c.CommonStockId == stock.Id && c.ListedTicker == listedTicker)
                 .Select(c => c.Cusip);
     }
 

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -399,9 +399,10 @@ public class ProfilesController : BaseController
             .TakeMostRecent(trade => trade.TransactionDate, RecentRowLimit)
             .Select(trade => new CongressTradeRowViewModel
             {
-                Ticker = trade.FiledTicker != ""
-                    ? trade.FiledTicker
-                    : trade.CommonStock != null ? trade.CommonStock.Ticker : null,
+                Ticker =
+                    trade.FiledTicker != "" ? trade.FiledTicker
+                    : trade.CommonStock != null ? trade.CommonStock.Ticker
+                    : null,
                 TransactionDate = trade.TransactionDate,
                 AssetName = trade.AssetName,
                 AssetType = trade.AssetType,

--- a/src/Equibles.Web/Controllers/ProfilesController.cs
+++ b/src/Equibles.Web/Controllers/ProfilesController.cs
@@ -399,7 +399,9 @@ public class ProfilesController : BaseController
             .TakeMostRecent(trade => trade.TransactionDate, RecentRowLimit)
             .Select(trade => new CongressTradeRowViewModel
             {
-                Ticker = trade.CommonStock != null ? trade.CommonStock.Ticker : trade.FiledTicker,
+                Ticker = trade.FiledTicker != ""
+                    ? trade.FiledTicker
+                    : trade.CommonStock != null ? trade.CommonStock.Ticker : null,
                 TransactionDate = trade.TransactionDate,
                 AssetName = trade.AssetName,
                 AssetType = trade.AssetType,

--- a/src/Equibles.Web/Controllers/ShortActivityController.cs
+++ b/src/Equibles.Web/Controllers/ShortActivityController.cs
@@ -68,7 +68,9 @@ public class ShortActivityController : BaseController
 
         var query = _shortInterestRepository
             .GetBySettlementDate(selectedDate)
-            .Include(s => s.CommonStock);
+            .Include(s => s.CommonStock)
+            // The OSS portal has no ETF shell. Keep its derived stock board primary-only.
+            .Where(s => s.ListedTicker == s.CommonStock.Ticker || s.ListedTicker == "");
 
         // Null DaysToCover coalesces to 0 so it sorts last under descending order.
         var ordered = sort switch

--- a/src/Equibles.Web/Controllers/ShortVolumeController.cs
+++ b/src/Equibles.Web/Controllers/ShortVolumeController.cs
@@ -71,6 +71,9 @@ public class ShortVolumeController : BaseController
         var query = _shortVolumeRepository
             .GetByDate(selectedDate)
             .Include(d => d.CommonStock)
+            // The OSS portal has no ETF shell. Keep its stock board primary-only so exact
+            // exchange-traded rows are neither duplicated nor mislabeled as the registrant.
+            .Where(d => d.ListedTicker == d.CommonStock.Ticker || d.ListedTicker == "")
             .Where(d => d.TotalVolume > 0);
 
         var ordered = sort switch

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -121,6 +121,9 @@ public class StockTabService
         return await _stockSplitRepository
             .GetEffectiveByStock(stock.Id, DateOnly.FromDateTime(DateTime.UtcNow))
             .AsNoTracking()
+            .Where(split =>
+                split.PriceSeriesTicker == null || split.PriceSeriesTicker == stock.Ticker
+            )
             .ToListAsync();
     }
 

--- a/src/Equibles.Worker/TickerMapService.cs
+++ b/src/Equibles.Worker/TickerMapService.cs
@@ -1,4 +1,6 @@
 using Equibles.CommonStocks.Repositories;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.Core.AutoWiring;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,5 +48,67 @@ public class TickerMapService
             comparer ?? StringComparer.OrdinalIgnoreCase,
             cancellationToken
         );
+    }
+
+    /// <summary>
+    /// Maps every current primary or authoritative exchange-traded reference ticker to its exact
+    /// listing identity. Duplicate ticker claims fail closed instead of selecting an arbitrary filer.
+    /// </summary>
+    public async Task<Dictionary<string, ListedSecurityKey>> BuildListed(
+        List<string> tickersToSync,
+        CancellationToken cancellationToken,
+        StringComparer comparer = null
+    )
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
+        var stocks = await stockRepo.GetAll()
+            .Where(stock => stock.Active)
+            .Select(stock => new { stock.Id, stock.Ticker, stock.ReferenceTickers })
+            .ToListAsync(cancellationToken);
+        var rawDelisted = await stockRepo.GetDelistedListings()
+            .Select(listing => new ListedSecurityKey(listing.CommonStockId, listing.ListedTicker))
+            .ToListAsync(cancellationToken);
+        var primaryByStock = stocks.ToDictionary(stock => stock.Id, stock => stock.Ticker);
+        var delistedSet = rawDelisted.Select(listing =>
+        {
+            var primary = primaryByStock.GetValueOrDefault(listing.CommonStockId);
+            var canonical = primary != null
+                && string.Equals(
+                    TickerNormalizer.NormalizeDashListed(listing.ListedTicker),
+                    TickerNormalizer.NormalizeDashListed(primary),
+                    StringComparison.OrdinalIgnoreCase
+                )
+                    ? primary
+                    : listing.ListedTicker;
+            return new ListedSecurityKey(listing.CommonStockId, canonical);
+        }).ToHashSet();
+        var requested = tickersToSync?.Count > 0
+            ? tickersToSync.ToHashSet(comparer ?? StringComparer.OrdinalIgnoreCase)
+            : null;
+        var claims = stocks
+            .SelectMany(stock => new[] { stock.Ticker }.Concat(stock.ReferenceTickers ?? [])
+                .Where(ticker => !string.IsNullOrWhiteSpace(ticker))
+                .Distinct(comparer ?? StringComparer.OrdinalIgnoreCase)
+                .Select(ticker => new KeyValuePair<string, ListedSecurityKey>(
+                    ticker,
+                    new ListedSecurityKey(
+                        stock.Id,
+                        string.Equals(
+                            TickerNormalizer.NormalizeDashListed(ticker),
+                            TickerNormalizer.NormalizeDashListed(stock.Ticker),
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                            ? stock.Ticker
+                            : ticker
+                    )
+                )))
+            .Where(claim => requested == null || requested.Contains(claim.Key))
+            .Where(claim => !delistedSet.Contains(claim.Value))
+            .GroupBy(claim => claim.Key, comparer ?? StringComparer.OrdinalIgnoreCase)
+            .Where(group => group.Select(claim => claim.Value.CommonStockId).Distinct().Count() == 1)
+            .Select(group => group.First());
+
+        return claims.ToDictionary(claim => claim.Key, claim => claim.Value, comparer ?? StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/Equibles.Worker/TickerMapService.cs
+++ b/src/Equibles.Worker/TickerMapService.cs
@@ -1,6 +1,6 @@
-using Equibles.CommonStocks.Repositories;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
 using Equibles.Core.AutoWiring;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -62,53 +62,73 @@ public class TickerMapService
     {
         using var scope = _scopeFactory.CreateScope();
         var stockRepo = scope.ServiceProvider.GetRequiredService<CommonStockRepository>();
-        var stocks = await stockRepo.GetAll()
+        var stocks = await stockRepo
+            .GetAll()
             .Where(stock => stock.Active)
-            .Select(stock => new { stock.Id, stock.Ticker, stock.ReferenceTickers })
+            .Select(stock => new
+            {
+                stock.Id,
+                stock.Ticker,
+                stock.ReferenceTickers,
+            })
             .ToListAsync(cancellationToken);
-        var rawDelisted = await stockRepo.GetDelistedListings()
+        var rawDelisted = await stockRepo
+            .GetDelistedListings()
             .Select(listing => new ListedSecurityKey(listing.CommonStockId, listing.ListedTicker))
             .ToListAsync(cancellationToken);
         var primaryByStock = stocks.ToDictionary(stock => stock.Id, stock => stock.Ticker);
-        var delistedSet = rawDelisted.Select(listing =>
-        {
-            var primary = primaryByStock.GetValueOrDefault(listing.CommonStockId);
-            var canonical = primary != null
-                && string.Equals(
-                    TickerNormalizer.NormalizeDashListed(listing.ListedTicker),
-                    TickerNormalizer.NormalizeDashListed(primary),
-                    StringComparison.OrdinalIgnoreCase
-                )
-                    ? primary
-                    : listing.ListedTicker;
-            return new ListedSecurityKey(listing.CommonStockId, canonical);
-        }).ToHashSet();
-        var requested = tickersToSync?.Count > 0
-            ? tickersToSync.ToHashSet(comparer ?? StringComparer.OrdinalIgnoreCase)
-            : null;
-        var claims = stocks
-            .SelectMany(stock => new[] { stock.Ticker }.Concat(stock.ReferenceTickers ?? [])
-                .Where(ticker => !string.IsNullOrWhiteSpace(ticker))
-                .Distinct(comparer ?? StringComparer.OrdinalIgnoreCase)
-                .Select(ticker => new KeyValuePair<string, ListedSecurityKey>(
-                    ticker,
-                    new ListedSecurityKey(
-                        stock.Id,
-                        string.Equals(
-                            TickerNormalizer.NormalizeDashListed(ticker),
-                            TickerNormalizer.NormalizeDashListed(stock.Ticker),
-                            StringComparison.OrdinalIgnoreCase
-                        )
-                            ? stock.Ticker
-                            : ticker
+        var delistedSet = rawDelisted
+            .Select(listing =>
+            {
+                var primary = primaryByStock.GetValueOrDefault(listing.CommonStockId);
+                var canonical =
+                    primary != null
+                    && string.Equals(
+                        TickerNormalizer.NormalizeDashListed(listing.ListedTicker),
+                        TickerNormalizer.NormalizeDashListed(primary),
+                        StringComparison.OrdinalIgnoreCase
                     )
-                )))
+                        ? primary
+                        : listing.ListedTicker;
+                return new ListedSecurityKey(listing.CommonStockId, canonical);
+            })
+            .ToHashSet();
+        var requested =
+            tickersToSync?.Count > 0
+                ? tickersToSync.ToHashSet(comparer ?? StringComparer.OrdinalIgnoreCase)
+                : null;
+        var claims = stocks
+            .SelectMany(stock =>
+                new[] { stock.Ticker }
+                    .Concat(stock.ReferenceTickers ?? [])
+                    .Where(ticker => !string.IsNullOrWhiteSpace(ticker))
+                    .Distinct(comparer ?? StringComparer.OrdinalIgnoreCase)
+                    .Select(ticker => new KeyValuePair<string, ListedSecurityKey>(
+                        ticker,
+                        new ListedSecurityKey(
+                            stock.Id,
+                            string.Equals(
+                                TickerNormalizer.NormalizeDashListed(ticker),
+                                TickerNormalizer.NormalizeDashListed(stock.Ticker),
+                                StringComparison.OrdinalIgnoreCase
+                            )
+                                ? stock.Ticker
+                                : ticker
+                        )
+                    ))
+            )
             .Where(claim => requested == null || requested.Contains(claim.Key))
             .Where(claim => !delistedSet.Contains(claim.Value))
             .GroupBy(claim => claim.Key, comparer ?? StringComparer.OrdinalIgnoreCase)
-            .Where(group => group.Select(claim => claim.Value.CommonStockId).Distinct().Count() == 1)
+            .Where(group =>
+                group.Select(claim => claim.Value.CommonStockId).Distinct().Count() == 1
+            )
             .Select(group => group.First());
 
-        return claims.ToDictionary(claim => claim.Key, claim => claim.Value, comparer ?? StringComparer.OrdinalIgnoreCase);
+        return claims.ToDictionary(
+            claim => claim.Key,
+            claim => claim.Value,
+            comparer ?? StringComparer.OrdinalIgnoreCase
+        );
     }
 }

--- a/src/Equibles.Yahoo.Repositories/DailyStockPriceRepository.cs
+++ b/src/Equibles.Yahoo.Repositories/DailyStockPriceRepository.cs
@@ -26,7 +26,7 @@ public class DailyStockPriceRepository : BaseRepository<DailyStockPrice>
     /// Every exact price series, including authoritative secondary tickers. The entity maps
     /// only to the isolated exact-listing table, so legacy ambiguous rows are never exposed.
     /// </summary>
-    public IQueryable<DailyStockPrice> GetAllSeries()
+    public virtual IQueryable<DailyStockPrice> GetAllSeries()
     {
         return base.GetAll();
     }

--- a/tests/Equibles.IntegrationTests/Finra/FinraImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraImportServiceTests.cs
@@ -110,6 +110,7 @@ public class ShortVolumeImportServiceTests : IDisposable
                 new DailyShortVolume
                 {
                     CommonStockId = stock.Id,
+                    ListedTicker = stock.Ticker,
                     Date = date,
                     ShortVolume = shortVolume,
                     ShortExemptVolume = 5_000,
@@ -129,7 +130,7 @@ public class ShortVolumeImportServiceTests : IDisposable
         _partitionRepo.Add(
             new FinraImportPartition
             {
-                Dataset = "daily-short-volume-files-v2",
+                Dataset = "daily-short-volume-files-v3",
                 PartitionDate = date,
                 ScopeKey = scopeKey,
                 ImportedAt = importedAt ?? Now.UtcDateTime,
@@ -139,10 +140,14 @@ public class ShortVolumeImportServiceTests : IDisposable
         _dbContext.ChangeTracker.Clear();
     }
 
-    private static string ResolveStockUniverse(params CommonStock[] stocks)
+    private static string ResolveListingUniverse(params CommonStock[] stocks)
     {
-        return FinraImportScope.ResolveStockUniverse(
-            stocks.ToDictionary(stock => stock.Ticker, stock => stock.Id, StringComparer.Ordinal)
+        return FinraImportScope.ResolveListingUniverse(
+            stocks.ToDictionary(
+                stock => stock.Ticker,
+                stock => new ListedSecurityKey(stock.Id, stock.Ticker),
+                StringComparer.Ordinal
+            )
         );
     }
 
@@ -276,7 +281,7 @@ public class ShortVolumeImportServiceTests : IDisposable
         var today = DateOnly.FromDateTime(Now.UtcDateTime);
         _workerOptions.MinSyncDate = today.ToDateTime(TimeOnly.MinValue);
         await SeedVolume(apple, today);
-        await SeedCompletedPartition(today, ResolveStockUniverse(apple));
+        await SeedCompletedPartition(today, ResolveListingUniverse(apple));
 
         await _service.Import(CancellationToken.None);
 
@@ -298,9 +303,41 @@ public class ShortVolumeImportServiceTests : IDisposable
 
         await _finraClient.Received(1).GetDailyShortVolume(today);
         _partitionRepo
-            .GetPartition("daily-short-volume-files-v2", ResolveStockUniverse(apple), today)
+            .GetPartition("daily-short-volume-files-v3", ResolveListingUniverse(apple), today)
             .Should()
             .ContainSingle();
+    }
+
+    [Fact]
+    public async Task Import_ConfiguredSubset_WritesFilteredIdentityMarker()
+    {
+        var apple = CreateStock("AAPL", "Apple Inc.");
+        await SeedStocks(apple);
+
+        var today = DateOnly.FromDateTime(Now.UtcDateTime);
+        _workerOptions.MinSyncDate = today.ToDateTime(TimeOnly.MinValue);
+        _workerOptions.TickersToSync = ["AAPL"];
+        _finraClient.GetDailyShortVolume(today).Returns(new List<ShortVolumeRecord>());
+        var listings = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal)
+        {
+            ["AAPL"] = new(apple.Id, "AAPL"),
+        };
+        var filteredScope = FinraImportScope.ResolveListingImportScope(
+            listings,
+            _workerOptions.TickersToSync
+        );
+
+        await _service.Import(CancellationToken.None);
+
+        filteredScope.Should().StartWith("listing-filter:");
+        _partitionRepo
+            .GetPartition("daily-short-volume-files-v3", filteredScope, today)
+            .Should()
+            .ContainSingle();
+        _partitionRepo
+            .GetPartition("daily-short-volume-files-v3", ResolveListingUniverse(apple), today)
+            .Should()
+            .BeEmpty();
     }
 
     [Fact]
@@ -336,8 +373,8 @@ public class ShortVolumeImportServiceTests : IDisposable
         volumes.Should().Contain(v => v.CommonStockId == microsoft.Id && v.ShortVolume == 300_000);
         _partitionRepo
             .GetPartition(
-                "daily-short-volume-files-v2",
-                ResolveStockUniverse(apple, microsoft),
+                "daily-short-volume-files-v3",
+                ResolveListingUniverse(apple, microsoft),
                 existingDate
             )
             .Should()
@@ -780,6 +817,7 @@ public class ShortInterestImportServiceTests : IDisposable
                 new ShortInterest
                 {
                     CommonStockId = stock.Id,
+                    ListedTicker = stock.Ticker,
                     SettlementDate = settlementDate,
                     CurrentShortPosition = currentShort,
                     PreviousShortPosition = 9_000_000,

--- a/tests/Equibles.IntegrationTests/Finra/FinraRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraRepositoryTests.cs
@@ -46,12 +46,14 @@ public class DailyShortVolumeRepositoryTests : IDisposable
         long shortVolume = 1_000_000,
         long shortExemptVolume = 5_000,
         long totalVolume = 5_000_000,
-        string market = "TRF"
+        string market = "TRF",
+        string listedTicker = ""
     )
     {
         return new DailyShortVolume
         {
             CommonStockId = stock.Id,
+            ListedTicker = listedTicker,
             Date = date,
             ShortVolume = shortVolume,
             ShortExemptVolume = shortExemptVolume,
@@ -112,6 +114,22 @@ public class DailyShortVolumeRepositoryTests : IDisposable
         var result = await _repository.GetHistoryByStock(apple).ToListAsync();
 
         result.Should().ContainSingle().Which.CommonStockId.Should().Be(apple.Id);
+    }
+
+    [Fact]
+    public async Task GetHistoryByListing_SeparatesEtfsCarriedByOneFiler()
+    {
+        var trust = CreateStock("VB", "Vanguard Index Funds");
+        var date = new DateOnly(2025, 1, 2);
+        _dbContext.Set<DailyShortVolume>().AddRange(
+            CreateVolume(trust, date, listedTicker: "VOO"),
+            CreateVolume(trust, date, listedTicker: "VTI")
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repository.GetHistoryByListing(trust, "VOO").ToListAsync();
+
+        result.Should().ContainSingle().Which.ListedTicker.Should().Be("VOO");
     }
 
     // -- GetByStock (date filter) -----------------------------------------
@@ -283,12 +301,14 @@ public class ShortInterestRepositoryTests : IDisposable
         long previousShortPosition = 9_500_000,
         long changeInShortPosition = 500_000,
         long? averageDailyVolume = 3_000_000,
-        decimal? daysToCover = 3.3m
+        decimal? daysToCover = 3.3m,
+        string listedTicker = ""
     )
     {
         return new ShortInterest
         {
             CommonStockId = stock.Id,
+            ListedTicker = listedTicker,
             SettlementDate = settlementDate,
             CurrentShortPosition = currentShortPosition,
             PreviousShortPosition = previousShortPosition,
@@ -350,6 +370,22 @@ public class ShortInterestRepositoryTests : IDisposable
         var result = await _repository.GetHistoryByStock(apple).ToListAsync();
 
         result.Should().ContainSingle().Which.CommonStockId.Should().Be(apple.Id);
+    }
+
+    [Fact]
+    public async Task GetHistoryByListing_SeparatesEtfsCarriedByOneFiler()
+    {
+        var trust = CreateStock("VB", "Vanguard Index Funds");
+        var date = new DateOnly(2025, 1, 15);
+        _dbContext.Set<ShortInterest>().AddRange(
+            CreateInterest(trust, date, listedTicker: "VOO"),
+            CreateInterest(trust, date, listedTicker: "VTI")
+        );
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repository.GetHistoryByListing(trust, "VTI").ToListAsync();
+
+        result.Should().ContainSingle().Which.ListedTicker.Should().Be("VTI");
     }
 
     // -- GetByStock (settlement date filter) ------------------------------

--- a/tests/Equibles.IntegrationTests/Finra/FinraRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/FinraRepositoryTests.cs
@@ -121,10 +121,12 @@ public class DailyShortVolumeRepositoryTests : IDisposable
     {
         var trust = CreateStock("VB", "Vanguard Index Funds");
         var date = new DateOnly(2025, 1, 2);
-        _dbContext.Set<DailyShortVolume>().AddRange(
-            CreateVolume(trust, date, listedTicker: "VOO"),
-            CreateVolume(trust, date, listedTicker: "VTI")
-        );
+        _dbContext
+            .Set<DailyShortVolume>()
+            .AddRange(
+                CreateVolume(trust, date, listedTicker: "VOO"),
+                CreateVolume(trust, date, listedTicker: "VTI")
+            );
         await _dbContext.SaveChangesAsync();
 
         var result = await _repository.GetHistoryByListing(trust, "VOO").ToListAsync();
@@ -377,10 +379,12 @@ public class ShortInterestRepositoryTests : IDisposable
     {
         var trust = CreateStock("VB", "Vanguard Index Funds");
         var date = new DateOnly(2025, 1, 15);
-        _dbContext.Set<ShortInterest>().AddRange(
-            CreateInterest(trust, date, listedTicker: "VOO"),
-            CreateInterest(trust, date, listedTicker: "VTI")
-        );
+        _dbContext
+            .Set<ShortInterest>()
+            .AddRange(
+                CreateInterest(trust, date, listedTicker: "VOO"),
+                CreateInterest(trust, date, listedTicker: "VTI")
+            );
         await _dbContext.SaveChangesAsync();
 
         var result = await _repository.GetHistoryByListing(trust, "VTI").ToListAsync();

--- a/tests/Equibles.IntegrationTests/Finra/OffExchangeVolumeImportServiceBackfillTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/OffExchangeVolumeImportServiceBackfillTests.cs
@@ -160,11 +160,10 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
 
         await _service.Import(CancellationToken.None);
 
-        _partitionRepo.GetPartition(
-            "off-exchange-weekly-v4",
-            ResolveListingUniverse(apple),
-            week
-        ).Should().BeEmpty();
+        _partitionRepo
+            .GetPartition("off-exchange-weekly-v4", ResolveListingUniverse(apple), week)
+            .Should()
+            .BeEmpty();
         _volumeRepo.GetByWeek(week).Should().BeEmpty();
 
         await _service.Import(CancellationToken.None);
@@ -172,11 +171,10 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
         var row = _volumeRepo.GetByWeek(week).Single(v => v.CommonStockId == apple.Id);
         row.AtsVolume.Should().Be(5_000);
         row.NonAtsOtcVolume.Should().Be(3_000);
-        _partitionRepo.GetPartition(
-            "off-exchange-weekly-v4",
-            ResolveListingUniverse(apple),
-            week
-        ).Should().ContainSingle();
+        _partitionRepo
+            .GetPartition("off-exchange-weekly-v4", ResolveListingUniverse(apple), week)
+            .Should()
+            .ContainSingle();
 
         _finraClient.ClearReceivedCalls();
         await _service.Import(CancellationToken.None);

--- a/tests/Equibles.IntegrationTests/Finra/OffExchangeVolumeImportServiceBackfillTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/OffExchangeVolumeImportServiceBackfillTests.cs
@@ -103,6 +103,7 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
                 new OffExchangeVolume
                 {
                     CommonStockId = apple.Id,
+                    ListedTicker = apple.Ticker,
                     WeekStartDate = storedWeek,
                     AtsVolume = 1,
                     NonAtsOtcVolume = 1,
@@ -110,7 +111,7 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
             );
         await _dbContext.SaveChangesAsync();
         _dbContext.ChangeTracker.Clear();
-        await SeedCompletedPartition(storedWeek);
+        await SeedCompletedPartition(apple, storedWeek);
 
         _workerOptions.MinSyncDate = backfillWeek.ToDateTime(TimeOnly.MinValue);
 
@@ -159,7 +160,11 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
 
         await _service.Import(CancellationToken.None);
 
-        _partitionRepo.GetPartition("off-exchange-weekly-v3", "all", week).Should().BeEmpty();
+        _partitionRepo.GetPartition(
+            "off-exchange-weekly-v4",
+            ResolveListingUniverse(apple),
+            week
+        ).Should().BeEmpty();
         _volumeRepo.GetByWeek(week).Should().BeEmpty();
 
         await _service.Import(CancellationToken.None);
@@ -167,7 +172,11 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
         var row = _volumeRepo.GetByWeek(week).Single(v => v.CommonStockId == apple.Id);
         row.AtsVolume.Should().Be(5_000);
         row.NonAtsOtcVolume.Should().Be(3_000);
-        _partitionRepo.GetPartition("off-exchange-weekly-v3", "all", week).Should().ContainSingle();
+        _partitionRepo.GetPartition(
+            "off-exchange-weekly-v4",
+            ResolveListingUniverse(apple),
+            week
+        ).Should().ContainSingle();
 
         _finraClient.ClearReceivedCalls();
         await _service.Import(CancellationToken.None);
@@ -196,6 +205,7 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
                 new OffExchangeVolume
                 {
                     CommonStockId = apple.Id,
+                    ListedTicker = apple.Ticker,
                     WeekStartDate = week,
                     AtsVolume = 9_000,
                     AtsTradeCount = 90,
@@ -205,7 +215,7 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
             );
         await _dbContext.SaveChangesAsync();
         _dbContext.ChangeTracker.Clear();
-        await SeedCompletedPartition(week, previousImport);
+        await SeedCompletedPartition(apple, week, previousImport);
 
         _finraClient
             .GetWeeklyOffExchangeVolume(Arg.Any<DateOnly>())
@@ -222,26 +232,38 @@ public class OffExchangeVolumeImportServiceBackfillTests : IDisposable
         row.NonAtsOtcVolume.Should().Be(4_000);
         row.NonAtsOtcTradeCount.Should().Be(40);
         _partitionRepo
-            .GetPartition("off-exchange-weekly-v3", "all", week)
+            .GetPartition("off-exchange-weekly-v4", ResolveListingUniverse(apple), week)
             .Single()
             .ImportedAt.Should()
             .Be(previousImport);
     }
 
-    private async Task SeedCompletedPartition(DateOnly week, DateTime? importedAt = null)
+    private async Task SeedCompletedPartition(
+        CommonStock stock,
+        DateOnly week,
+        DateTime? importedAt = null
+    )
     {
         _partitionRepo.Add(
             new FinraImportPartition
             {
-                Dataset = "off-exchange-weekly-v3",
+                Dataset = "off-exchange-weekly-v4",
                 PartitionDate = week,
-                ScopeKey = "all",
+                ScopeKey = ResolveListingUniverse(stock),
                 ImportedAt = importedAt ?? Now.UtcDateTime,
             }
         );
         await _partitionRepo.SaveChanges();
         _dbContext.ChangeTracker.Clear();
     }
+
+    private static string ResolveListingUniverse(CommonStock stock) =>
+        FinraImportScope.ResolveListingUniverse(
+            new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal)
+            {
+                [stock.Ticker] = new(stock.Id, stock.Ticker),
+            }
+        );
 
     private static List<OffExchangeWeeklyRecord> MakeRecords(long ats, long otc) =>
         [

--- a/tests/Equibles.IntegrationTests/Finra/ShortInterestImportServiceFilteredFetchTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortInterestImportServiceFilteredFetchTests.cs
@@ -55,6 +55,7 @@ public class ShortInterestImportServiceFilteredFetchTests : ParadeDbMcpTestBase
             new ShortInterest
             {
                 CommonStockId = have.Id,
+                ListedTicker = have.Ticker,
                 SettlementDate = settlementDate,
                 CurrentShortPosition = 1,
             }

--- a/tests/Equibles.IntegrationTests/Finra/ShortVolumeImportServiceCollisionRowHealTests.cs
+++ b/tests/Equibles.IntegrationTests/Finra/ShortVolumeImportServiceCollisionRowHealTests.cs
@@ -53,6 +53,7 @@ public class ShortVolumeImportServiceCollisionRowHealTests : ParadeDbMcpTestBase
             new DailyShortVolume
             {
                 CommonStockId = _stock.Id,
+                ListedTicker = _stock.Ticker,
                 Date = _corruptDate,
                 ShortVolume = 5_000,
                 TotalVolume = 9_000,

--- a/tests/Equibles.IntegrationTests/Integrations/TickerMapServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Integrations/TickerMapServiceTests.cs
@@ -1,6 +1,6 @@
 using Equibles.CommonStocks.Data;
-using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Data.Helpers;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Data;
 using Equibles.IntegrationTests.Helpers;
@@ -253,9 +253,11 @@ public class TickerMapServiceTests : IDisposable
 
         var result = await _service.BuildListed(["VOO"], CancellationToken.None);
 
-        result.Should().ContainSingle().Which.Should().Be(
-            new KeyValuePair<string, ListedSecurityKey>("VOO", new(trust.Id, "VOO"))
-        );
+        result
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(new KeyValuePair<string, ListedSecurityKey>("VOO", new(trust.Id, "VOO")));
     }
 
     [Fact]
@@ -279,12 +281,14 @@ public class TickerMapServiceTests : IDisposable
         var stock = CreateStock("BRK-B", "Berkshire Hathaway");
         stock.ReferenceTickers = ["BRK.B"];
         await SeedStocks(stock);
-        _stockRepo.AddDelistedListing(new CommonStockDelistedListing
-        {
-            CommonStockId = stock.Id,
-            ListedTicker = "BRK.B",
-            DelistedOn = new DateOnly(2026, 1, 1),
-        });
+        _stockRepo.AddDelistedListing(
+            new CommonStockDelistedListing
+            {
+                CommonStockId = stock.Id,
+                ListedTicker = "BRK.B",
+                DelistedOn = new DateOnly(2026, 1, 1),
+            }
+        );
         await _stockRepo.SaveChanges();
 
         var result = await _service.BuildListed(null, CancellationToken.None);
@@ -299,12 +303,14 @@ public class TickerMapServiceTests : IDisposable
         var trust = CreateStock("OLD", "Trust With Active Series");
         trust.ReferenceTickers = ["LIVEETF"];
         await SeedStocks(trust);
-        _stockRepo.AddDelistedListing(new CommonStockDelistedListing
-        {
-            CommonStockId = trust.Id,
-            ListedTicker = trust.Ticker,
-            DelistedOn = new DateOnly(2026, 1, 1),
-        });
+        _stockRepo.AddDelistedListing(
+            new CommonStockDelistedListing
+            {
+                CommonStockId = trust.Id,
+                ListedTicker = trust.Ticker,
+                DelistedOn = new DateOnly(2026, 1, 1),
+            }
+        );
         await _stockRepo.SaveChanges();
 
         var result = await _service.BuildListed(null, CancellationToken.None);

--- a/tests/Equibles.IntegrationTests/Integrations/TickerMapServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Integrations/TickerMapServiceTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Data.Helpers;
 using Equibles.CommonStocks.Repositories;
 using Equibles.Data;
 using Equibles.IntegrationTests.Helpers;
@@ -228,6 +229,101 @@ public class TickerMapServiceTests : IDisposable
         var result = await _clientEvalService.Build(["BRK.B"], CancellationToken.None);
 
         result.Should().ContainSingle().Which.Value.Should().Be(brk.Id);
+    }
+
+    [Fact]
+    public async Task BuildListed_MapsAuthoritativeEtfTickerToExactListingIdentity()
+    {
+        var trust = CreateStock("VB", "Vanguard Index Funds");
+        trust.ReferenceTickers = ["VB", "VOO", "VTI"];
+        await SeedStocks(trust);
+
+        var result = await _service.BuildListed(null, CancellationToken.None);
+
+        result["VOO"].Should().Be(new ListedSecurityKey(trust.Id, "VOO"));
+        result["VTI"].Should().Be(new ListedSecurityKey(trust.Id, "VTI"));
+    }
+
+    [Fact]
+    public async Task BuildListed_FilterKeepsOnlyRequestedExactListing()
+    {
+        var trust = CreateStock("VB", "Vanguard Index Funds");
+        trust.ReferenceTickers = ["VB", "VOO", "VTI"];
+        await SeedStocks(trust);
+
+        var result = await _service.BuildListed(["VOO"], CancellationToken.None);
+
+        result.Should().ContainSingle().Which.Should().Be(
+            new KeyValuePair<string, ListedSecurityKey>("VOO", new(trust.Id, "VOO"))
+        );
+    }
+
+    [Fact]
+    public async Task BuildListed_DuplicateTickerClaimsFailClosed()
+    {
+        var first = CreateStock("ONE", "First Trust");
+        first.ReferenceTickers = ["CLASH"];
+        var second = CreateStock("TWO", "Second Trust");
+        second.ReferenceTickers = ["CLASH"];
+        await SeedStocks(first, second);
+
+        var result = await _service.BuildListed(null, CancellationToken.None);
+
+        result.Should().NotContainKey("CLASH");
+        result.Should().ContainKeys("ONE", "TWO");
+    }
+
+    [Fact]
+    public async Task BuildListed_DotDashPrimaryAliasCannotEvadeDelisting()
+    {
+        var stock = CreateStock("BRK-B", "Berkshire Hathaway");
+        stock.ReferenceTickers = ["BRK.B"];
+        await SeedStocks(stock);
+        _stockRepo.AddDelistedListing(new CommonStockDelistedListing
+        {
+            CommonStockId = stock.Id,
+            ListedTicker = "BRK.B",
+            DelistedOn = new DateOnly(2026, 1, 1),
+        });
+        await _stockRepo.SaveChanges();
+
+        var result = await _service.BuildListed(null, CancellationToken.None);
+
+        result.Should().NotContainKey("BRK-B");
+        result.Should().NotContainKey("BRK.B");
+    }
+
+    [Fact]
+    public async Task BuildListed_DelistedPrimaryDoesNotHideActiveSiblingListing()
+    {
+        var trust = CreateStock("OLD", "Trust With Active Series");
+        trust.ReferenceTickers = ["LIVEETF"];
+        await SeedStocks(trust);
+        _stockRepo.AddDelistedListing(new CommonStockDelistedListing
+        {
+            CommonStockId = trust.Id,
+            ListedTicker = trust.Ticker,
+            DelistedOn = new DateOnly(2026, 1, 1),
+        });
+        await _stockRepo.SaveChanges();
+
+        var result = await _service.BuildListed(null, CancellationToken.None);
+
+        result.Should().NotContainKey("OLD");
+        result["LIVEETF"].Should().Be(new ListedSecurityKey(trust.Id, "LIVEETF"));
+    }
+
+    [Fact]
+    public async Task BuildListed_AcceptsTheFullListedTickerContractLength()
+    {
+        var ticker = new string('X', TickerNormalizer.MaxListedLength);
+        var trust = CreateStock("FUND", "Long Symbol Trust");
+        trust.ReferenceTickers = [ticker];
+        await SeedStocks(trust);
+
+        var result = await _service.BuildListed([ticker], CancellationToken.None);
+
+        result[ticker].Should().Be(new ListedSecurityKey(trust.Id, ticker));
     }
 
     // ── Build handles many stocks ─────────────────────────────────────

--- a/tests/Equibles.IntegrationTests/Mcp/NportFundsHoldingStockToolTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/NportFundsHoldingStockToolTests.cs
@@ -139,7 +139,8 @@ public class NportFundsHoldingStockToolTests : IDisposable
 
         var result = await _tools.GetFundsHoldingStock("AAPL");
 
-        result.Should().Contain("APPLE # SYNTHETIC \\| INC");
+        result.Should().Contain("Funds holding AAPL");
+        result.Should().NotContain("SYNTHETIC");
         result.Should().Contain("VANGUARD # ROW \\| TRUST");
         result.Should().Contain("INDEX  FUND \\| EXTRA");
         result.Should().Contain("N\\|S EXTRA");

--- a/tests/Equibles.IntegrationTests/Mcp/OffExchangeVolumeToolsGetOffExchangeVolumeCultureInvarianceTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/OffExchangeVolumeToolsGetOffExchangeVolumeCultureInvarianceTests.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
@@ -16,6 +17,7 @@ public class OffExchangeVolumeToolsGetOffExchangeVolumeCultureInvarianceTests : 
         new(
             new OffExchangeVolumeRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<OffExchangeVolumeTools>()
         );

--- a/tests/Equibles.IntegrationTests/Mcp/OffExchangeVolumeToolsStrictDatesAndTruncationTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/OffExchangeVolumeToolsStrictDatesAndTruncationTests.cs
@@ -1,5 +1,6 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Repositories;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.Mcp.Tools;
 using Equibles.Finra.Repositories;
@@ -22,6 +23,7 @@ public class OffExchangeVolumeToolsStrictDatesAndTruncationTests : ParadeDbMcpTe
         new(
             new OffExchangeVolumeRepository(DbContext),
             new CommonStockRepository(DbContext),
+            new StockSplitRepository(DbContext),
             ErrorManager,
             NullLogger<OffExchangeVolumeTools>()
         );
@@ -69,16 +71,18 @@ public class OffExchangeVolumeToolsStrictDatesAndTruncationTests : ParadeDbMcpTe
     }
 
     [Fact]
-    public async Task GetOffExchangeVolume_SecondaryListing_DoesNotReturnPrimarySeries()
+    public async Task GetOffExchangeVolume_SecondaryListing_WithNoExactRows_DoesNotReturnPrimarySeries()
     {
         var stock = AddGme();
         stock.SecondaryTickers = ["GME-A"];
+        AddWeek(stock, new DateOnly(2026, 3, 16));
         await DbContext.SaveChangesAsync();
 
         var result = await Sut().GetOffExchangeVolume("GME-A");
 
-        result.Should().Contain("No exact off-exchange-volume series is available for GME-A");
-        result.Should().Contain("GME's FINRA rows are not substituted");
+        result.Should().Contain("No off-exchange volume data found for GME-A");
+        result.Should().NotContain("2026-03-16");
+        result.Should().NotContain("5,000,000");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -119,8 +119,9 @@ public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
 
         var result = await Sut().GetShortSqueezeScores(ticker: "SOXX");
 
-        result.Should().Contain("No exact short-squeeze score series is available for SOXX");
-        result.Should().Contain("AAXJ's FINRA rows are not substituted");
+        result.Should().Contain("No short-squeeze score model is available for SOXX");
+        result.Should().Contain("raw FINRA series is listing-specific");
+        result.Should().Contain("issuer-level shares outstanding and primary-listing market factors");
         result.Should().NotContain("No short-squeeze scores available");
     }
 

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsGetShortSqueezeScoresTests.cs
@@ -121,7 +121,9 @@ public class ShortDataToolsGetShortSqueezeScoresTests : ParadeDbMcpTestBase
 
         result.Should().Contain("No short-squeeze score model is available for SOXX");
         result.Should().Contain("raw FINRA series is listing-specific");
-        result.Should().Contain("issuer-level shares outstanding and primary-listing market factors");
+        result
+            .Should()
+            .Contain("issuer-level shares outstanding and primary-listing market factors");
         result.Should().NotContain("No short-squeeze scores available");
     }
 

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsHistoryOutputNotesTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsHistoryOutputNotesTests.cs
@@ -90,6 +90,7 @@ public class ShortDataToolsHistoryOutputNotesTests : ParadeDbMcpTestBase
                 {
                     CommonStock = stock,
                     CommonStockId = stock.Id,
+                    ListedTicker = stock.Ticker,
                     SettlementDate = settlementDate,
                     CurrentShortPosition = position,
                     PreviousShortPosition = previous,
@@ -218,6 +219,47 @@ public class ShortDataToolsHistoryOutputNotesTests : ParadeDbMcpTestBase
         // The straddle row's Change reconciles with the adjacent restated positions.
         result.Should().Contain("+500,000");
         result.Should().NotContain("+5,000,000");
+    }
+
+    [Fact]
+    public async Task GetShortInterest_OneSettlementRange_UsesPreRangeRowForSplitChange()
+    {
+        var stock = AddGme();
+        AddShortInterest(
+            stock,
+            new DateOnly(2026, 2, 27),
+            position: 500_000,
+            previous: 450_000,
+            change: 50_000
+        );
+        AddShortInterest(
+            stock,
+            new DateOnly(2026, 3, 13),
+            position: 5_500_000,
+            previous: 500_000,
+            change: 5_000_000
+        );
+        DbContext.Set<StockSplit>().Add(new StockSplit
+        {
+            CommonStock = stock,
+            CommonStockId = stock.Id,
+            PriceSeriesTicker = stock.Ticker,
+            EffectiveDate = new DateOnly(2026, 3, 1),
+            Numerator = 10m,
+            Denominator = 1m,
+            Source = StockSplitSource.Manual,
+        });
+        await DbContext.SaveChangesAsync();
+
+        var result = await Sut().GetShortInterest(
+            "GME",
+            startDate: "2026-03-13",
+            endDate: "2026-03-13"
+        );
+
+        result.Should().Contain("+500,000");
+        result.Should().NotContain("+5,000,000");
+        result.Should().NotContain("| 2026-02-27");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsHistoryOutputNotesTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsHistoryOutputNotesTests.cs
@@ -239,23 +239,24 @@ public class ShortDataToolsHistoryOutputNotesTests : ParadeDbMcpTestBase
             previous: 500_000,
             change: 5_000_000
         );
-        DbContext.Set<StockSplit>().Add(new StockSplit
-        {
-            CommonStock = stock,
-            CommonStockId = stock.Id,
-            PriceSeriesTicker = stock.Ticker,
-            EffectiveDate = new DateOnly(2026, 3, 1),
-            Numerator = 10m,
-            Denominator = 1m,
-            Source = StockSplitSource.Manual,
-        });
+        DbContext
+            .Set<StockSplit>()
+            .Add(
+                new StockSplit
+                {
+                    CommonStock = stock,
+                    CommonStockId = stock.Id,
+                    PriceSeriesTicker = stock.Ticker,
+                    EffectiveDate = new DateOnly(2026, 3, 1),
+                    Numerator = 10m,
+                    Denominator = 1m,
+                    Source = StockSplitSource.Manual,
+                }
+            );
         await DbContext.SaveChangesAsync();
 
-        var result = await Sut().GetShortInterest(
-            "GME",
-            startDate: "2026-03-13",
-            endDate: "2026-03-13"
-        );
+        var result = await Sut()
+            .GetShortInterest("GME", startDate: "2026-03-13", endDate: "2026-03-13");
 
         result.Should().Contain("+500,000");
         result.Should().NotContain("+5,000,000");

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
@@ -89,7 +89,8 @@ public class ShortDataToolsTests : ParadeDbMcpTestBase
         stock.SecondaryTickers = ["GME-A"];
         DbContext.AddRange(
             stock,
-            new DailyShortVolume {
+            new DailyShortVolume
+            {
                 CommonStock = stock,
                 CommonStockId = stock.Id,
                 Date = DateOnly.FromDateTime(DateTime.UtcNow),
@@ -233,7 +234,8 @@ public class ShortDataToolsTests : ParadeDbMcpTestBase
         stock.SecondaryTickers = ["GME-A"];
         DbContext.AddRange(
             stock,
-            new ShortInterest {
+            new ShortInterest
+            {
                 CommonStock = stock,
                 CommonStockId = stock.Id,
                 SettlementDate = DateOnly.FromDateTime(DateTime.UtcNow),

--- a/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/ShortDataToolsTests.cs
@@ -87,13 +87,22 @@ public class ShortDataToolsTests : ParadeDbMcpTestBase
     {
         var stock = GmeStock();
         stock.SecondaryTickers = ["GME-A"];
-        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.AddRange(
+            stock,
+            new DailyShortVolume {
+                CommonStock = stock,
+                CommonStockId = stock.Id,
+                Date = DateOnly.FromDateTime(DateTime.UtcNow),
+                ShortVolume = 100,
+                TotalVolume = 200,
+            }
+        );
         await DbContext.SaveChangesAsync();
 
         var result = await Sut().GetShortVolume("GME-A");
 
-        result.Should().Contain("No exact short-volume series is available for GME-A");
-        result.Should().Contain("GME's FINRA rows are not substituted");
+        result.Should().Contain("No short volume data found for GME-A");
+        result.Should().NotContain("100");
     }
 
     [Fact]
@@ -222,13 +231,21 @@ public class ShortDataToolsTests : ParadeDbMcpTestBase
     {
         var stock = GmeStock();
         stock.SecondaryTickers = ["GME-A"];
-        DbContext.Set<CommonStock>().Add(stock);
+        DbContext.AddRange(
+            stock,
+            new ShortInterest {
+                CommonStock = stock,
+                CommonStockId = stock.Id,
+                SettlementDate = DateOnly.FromDateTime(DateTime.UtcNow),
+                CurrentShortPosition = 100,
+            }
+        );
         await DbContext.SaveChangesAsync();
 
         var result = await Sut().GetShortInterest("GME-A");
 
-        result.Should().Contain("No exact short-interest series is available for GME-A");
-        result.Should().Contain("GME's FINRA rows are not substituted");
+        result.Should().Contain("No short interest data found for GME-A");
+        result.Should().NotContain("100");
     }
 
     [Fact]

--- a/tests/Equibles.IntegrationTests/Sec/FailToDeliverUpsertWhenMatchedTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FailToDeliverUpsertWhenMatchedTests.cs
@@ -19,7 +19,7 @@ public class FailToDeliverUpsertWhenMatchedTests : ParadeDbMcpTestBase
         : base(fixture) { }
 
     [Fact]
-    public async Task UpsertRange_OnCommonStockIdAndSettlementDate_WhenMatched_OverwritesExistingRowQuantityAndPrice()
+    public async Task UpsertRange_OnExactListingAndSettlementDate_WhenMatched_OverwritesExistingRowQuantityAndPrice()
     {
         var stock = new CommonStock
         {
@@ -32,6 +32,7 @@ public class FailToDeliverUpsertWhenMatchedTests : ParadeDbMcpTestBase
         var existing = new FailToDeliver
         {
             CommonStockId = stock.Id,
+            ListedTicker = stock.Ticker,
             SettlementDate = settlementDate,
             Quantity = 999,
             Price = 10.00m,
@@ -48,12 +49,18 @@ public class FailToDeliverUpsertWhenMatchedTests : ParadeDbMcpTestBase
                 new FailToDeliver
                 {
                     CommonStockId = stock.Id,
+                    ListedTicker = stock.Ticker,
                     SettlementDate = settlementDate,
                     Quantity = 12345,
                     Price = 187.50m,
                 },
             ])
-            .On(f => new { f.CommonStockId, f.SettlementDate })
+            .On(f => new
+            {
+                f.CommonStockId,
+                f.ListedTicker,
+                f.SettlementDate,
+            })
             .WhenMatched(
                 (existing, incoming) =>
                     new FailToDeliver { Quantity = incoming.Quantity, Price = incoming.Price }

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -952,10 +952,11 @@ public class YahooPriceImportServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Import_SecondaryListingSplit_RebasesOnlyThatListedSeries()
+    public async Task Import_SecondaryEtfSplit_CapturesAndRebasesOnlyThatListedSeries()
     {
         var alphabet = CreateStock("GOOGL", "Alphabet Inc.");
         alphabet.SecondaryTickers = ["GOOG"];
+        alphabet.ReferenceTickers = ["GOOG"];
         await SeedStocks(alphabet);
 
         var existingDate = new DateOnly(2026, 3, 20);
@@ -995,7 +996,11 @@ public class YahooPriceImportServiceTests : IDisposable
         primary.Should().ContainSingle().Which.Close.Should().Be(190m);
         secondary.Select(p => p.Close).Should().Equal(87.5m, 88m);
         secondary.Should().AllSatisfy(p => p.ListedTicker.Should().Be("GOOG"));
-        _splitRepo.GetAll().Should().BeEmpty("a sibling class split is not issuer-wide");
+        var split = _splitRepo.GetAll().Should().ContainSingle().Which;
+        split.PriceSeriesTicker.Should().Be("GOOG");
+        split.EffectiveDate.Should().Be(nextDate);
+        split.Numerator.Should().Be(2m);
+        split.Denominator.Should().Be(1m);
         await _yahooClient.Received(1).GetChart("GOOG", floor, Arg.Any<DateOnly>());
     }
 

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -957,6 +957,7 @@ public class YahooPriceImportServiceTests : IDisposable
         var alphabet = CreateStock("GOOGL", "Alphabet Inc.");
         alphabet.SecondaryTickers = ["GOOG"];
         alphabet.ReferenceTickers = ["GOOG"];
+        alphabet.PriceHistoryBackfilledTickers = ["GOOG"];
         await SeedStocks(alphabet);
 
         var existingDate = new DateOnly(2026, 3, 20);

--- a/tests/Equibles.UnitTests/CorporateActions/StockSplitCaptureManagerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/StockSplitCaptureManagerTests.cs
@@ -45,7 +45,7 @@ public class StockSplitCaptureManagerTests
         };
 
     [Fact]
-    public async Task Capture_StalePrimaryTargetAfterReorder_DoesNotWriteIssuerAction()
+    public async Task Capture_CurrentSecondaryTarget_WritesExactSeriesAction()
     {
         await using var context = NewDb();
         var stock = new CommonStock
@@ -57,22 +57,22 @@ public class StockSplitCaptureManagerTests
         context.Add(stock);
         await context.SaveChangesAsync();
 
-        // The crawl originally saw GOOGL as primary. By the write boundary it is secondary, so
-        // only the exact price series may be updated; the issuer-level action must be skipped.
-        var staleWrite = await NewManager(context).Capture(stock.Id, "GOOGL", [Split()]);
+        var secondaryWrite = await NewManager(context).Capture(stock.Id, "GOOGL", [Split()]);
 
-        staleWrite.Should().Be(0);
-        (await context.Set<StockSplit>().ToListAsync()).Should().BeEmpty();
+        secondaryWrite.Should().Be(1);
+        var secondary = await context.Set<StockSplit>().SingleAsync();
+        secondary.PriceSeriesTicker.Should().Be("GOOGL");
 
         var currentWrite = await NewManager(context).Capture(stock.Id, "GOOG", [Split()]);
 
         currentWrite.Should().Be(1);
-        var stored = await context.Set<StockSplit>().SingleAsync();
-        stored.PriceSeriesTicker.Should().Be("GOOG");
+        (await context.Set<StockSplit>().OrderBy(split => split.PriceSeriesTicker).ToListAsync())
+            .Select(split => split.PriceSeriesTicker)
+            .Should().Equal("GOOG", "GOOGL");
     }
 
     [Fact]
-    public async Task Capture_SameDateAlreadyAttributedToSibling_PreservesOriginalSeriesAndRatio()
+    public async Task Capture_SameDateAlreadyAttributedToSibling_AddsIndependentPrimaryAction()
     {
         await using var context = NewDb();
         var stock = new CommonStock
@@ -97,15 +97,18 @@ public class StockSplitCaptureManagerTests
 
         var changes = await NewManager(context).Capture(stock.Id, "GOOG", [Split(20m)]);
 
-        changes.Should().Be(0);
+        changes.Should().Be(1);
         context.ChangeTracker.Clear();
-        var stored = await context.Set<StockSplit>().SingleAsync();
-        stored.PriceSeriesTicker.Should().Be("GOOGL");
-        stored.Numerator.Should().Be(2m);
+        var stored = await context.Set<StockSplit>().OrderBy(split => split.PriceSeriesTicker).ToListAsync();
+        stored.Should().HaveCount(2);
+        stored[0].PriceSeriesTicker.Should().Be("GOOG");
+        stored[0].Numerator.Should().Be(20m);
+        stored[1].PriceSeriesTicker.Should().Be("GOOGL");
+        stored[1].Numerator.Should().Be(2m);
     }
 
     [Fact]
-    public async Task Capture_UnattributedLegacyRow_AttributesOnlyFromExactCurrentPrimaryObservation()
+    public async Task Capture_UnattributedLegacyRow_RemainsPrimaryOnly()
     {
         await using var context = NewDb();
         var stock = new CommonStock
@@ -132,21 +135,27 @@ public class StockSplitCaptureManagerTests
         var secondaryObservation = await NewManager(context)
             .Capture(stock.Id, "GOOGL", [Split(20m)]);
 
-        secondaryObservation.Should().Be(0);
+        secondaryObservation.Should().Be(1);
         context.ChangeTracker.Clear();
-        var stillUnattributed = await context.Set<StockSplit>().SingleAsync();
+        var stillUnattributed = await context.Set<StockSplit>()
+            .SingleAsync(split => split.PriceSeriesTicker == null);
         stillUnattributed.PriceSeriesTicker.Should().BeNull();
         stillUnattributed.Numerator.Should().Be(2m);
         stillUnattributed.PriceAdjustmentAppliedTime.Should().NotBeNull();
+        var secondary = await context.Set<StockSplit>()
+            .SingleAsync(split => split.PriceSeriesTicker == "GOOGL");
+        secondary.Numerator.Should().Be(20m);
 
         var primaryObservation = await NewManager(context).Capture(stock.Id, "GOOG", [Split(20m)]);
 
         primaryObservation.Should().Be(1);
         context.ChangeTracker.Clear();
-        var attributed = await context.Set<StockSplit>().SingleAsync();
+        var attributed = await context.Set<StockSplit>()
+            .SingleAsync(split => split.PriceSeriesTicker == "GOOG");
         attributed.PriceSeriesTicker.Should().Be("GOOG");
         attributed.Numerator.Should().Be(20m);
         attributed.PriceAdjustmentAppliedTime.Should().BeNull();
+        (await context.Set<StockSplit>().CountAsync()).Should().Be(2);
     }
 
     [Theory]

--- a/tests/Equibles.UnitTests/CorporateActions/StockSplitCaptureManagerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/StockSplitCaptureManagerTests.cs
@@ -68,7 +68,8 @@ public class StockSplitCaptureManagerTests
         currentWrite.Should().Be(1);
         (await context.Set<StockSplit>().OrderBy(split => split.PriceSeriesTicker).ToListAsync())
             .Select(split => split.PriceSeriesTicker)
-            .Should().Equal("GOOG", "GOOGL");
+            .Should()
+            .Equal("GOOG", "GOOGL");
     }
 
     [Fact]
@@ -99,7 +100,10 @@ public class StockSplitCaptureManagerTests
 
         changes.Should().Be(1);
         context.ChangeTracker.Clear();
-        var stored = await context.Set<StockSplit>().OrderBy(split => split.PriceSeriesTicker).ToListAsync();
+        var stored = await context
+            .Set<StockSplit>()
+            .OrderBy(split => split.PriceSeriesTicker)
+            .ToListAsync();
         stored.Should().HaveCount(2);
         stored[0].PriceSeriesTicker.Should().Be("GOOG");
         stored[0].Numerator.Should().Be(20m);
@@ -137,12 +141,14 @@ public class StockSplitCaptureManagerTests
 
         secondaryObservation.Should().Be(1);
         context.ChangeTracker.Clear();
-        var stillUnattributed = await context.Set<StockSplit>()
+        var stillUnattributed = await context
+            .Set<StockSplit>()
             .SingleAsync(split => split.PriceSeriesTicker == null);
         stillUnattributed.PriceSeriesTicker.Should().BeNull();
         stillUnattributed.Numerator.Should().Be(2m);
         stillUnattributed.PriceAdjustmentAppliedTime.Should().NotBeNull();
-        var secondary = await context.Set<StockSplit>()
+        var secondary = await context
+            .Set<StockSplit>()
             .SingleAsync(split => split.PriceSeriesTicker == "GOOGL");
         secondary.Numerator.Should().Be(20m);
 
@@ -150,7 +156,8 @@ public class StockSplitCaptureManagerTests
 
         primaryObservation.Should().Be(1);
         context.ChangeTracker.Clear();
-        var attributed = await context.Set<StockSplit>()
+        var attributed = await context
+            .Set<StockSplit>()
             .SingleAsync(split => split.PriceSeriesTicker == "GOOG");
         attributed.PriceSeriesTicker.Should().Be("GOOG");
         attributed.Numerator.Should().Be(20m);

--- a/tests/Equibles.UnitTests/Finra/FinraClassShareSymbolsTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraClassShareSymbolsTests.cs
@@ -1,4 +1,5 @@
 using Equibles.Finra.HostedService.Services;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Integrations.Finra.Models;
 
 namespace Equibles.UnitTests.Finra;
@@ -97,9 +98,10 @@ public class FinraClassShareSymbolsTests
     public void Merge_DottedClassShareSymbol_ResolvesToDashTicker()
     {
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal)
+        var security = new ListedSecurityKey(stockId, "BRK-B");
+        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal)
         {
-            ["BRK-B"] = stockId,
+            ["BRK-B"] = security,
         };
         var index = FinraClassShareSymbols.BuildCompressedIndex(tickerMap, StringComparer.Ordinal);
         var records = new List<OffExchangeWeeklyRecord>
@@ -121,6 +123,6 @@ public class FinraClassShareSymbolsTests
         );
 
         result.Should().ContainSingle();
-        result[stockId].AtsVolume.Should().Be(5_000);
+        result[security].AtsVolume.Should().Be(5_000);
     }
 }

--- a/tests/Equibles.UnitTests/Finra/FinraClassShareSymbolsTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraClassShareSymbolsTests.cs
@@ -1,5 +1,5 @@
-using Equibles.Finra.HostedService.Services;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.Finra.HostedService.Services;
 using Equibles.Integrations.Finra.Models;
 
 namespace Equibles.UnitTests.Finra;

--- a/tests/Equibles.UnitTests/Finra/FinraImportScopeTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraImportScopeTests.cs
@@ -1,4 +1,5 @@
 using Equibles.Finra.HostedService.Services;
+using Equibles.CommonStocks.Data.Models;
 
 namespace Equibles.UnitTests.Finra;
 
@@ -82,5 +83,57 @@ public class FinraImportScopeTests
             .ResolveStockUniverse(preferred)
             .Should()
             .NotBe(FinraImportScope.ResolveStockUniverse(common));
+    }
+
+    [Fact]
+    public void ResolveListingImportScope_UnfilteredUniverse_UsesCompletenessMarker()
+    {
+        var listings = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal)
+        {
+            ["AAPL"] = new(Guid.NewGuid(), "AAPL"),
+        };
+
+        FinraImportScope.ResolveListingImportScope(listings, []).Should().StartWith("listings:");
+        FinraImportScope
+            .ResolveListingImportScope(listings, ["", "  "])
+            .Should()
+            .StartWith("listings:");
+    }
+
+    [Fact]
+    public void ResolveListingImportScope_ConfiguredSubset_UsesSubsetMarker()
+    {
+        var listings = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal)
+        {
+            ["VOO"] = new(Guid.NewGuid(), "VOO"),
+        };
+
+        var scope = FinraImportScope.ResolveListingImportScope(listings, [" voo "]);
+
+        scope.Should().StartWith("listing-filter:");
+    }
+
+    [Fact]
+    public void ResolveListingImportScope_ConfiguredSubsetChangesWhenResolutionChanges()
+    {
+        var stockId = Guid.NewGuid();
+        var unresolved = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal);
+        var resolved = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal)
+        {
+            ["VOO"] = new(stockId, "VOO"),
+        };
+        var reassigned = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal)
+        {
+            ["VOO"] = new(Guid.NewGuid(), "VOO"),
+        };
+
+        var unresolvedScope = FinraImportScope.ResolveListingImportScope(unresolved, ["VOO"]);
+        var resolvedScope = FinraImportScope.ResolveListingImportScope(resolved, ["VOO"]);
+
+        resolvedScope.Should().NotBe(unresolvedScope);
+        FinraImportScope
+            .ResolveListingImportScope(reassigned, ["VOO"])
+            .Should()
+            .NotBe(resolvedScope);
     }
 }

--- a/tests/Equibles.UnitTests/Finra/FinraImportScopeTests.cs
+++ b/tests/Equibles.UnitTests/Finra/FinraImportScopeTests.cs
@@ -1,5 +1,5 @@
-using Equibles.Finra.HostedService.Services;
 using Equibles.CommonStocks.Data.Models;
+using Equibles.Finra.HostedService.Services;
 
 namespace Equibles.UnitTests.Finra;
 

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockAtsOnlyTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockAtsOnlyTests.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Finra.HostedService.Services;
 using Equibles.Integrations.Finra.Models;
 
@@ -19,7 +20,8 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockAtsOnlyTests
     public void MergeRecordsByStock_AtsRowWithNoOtcRow_YieldsEntityWithNonAtsOtcZero()
     {
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = stockId };
+        var security = new ListedSecurityKey(stockId, "AAPL");
+        var tickerMap = new Dictionary<string, ListedSecurityKey> { ["AAPL"] = security };
         var records = new List<OffExchangeWeeklyRecord>
         {
             new()
@@ -34,12 +36,12 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockAtsOnlyTests
         var result = OffExchangeVolumeMerger.Merge(
             records,
             tickerMap,
-            new Dictionary<string, Guid>(),
+            new Dictionary<string, ListedSecurityKey>(),
             new DateOnly(2024, 3, 4)
         );
 
         result.Should().ContainSingle();
-        var merged = result[stockId];
+        var merged = result[security];
         merged.AtsVolume.Should().Be(5_000);
         merged.AtsTradeCount.Should().Be(50);
         merged.NonAtsOtcVolume.Should().Be(0);

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockMergeAtsAndOtcTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockMergeAtsAndOtcTests.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Finra.HostedService.Services;
 using Equibles.Integrations.Finra.Models;
 
@@ -21,7 +22,8 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockMergeAtsAndOtcTest
     public void MergeRecordsByStock_AtsAndOtcRowsForSameSymbol_MergeIntoOneEntityWithBothPairs()
     {
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = stockId };
+        var security = new ListedSecurityKey(stockId, "AAPL");
+        var tickerMap = new Dictionary<string, ListedSecurityKey> { ["AAPL"] = security };
         var records = new List<OffExchangeWeeklyRecord>
         {
             new()
@@ -43,12 +45,12 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockMergeAtsAndOtcTest
         var result = OffExchangeVolumeMerger.Merge(
             records,
             tickerMap,
-            new Dictionary<string, Guid>(),
+            new Dictionary<string, ListedSecurityKey>(),
             new DateOnly(2024, 3, 4)
         );
 
         result.Should().HaveCount(1);
-        var merged = result[stockId];
+        var merged = result[security];
         merged.AtsVolume.Should().Be(1_000);
         merged.AtsTradeCount.Should().Be(10);
         merged.NonAtsOtcVolume.Should().Be(2_000);

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockNullQuantityTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockNullQuantityTests.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Finra.HostedService.Services;
 using Equibles.Integrations.Finra.Models;
 
@@ -16,7 +17,8 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockNullQuantityTests
     public void MergeRecordsByStock_TrackedSymbolWithNullQuantities_MergesAsZeroWithoutThrowing()
     {
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = stockId };
+        var security = new ListedSecurityKey(stockId, "AAPL");
+        var tickerMap = new Dictionary<string, ListedSecurityKey> { ["AAPL"] = security };
         var records = new List<OffExchangeWeeklyRecord>
         {
             new()
@@ -32,13 +34,13 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockNullQuantityTests
             OffExchangeVolumeMerger.Merge(
                 records,
                 tickerMap,
-                new Dictionary<string, Guid>(),
+                new Dictionary<string, ListedSecurityKey>(),
                 new DateOnly(2024, 3, 4)
             );
 
         var result = act.Should().NotThrow().Subject;
-        result.Should().ContainKey(stockId);
-        result[stockId].AtsVolume.Should().Be(0);
-        result[stockId].AtsTradeCount.Should().Be(0);
+        result.Should().ContainKey(security);
+        result[security].AtsVolume.Should().Be(0);
+        result[security].AtsTradeCount.Should().Be(0);
     }
 }

--- a/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockUnknownSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Finra/OffExchangeVolumeImportServiceMergeRecordsByStockUnknownSymbolTests.cs
@@ -1,3 +1,4 @@
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Finra.HostedService.Services;
 using Equibles.Integrations.Finra.Models;
 
@@ -22,7 +23,8 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockUnknownSymbolTests
     public void MergeRecordsByStock_SymbolNotInTickerMap_IsSkippedNotPersisted()
     {
         var trackedStockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = trackedStockId };
+        var security = new ListedSecurityKey(trackedStockId, "AAPL");
+        var tickerMap = new Dictionary<string, ListedSecurityKey> { ["AAPL"] = security };
         var records = new List<OffExchangeWeeklyRecord>
         {
             new()
@@ -44,11 +46,11 @@ public class OffExchangeVolumeImportServiceMergeRecordsByStockUnknownSymbolTests
         var result = OffExchangeVolumeMerger.Merge(
             records,
             tickerMap,
-            new Dictionary<string, Guid>(),
+            new Dictionary<string, ListedSecurityKey>(),
             new DateOnly(2024, 3, 4)
         );
 
         result.Should().ContainSingle();
-        result[trackedStockId].AtsVolume.Should().Be(1_000);
+        result[security].AtsVolume.Should().Be(1_000);
     }
 }

--- a/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockDuplicateSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockDuplicateSymbolTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.HostedService.Services;
 using Equibles.Integrations.Finra.Models;
@@ -42,7 +43,8 @@ public class ShortVolumeImportServiceAggregateVolumesByStockDuplicateSymbolTests
         );
 
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = stockId };
+        var security = new ListedSecurityKey(stockId, "AAPL");
+        var tickerMap = new Dictionary<string, ListedSecurityKey> { ["AAPL"] = security };
         var records = new List<ShortVolumeRecord>
         {
             new()
@@ -62,11 +64,11 @@ public class ShortVolumeImportServiceAggregateVolumesByStockDuplicateSymbolTests
         };
 
         var result =
-            (Dictionary<Guid, DailyShortVolume>)
+            (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 method.Invoke(null, [records, tickerMap, new DateOnly(2024, 12, 31)]);
 
         result.Should().HaveCount(1);
-        var aggregated = result[stockId];
+        var aggregated = result[security];
         aggregated.ShortVolume.Should().Be(3_000);
         aggregated.ShortExemptVolume.Should().Be(300);
         aggregated.TotalVolume.Should().Be(15_000);

--- a/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockMergeNullVolumeTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockMergeNullVolumeTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.HostedService.Services;
 using Equibles.Integrations.Finra.Models;
@@ -23,7 +24,8 @@ public class ShortVolumeImportServiceAggregateVolumesByStockMergeNullVolumeTests
         );
 
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = stockId };
+        var security = new ListedSecurityKey(stockId, "AAPL");
+        var tickerMap = new Dictionary<string, ListedSecurityKey> { ["AAPL"] = security };
         var records = new List<ShortVolumeRecord>
         {
             new()
@@ -43,11 +45,11 @@ public class ShortVolumeImportServiceAggregateVolumesByStockMergeNullVolumeTests
         };
 
         var result =
-            (Dictionary<Guid, DailyShortVolume>)
+            (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 method.Invoke(null, [records, tickerMap, new DateOnly(2024, 12, 31)]);
 
         result.Should().HaveCount(1);
-        var aggregated = result[stockId];
+        var aggregated = result[security];
         aggregated
             .ShortVolume.Should()
             .Be(1_000, "the null second-venue ShortVolume contributes 0");

--- a/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockNullSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockNullSymbolTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.HostedService.Services;
 using Equibles.Integrations.Finra.Models;
@@ -26,7 +27,7 @@ public class ShortVolumeImportServiceAggregateVolumesByStockNullSymbolTests
     //
     // The risk this pin uniquely catches:
     //   • Drop the IsNullOrEmpty guard — `tickerMap.TryGetValue(null, ...)`
-    //     throws ArgumentNullException on Dictionary<string, Guid>. Real
+    //     throws ArgumentNullException on the listing dictionary. Real
     //     FINRA daily-short-volume CSVs occasionally emit blank Symbol
     //     cells in malformed rows (typically the summary trailer or a
     //     mid-file corruption); the IsNullOrEmpty branch absorbs them
@@ -65,7 +66,9 @@ public class ShortVolumeImportServiceAggregateVolumesByStockNullSymbolTests
         );
 
         var trackedStockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = trackedStockId };
+        var tickerMap = new Dictionary<string, ListedSecurityKey> {
+            ["AAPL"] = new(trackedStockId, "AAPL")
+        };
         var records = new List<ShortVolumeRecord>
         {
             new()
@@ -78,7 +81,7 @@ public class ShortVolumeImportServiceAggregateVolumesByStockNullSymbolTests
         };
 
         var act = () =>
-            (Dictionary<Guid, DailyShortVolume>)
+            (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 method!.Invoke(null, [records, tickerMap, new DateOnly(2024, 12, 31)]);
 
         var result = act.Should().NotThrow().Subject;

--- a/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockNullSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockNullSymbolTests.cs
@@ -66,8 +66,9 @@ public class ShortVolumeImportServiceAggregateVolumesByStockNullSymbolTests
         );
 
         var trackedStockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, ListedSecurityKey> {
-            ["AAPL"] = new(trackedStockId, "AAPL")
+        var tickerMap = new Dictionary<string, ListedSecurityKey>
+        {
+            ["AAPL"] = new(trackedStockId, "AAPL"),
         };
         var records = new List<ShortVolumeRecord>
         {

--- a/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockNullVolumeTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockNullVolumeTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.HostedService.Services;
 using Equibles.Integrations.Finra.Models;
@@ -20,7 +21,8 @@ public class ShortVolumeImportServiceAggregateVolumesByStockNullVolumeTests
         );
 
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = stockId };
+        var security = new ListedSecurityKey(stockId, "AAPL");
+        var tickerMap = new Dictionary<string, ListedSecurityKey> { ["AAPL"] = security };
         var records = new List<ShortVolumeRecord>
         {
             new()
@@ -33,10 +35,10 @@ public class ShortVolumeImportServiceAggregateVolumesByStockNullVolumeTests
         };
 
         var result =
-            (Dictionary<Guid, DailyShortVolume>)
+            (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 method.Invoke(null, [records, tickerMap, new DateOnly(2024, 9, 30)]);
 
-        result.Should().ContainKey(stockId);
-        result[stockId].ShortVolume.Should().Be(0);
+        result.Should().ContainKey(security);
+        result[security].ShortVolume.Should().Be(0);
     }
 }

--- a/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockUnknownSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceAggregateVolumesByStockUnknownSymbolTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.HostedService.Services;
 using Equibles.Integrations.Finra.Models;
@@ -66,7 +67,8 @@ public class ShortVolumeImportServiceAggregateVolumesByStockUnknownSymbolTests
         );
 
         var trackedStockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid> { ["AAPL"] = trackedStockId };
+        var security = new ListedSecurityKey(trackedStockId, "AAPL");
+        var tickerMap = new Dictionary<string, ListedSecurityKey> { ["AAPL"] = security };
         var records = new List<ShortVolumeRecord>
         {
             new()
@@ -86,10 +88,10 @@ public class ShortVolumeImportServiceAggregateVolumesByStockUnknownSymbolTests
         };
 
         var result =
-            (Dictionary<Guid, DailyShortVolume>)
+            (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 method!.Invoke(null, [records, tickerMap, new DateOnly(2024, 12, 31)]);
 
         result.Should().ContainSingle();
-        result[trackedStockId].ShortVolume.Should().Be(1_000);
+        result[security].ShortVolume.Should().Be(1_000);
     }
 }

--- a/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceCaseVariantSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceCaseVariantSymbolTests.cs
@@ -30,7 +30,10 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
     {
         var stockId = Guid.NewGuid();
         var security = new ListedSecurityKey(stockId, "TPC");
-        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal) { ["TPC"] = security };
+        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal)
+        {
+            ["TPC"] = security,
+        };
         var records = new List<ShortVolumeRecord>
         {
             new()
@@ -65,7 +68,10 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
         // corrupt row must be deleted rather than left behind.
         var stockId = Guid.NewGuid();
         var security = new ListedSecurityKey(stockId, "TPC");
-        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal) { ["TPC"] = security };
+        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal)
+        {
+            ["TPC"] = security,
+        };
         var records = new List<ShortVolumeRecord>
         {
             new() { Symbol = "TpC", ShortVolume = 5_000 },
@@ -74,7 +80,9 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
             (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
 
-        var result = (HashSet<ListedSecurityKey>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
+        var result =
+            (HashSet<ListedSecurityKey>)
+                CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
 
         result.Should().ContainSingle().Which.Should().Be(security);
     }
@@ -85,8 +93,9 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
         // The common stock traded that day: the ordinal re-import overwrites the stored
         // row with the correct TPC-only figures, so nothing may be deleted.
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal) {
-            ["TPC"] = new(stockId, "TPC")
+        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal)
+        {
+            ["TPC"] = new(stockId, "TPC"),
         };
         var records = new List<ShortVolumeRecord>
         {
@@ -97,7 +106,9 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
             (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
 
-        var result = (HashSet<ListedSecurityKey>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
+        var result =
+            (HashSet<ListedSecurityKey>)
+                CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
 
         result.Should().BeEmpty();
     }
@@ -110,8 +121,9 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
         // whose exact symbol is in the file but produced no aggregate must still be protected
         // from deletion — its absence is a filter decision, not a case-fold artifact.
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal) {
-            ["TPC"] = new(stockId, "TPC")
+        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal)
+        {
+            ["TPC"] = new(stockId, "TPC"),
         };
         var records = new List<ShortVolumeRecord>
         {
@@ -121,7 +133,8 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
         var emptyAggregate = new Dictionary<ListedSecurityKey, DailyShortVolume>();
 
         var result =
-            (HashSet<ListedSecurityKey>)CollisionOnly.Invoke(null, [records, tickerMap, emptyAggregate]);
+            (HashSet<ListedSecurityKey>)
+                CollisionOnly.Invoke(null, [records, tickerMap, emptyAggregate]);
 
         result.Should().BeEmpty();
     }
@@ -134,8 +147,9 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
         // day — flagging it would delete its rows daily. Confine deletion to the
         // all-uppercase population the case-fold could actually have corrupted.
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal) {
-            ["TpC"] = new(stockId, "TpC")
+        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal)
+        {
+            ["TpC"] = new(stockId, "TpC"),
         };
         var records = new List<ShortVolumeRecord>
         {
@@ -145,7 +159,9 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
             (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
 
-        var result = (HashSet<ListedSecurityKey>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
+        var result =
+            (HashSet<ListedSecurityKey>)
+                CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
 
         result.Should().BeEmpty();
     }
@@ -167,7 +183,9 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
             (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
 
-        var result = (HashSet<ListedSecurityKey>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
+        var result =
+            (HashSet<ListedSecurityKey>)
+                CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
 
         result.Should().BeEmpty();
     }

--- a/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceCaseVariantSymbolTests.cs
+++ b/tests/Equibles.UnitTests/Finra/ShortVolumeImportServiceCaseVariantSymbolTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
 using Equibles.Finra.Data.Models;
 using Equibles.Finra.HostedService.Services;
 using Equibles.Integrations.Finra.Models;
@@ -28,7 +29,8 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
     public void AggregateVolumesByStock_OrdinalMap_CaseVariantSymbolIsSkippedNotSummed()
     {
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["TPC"] = stockId };
+        var security = new ListedSecurityKey(stockId, "TPC");
+        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal) { ["TPC"] = security };
         var records = new List<ShortVolumeRecord>
         {
             new()
@@ -47,12 +49,12 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
         };
 
         var result =
-            (Dictionary<Guid, DailyShortVolume>)
+            (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
 
         result.Should().HaveCount(1);
-        result[stockId].ShortVolume.Should().Be(90_492);
-        result[stockId].TotalVolume.Should().Be(117_265);
+        result[security].ShortVolume.Should().Be(90_492);
+        result[security].TotalVolume.Should().Be(117_265);
     }
 
     [Fact]
@@ -62,18 +64,19 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
         // the file has TpC but no TPC, so the ordinal re-import writes nothing and the
         // corrupt row must be deleted rather than left behind.
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["TPC"] = stockId };
+        var security = new ListedSecurityKey(stockId, "TPC");
+        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal) { ["TPC"] = security };
         var records = new List<ShortVolumeRecord>
         {
             new() { Symbol = "TpC", ShortVolume = 5_000 },
         };
         var aggregated =
-            (Dictionary<Guid, DailyShortVolume>)
+            (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
 
-        var result = (HashSet<Guid>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
+        var result = (HashSet<ListedSecurityKey>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
 
-        result.Should().ContainSingle().Which.Should().Be(stockId);
+        result.Should().ContainSingle().Which.Should().Be(security);
     }
 
     [Fact]
@@ -82,17 +85,19 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
         // The common stock traded that day: the ordinal re-import overwrites the stored
         // row with the correct TPC-only figures, so nothing may be deleted.
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["TPC"] = stockId };
+        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal) {
+            ["TPC"] = new(stockId, "TPC")
+        };
         var records = new List<ShortVolumeRecord>
         {
             new() { Symbol = "TPC", ShortVolume = 90_492 },
             new() { Symbol = "TpC", ShortVolume = 5_000 },
         };
         var aggregated =
-            (Dictionary<Guid, DailyShortVolume>)
+            (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
 
-        var result = (HashSet<Guid>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
+        var result = (HashSet<ListedSecurityKey>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
 
         result.Should().BeEmpty();
     }
@@ -105,16 +110,18 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
         // whose exact symbol is in the file but produced no aggregate must still be protected
         // from deletion — its absence is a filter decision, not a case-fold artifact.
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["TPC"] = stockId };
+        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal) {
+            ["TPC"] = new(stockId, "TPC")
+        };
         var records = new List<ShortVolumeRecord>
         {
             new() { Symbol = "TPC", ShortVolume = 0 },
             new() { Symbol = "TpC", ShortVolume = 5_000 },
         };
-        var emptyAggregate = new Dictionary<Guid, DailyShortVolume>();
+        var emptyAggregate = new Dictionary<ListedSecurityKey, DailyShortVolume>();
 
         var result =
-            (HashSet<Guid>)CollisionOnly.Invoke(null, [records, tickerMap, emptyAggregate]);
+            (HashSet<ListedSecurityKey>)CollisionOnly.Invoke(null, [records, tickerMap, emptyAggregate]);
 
         result.Should().BeEmpty();
     }
@@ -127,16 +134,18 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
         // day — flagging it would delete its rows daily. Confine deletion to the
         // all-uppercase population the case-fold could actually have corrupted.
         var stockId = Guid.NewGuid();
-        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal) { ["TpC"] = stockId };
+        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal) {
+            ["TpC"] = new(stockId, "TpC")
+        };
         var records = new List<ShortVolumeRecord>
         {
             new() { Symbol = "TPC", ShortVolume = 90_492 },
         };
         var aggregated =
-            (Dictionary<Guid, DailyShortVolume>)
+            (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
 
-        var result = (HashSet<Guid>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
+        var result = (HashSet<ListedSecurityKey>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
 
         result.Should().BeEmpty();
     }
@@ -146,19 +155,19 @@ public class ShortVolumeImportServiceCaseVariantSymbolTests
     {
         // A stock the day's file never mentions keeps its stored row — absence from one
         // file is not evidence the row was a collision artifact.
-        var tickerMap = new Dictionary<string, Guid>(StringComparer.Ordinal)
+        var tickerMap = new Dictionary<string, ListedSecurityKey>(StringComparer.Ordinal)
         {
-            ["TPC"] = Guid.NewGuid(),
+            ["TPC"] = new(Guid.NewGuid(), "TPC"),
         };
         var records = new List<ShortVolumeRecord>
         {
             new() { Symbol = "AAPL", ShortVolume = 1_000 },
         };
         var aggregated =
-            (Dictionary<Guid, DailyShortVolume>)
+            (Dictionary<ListedSecurityKey, DailyShortVolume>)
                 Aggregate.Invoke(null, [records, tickerMap, new DateOnly(2026, 8, 4)]);
 
-        var result = (HashSet<Guid>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
+        var result = (HashSet<ListedSecurityKey>)CollisionOnly.Invoke(null, [records, tickerMap, aggregated]);
 
         result.Should().BeEmpty();
     }


### PR DESCRIPTION
## Summary
- model raw market and ownership observations by exact listed ticker within an SEC filer
- keep secondary ETF listings distinct across FINRA, FTD, 13F, splits, prices, Congress, web, and MCP surfaces
- add the OSS migration and regression coverage

## Verification
- `dotnet build Equibles.sln -c Release`
- OSS unit suite: 4,761 passed
- affected integration suite: 29 passed
- migration forward/down scripts generated and exercised against isolated PostgreSQL