### PR TITLE
fix(holdings): replay ETF listing CUSIPs

### DIFF
--- a/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
+++ b/src/Equibles.Sec.HostedService/FtdScraperWorker.cs
@@ -73,10 +73,13 @@ public class FtdScraperWorker : BaseScraperWorker
 
         // And the sibling-listing sweep: secondary tickers' CUSIPs (share classes, units)
         // recorded against the exact listed symbol so 13F lines filed under them resolve.
-        await ftdService.BackfillListedTickerCusips(stoppingToken);
+        var listedCusipBacklog = await ftdService.BackfillListedTickerCusips(stoppingToken);
 
         // The old data importer admitted primary symbols only. Replay a bounded, durable slice
         // until historical secondary ETF/listing FTD rows have been restored.
-        await ftdService.BackfillListedRecords(stoppingToken);
+        var listedRecordBacklog = await ftdService.BackfillListedRecords(stoppingToken);
+
+        if (listedCusipBacklog || listedRecordBacklog)
+            RequestImmediateContinuation();
     }
 }

--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -494,12 +494,12 @@ public class FtdImportService
     /// and these rows were never collected on that pass.
     /// </para>
     /// </summary>
-    public async Task BackfillListedTickerCusips(CancellationToken cancellationToken)
+    public async Task<bool> BackfillListedTickerCusips(CancellationToken cancellationToken)
     {
         var fileNames = await NextSweepFiles(ListedCusipSweepCursorName);
         if (fileNames.Count == 0)
         {
-            return;
+            return false;
         }
 
         var primaryMap = await BuildTickerMap(cancellationToken);
@@ -510,12 +510,13 @@ public class FtdImportService
             // advance: consuming the archive now would permanently skip these files' rows,
             // and the frontier has no reset path. Wedging is already prevented per-file by
             // the download catch below; this state clears itself once stocks exist.
-            return;
+            return false;
         }
 
         var strippedAliases = BuildStrippedSecondaryAliases(secondaryMap, primaryMap);
         // stockId → (listedTicker → cusips seen for it)
         var byStock = new Dictionary<Guid, Dictionary<string, HashSet<string>>>();
+        string lastCompletedFile = null;
 
         foreach (var fileName in fileNames)
         {
@@ -555,21 +556,33 @@ public class FtdImportService
                     }
                     cusips.Add(record.Cusip);
                 }
+                lastCompletedFile = fileName;
+            }
+            catch (HttpRequestException ex)
+                when (ex.StatusCode == System.Net.HttpStatusCode.NotFound
+                    && !IsRecentFtdFile(fileName)
+                )
+            {
+                _logger.LogWarning(
+                    "Listed-CUSIP sweep: archive file {File} is unavailable (404), advancing",
+                    fileName
+                );
+                lastCompletedFile = fileName;
             }
             catch (Exception ex) when (ex is HttpRequestException or InvalidDataException)
             {
-                // A missing archive file costs coverage for that fortnight only; the
-                // frontier still advances so the sweep cannot wedge on one bad file.
                 _logger.LogWarning(
                     ex,
-                    "Listed-CUSIP sweep: failed to download {File}, skipping",
+                    "Listed-CUSIP sweep: failed to process {File}; retrying from this file",
                     fileName
                 );
+                break;
             }
         }
 
         var recorded = await RecordListedCusips(byStock, cancellationToken);
-        await AdvanceSweepFrontier(ListedCusipSweepCursorName, fileNames[^1]);
+        if (lastCompletedFile != null)
+            await AdvanceSweepFrontier(ListedCusipSweepCursorName, lastCompletedFile);
 
         if (recorded > 0)
         {
@@ -579,6 +592,8 @@ public class FtdImportService
                 fileNames.Count
             );
         }
+
+        return SweepHasBacklog(fileNames, lastCompletedFile);
     }
 
     /// <summary>
@@ -586,15 +601,15 @@ public class FtdImportService
     /// primary tickers, so a schema backfill cannot recover secondary ETF rows that were skipped.
     /// A durable oldest-first frontier makes the repair bounded and restart-safe.
     /// </summary>
