### PR TITLE
fix(holdings): admit authoritative ETF CUSIPs

### DIFF
--- a/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
+++ b/src/Equibles.Sec.HostedService/Services/FtdImportService.cs
@@ -485,8 +485,9 @@ public class FtdImportService
     /// Same authority and guards as the alias sweep: the SEC publishes SYMBOL and CUSIP on one
     /// row (no name matching); a symbol that is any stock's PRIMARY ticker is left to the alias
     /// sweep; a symbol two stocks' secondary lists collapse onto is dropped rather than guessed;
-    /// and the CUSIP must share the stock's issuer prefix, which blocks recycled symbols.
-    /// Sibling classes SHARE the issuer prefix — here that is the point, not a trap.
+    /// and an ordinary secondary symbol's CUSIP must share the stock's issuer prefix, which blocks
+    /// recycled symbols. An exact authoritative ReferenceTicker does not require that prefix:
+    /// separate ETF fund series under one filer can have unrelated six-digit CUSIP prefixes.
     /// </para>
     /// <para>
     /// Own frontier (<see cref="ListedCusipSweepCursorName"/>) starting at the archive origin:
@@ -668,14 +669,22 @@ public class FtdImportService
         var recorded = 0;
         foreach (var stock in stocks)
         {
-            // Without a current primary CUSIP there is no issuer prefix to anchor the
-            // recycled-symbol guard against — skip rather than record unverifiable identity.
-            if (stock.Cusip == null || !byStock.TryGetValue(stock.Id, out var byTicker))
+            if (!byStock.TryGetValue(stock.Id, out var byTicker))
                 continue;
 
+            var referenceTickers = stock.ReferenceTickers.ToHashSet(
+                StringComparer.OrdinalIgnoreCase
+            );
+            // A fund filer's product series can carry unrelated six-digit CUSIP prefixes
+            // (AAXJ 464288 vs IVV 464287). ReferenceTickers is the authoritative current
+            // security-type feed, so its exact ticker can trust the SEC CNS pair directly.
+            // Other secondary listings retain the issuer-prefix ticker-recycling guard.
             var candidates = byTicker
                 .SelectMany(kv =>
-                    kv.Value.Where(c => CusipIdentity.SameIssuer(c, stock.Cusip))
+                    kv.Value.Where(c =>
+                            referenceTickers.Contains(kv.Key)
+                            || (stock.Cusip != null && CusipIdentity.SameIssuer(c, stock.Cusip))
+                        )
                         .Select(c => (ListedTicker: kv.Key, Cusip: c))
                 )
                 .ToList();
@@ -1235,9 +1244,9 @@ public class FtdImportService
 
     private const string InactiveCusipSweepCursorName = "Ftd.InactiveCusipSweep";
 
-    // V2 deliberately replays the archive once: V1 advanced before authoritative ETF
-    // secondary tickers existed, permanently skipping those listings' historical CUSIPs.
-    internal const string ListedCusipSweepCursorName = "Ftd.ListedCusipSweepV2";
+    // V3 deliberately replays the archive once: V2 required every listing to share the
+    // filer's primary six-digit CUSIP prefix, which is false for separate ETF fund series.
+    internal const string ListedCusipSweepCursorName = "Ftd.ListedCusipSweepV3";
     private const string ListedRecordSweepCursorName = "Ftd.ListedRecordSweepV1";
 
     // Twelve fortnightly files ≈ six months per bounded cycle. The worker requests a

--- a/tests/Equibles.IntegrationTests/Sec/FtdImportServiceRecordListedCusipsTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FtdImportServiceRecordListedCusipsTests.cs
@@ -19,13 +19,10 @@ using Xunit;
 namespace Equibles.IntegrationTests.Sec;
 
 /// <summary>
-/// The listed-CUSIP sweep's issuer-prefix guard (#4247). The sweep resolves CNS symbols
-/// against the SECONDARY ticker space, and the only thing standing between a recycled
-/// secondary symbol and importing a delisted issuer's positions is
-/// <c>CusipIdentity.SameIssuer</c> against the stock's primary CUSIP. Sibling classes
-/// SHARE the first-six issuer prefix — for this table that is the admission ticket, not
-/// a trap. A stock with no primary CUSIP has no prefix to verify against and must
-/// record nothing.
+/// The listed-CUSIP sweep's identity guards. An exact authoritative reference ticker admits
+/// the SEC CNS symbol+CUSIP pair directly because separate fund series under one filer can have
+/// different six-digit prefixes. Other secondary symbols still require the stock's issuer prefix,
+/// which is the guard against adopting a recycled symbol's historical CUSIP.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class FtdImportServiceRecordListedCusipsTests : IAsyncLifetime
@@ -143,6 +140,69 @@ public class FtdImportServiceRecordListedCusipsTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RecordListedCusips_ReferenceTickerWithDifferentIssuerPrefix_Records()
+    {
+        var ishares = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "AAXJ",
+            Name = "iShares MSCI All Country Asia ex Japan ETF",
+            Cik = "1100663",
+            Cusip = "464288182",
+            SecondaryTickers = ["IVV"],
+            ReferenceTickers = ["AAXJ", "IVV"],
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(ishares);
+            await seed.SaveChangesAsync();
+        }
+
+        var recorded = await InvokeRecordListedCusips(
+            BuildService(),
+            Candidates(ishares.Id, "IVV", "464287200")
+        );
+
+        recorded.Should().Be(1);
+        using var verify = FreshContext();
+        var listing = await verify.Set<CommonStockListedCusip>().SingleAsync();
+        listing.CommonStockId.Should().Be(ishares.Id);
+        listing.ListedTicker.Should().Be("IVV");
+        listing.Cusip.Should().Be("464287200");
+    }
+
+    [Fact]
+    public async Task RecordListedCusips_ReferenceTickerWithoutPrimaryCusip_Records()
+    {
+        var fund = new CommonStock
+        {
+            Id = Guid.NewGuid(),
+            Ticker = "FUND",
+            Name = "Series Trust",
+            Cik = "0000000003",
+            SecondaryTickers = ["ETF1"],
+            ReferenceTickers = ["ETF1"],
+        };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Set<CommonStock>().Add(fund);
+            await seed.SaveChangesAsync();
+        }
+
+        var recorded = await InvokeRecordListedCusips(
+            BuildService(),
+            Candidates(fund.Id, "ETF1", "33333R107")
+        );
+
+        recorded.Should().Be(1);
+        using var verify = FreshContext();
+        var listing = await verify.Set<CommonStockListedCusip>().SingleAsync();
+        listing.CommonStockId.Should().Be(fund.Id);
+        listing.ListedTicker.Should().Be("ETF1");
+        listing.Cusip.Should().Be("33333R107");
+    }
+
+    [Fact]
     public async Task RecordListedCusips_ForeignIssuerPrefix_RecordsNothing()
     {
         // The recycled-symbol case: an old archive file pairs this secondary symbol with a
@@ -176,8 +236,8 @@ public class FtdImportServiceRecordListedCusipsTests : IAsyncLifetime
     [Fact]
     public async Task RecordListedCusips_StockWithoutPrimaryCusip_RecordsNothing()
     {
-        // No primary CUSIP means no issuer prefix to anchor the guard — unverifiable
-        // identity is skipped, not admitted on faith.
+        // A non-reference secondary symbol still has no authority without a primary
+        // issuer prefix, so it is skipped rather than admitted on faith.
         var stock = new CommonStock
         {
             Id = Guid.NewGuid(),

--- a/tests/Equibles.UnitTests/Sec/FtdImportServiceAliasSweepCursorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FtdImportServiceAliasSweepCursorTests.cs
@@ -14,9 +14,9 @@ public class FtdImportServiceAliasSweepCursorTests
     [Fact]
     public void ListedCusipSweepUsesPostEtfIdentityCursor()
     {
-        // V1 reached the live frontier before FundSeries secondary tickers were authoritative.
-        // Reusing it would leave historical ETF CUSIPs permanently undiscovered in production.
-        FtdImportService.ListedCusipSweepCursorName.Should().Be("Ftd.ListedCusipSweepV2");
+        // V2 rejected separate fund series whose CUSIP prefix differs from the filer's primary.
+        // Reusing it would leave those ETF CUSIPs permanently undiscovered in production.
+        FtdImportService.ListedCusipSweepCursorName.Should().Be("Ftd.ListedCusipSweepV3");
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- trust exact SEC CNS symbol+CUSIP pairs for authoritative ETF ReferenceTickers even when the shared filer has a different issuer prefix
- retain issuer-prefix recycling protection for ordinary secondary listings
- replay the listed-CUSIP archive through a V3 durable cursor so previously rejected ETF series are repaired

## Production evidence
- IVV is an authoritative ReferenceTicker under AAXJ
- AAXJ primary CUSIP is `464288182`; IVV is `464287200`
- the former universal prefix guard rejected IVV while VOO/VTI passed

## Verification
- CSharpier on all changed C# files
- Release builds: Unit and Integration test projects
- full OSS unit suite: 4,766 passed
- focused cursor/backlog tests: 11 passed
- focused PostgreSQL identity integration tests: 5 passed
- independent full-diff audit approved after the XML contract was corrected
- `git diff --check`