-    public async Task BackfillListedRecords(CancellationToken cancellationToken)
+    public async Task<bool> BackfillListedRecords(CancellationToken cancellationToken)
     {
         var fileNames = await NextSweepFiles(ListedRecordSweepCursorName);
         if (fileNames.Count == 0)
-            return;
+            return false;
 
         var tickerMap = await BuildListedTickerMap(cancellationToken);
         if (tickerMap.Count == 0)
-            return;
+            return false;
 
         string lastCompletedFile = null;
         foreach (var fileName in fileNames)
@@ -630,6 +645,8 @@ public class FtdImportService
 
         if (lastCompletedFile != null)
             await AdvanceSweepFrontier(ListedRecordSweepCursorName, lastCompletedFile);
+
+        return SweepHasBacklog(fileNames, lastCompletedFile);
     }
 
     private async Task<int> RecordListedCusips(
@@ -1210,18 +1227,22 @@ public class FtdImportService
         return $"cnsfails{frontier:yyyyMM}{half}.zip";
     }
 
+    internal static bool SweepHasBacklog(IReadOnlyList<string> requested, string lastCompleted) =>
+        !string.Equals(requested[^1], lastCompleted, StringComparison.Ordinal)
+        || requested.Count == AliasSweepFilesPerCycle;
+
     private const string AliasSweepCursorName = "Ftd.RetiredCusipSweep";
 
     private const string InactiveCusipSweepCursorName = "Ftd.InactiveCusipSweep";
 
-    // Separate cursor: the alias sweep's frontier has already consumed the archive on
-    // long-running deployments, and listed-CUSIP rows were never collected on that pass.
-    private const string ListedCusipSweepCursorName = "Ftd.ListedCusipSweep";
+    // V2 deliberately replays the archive once: V1 advanced before authoritative ETF
+    // secondary tickers existed, permanently skipping those listings' historical CUSIPs.
+    internal const string ListedCusipSweepCursorName = "Ftd.ListedCusipSweepV2";
     private const string ListedRecordSweepCursorName = "Ftd.ListedRecordSweepV1";
 
-    // Twelve fortnightly files ≈ six months of archive per daily cycle, so the whole
-    // 2017→today range is swept in about a fortnight of cycles without ever making the
-    // FTD worker's run long.
+    // Twelve fortnightly files ≈ six months per bounded cycle. The worker requests a
+    // short continuation while a full batch remains, yielding between bursts instead of
+    // monopolizing the shared SEC budget or sleeping a day with a repair outstanding.
     private const int AliasSweepFilesPerCycle = 12;
 
     private sealed record LiveIdentityEvidence(

--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceAliasSweepCursorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceAliasSweepCursorTests.cs
@@ -11,6 +11,30 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class FtdImportServiceAliasSweepCursorTests
 {
+    [Fact]
+    public void ListedCusipSweepUsesPostEtfIdentityCursor()
+    {
+        // V1 reached the live frontier before FundSeries secondary tickers were authoritative.
+        // Reusing it would leave historical ETF CUSIPs permanently undiscovered in production.
+        FtdImportService.ListedCusipSweepCursorName.Should().Be("Ftd.ListedCusipSweepV2");
+    }
+
+    [Theory]
+    [InlineData(12, true, true)]
+    [InlineData(4, true, false)]
+    [InlineData(4, false, true)]
+    public void SweepContinuationReflectsBothBatchSizeAndPartialFailure(
+        int fileCount,
+        bool completedLast,
+        bool expected
+    )
+    {
+        var files = Enumerable.Range(0, fileCount).Select(i => $"file-{i}").ToList();
+        var lastCompleted = completedLast ? files[^1] : null;
+
+        FtdImportService.SweepHasBacklog(files, lastCompleted).Should().Be(expected);
+    }
+
     [Theory]
     [InlineData("cnsfails201706b.zip")]
     [InlineData("cnsfails202212a.zip")]


### PR DESCRIPTION
## Summary
- reset the listed-CUSIP sweep with a versioned cursor now that authoritative ETF secondary tickers exist
- retry transient archive failures without advancing past missing identity evidence
- drain exact-listing CUSIP and FTD repairs in bounded immediate-continuation batches

## Verification
- `dotnet csharpier format` on all changed C# files
- `dotnet build tests/Equibles.UnitTests/Equibles.UnitTests.csproj -c Release`
- `dotnet vstest tests/Equibles.UnitTests/bin/Release/net10.0/Equibles.UnitTests.dll` — 4,766 passed
- independent audit and follow-up audit clean