### PR TITLE
fix(holdings): order bulk upserts to avoid deadlocks

### DIFF
--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -1964,6 +1964,11 @@ public class HoldingsImportService
         if (safeHoldings.Count == 0)
             return new HoldingsFlushResult(0, SkippedStaleParent: skipped > 0);
 
+        // PostgreSQL takes a KEY SHARE lock on each CommonStock while checking the holding FK.
+        // Bulk and realtime imports can flush overlapping stocks concurrently; one shared parent
+        // order prevents the two multi-row upserts from forming a circular lock dependency.
+        safeHoldings = OrderForUpsert(safeHoldings);
+
         var entriesByKey = new Dictionary<string, List<HoldingManagerEntry>>();
         foreach (var h in safeHoldings)
         {
@@ -2047,6 +2052,16 @@ public class HoldingsImportService
 
         return new HoldingsFlushResult(safeHoldings.Count, SkippedStaleParent: skipped > 0);
     }
+
+    internal static List<InstitutionalHolding> OrderForUpsert(
+        IEnumerable<InstitutionalHolding> holdings
+    ) =>
+        holdings
+            .OrderBy(holding => holding.CommonStockId)
+            .ThenBy(holding => holding.InstitutionalHolderId)
+            .ThenBy(holding => holding.ReportDate)
+            .ThenBy(holding => holding.AccessionNumber, StringComparer.Ordinal)
+            .ToList();
 
     /// <summary>
     /// True when the stored attribution already says exactly what the re-parsed filing says.

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceOrderForUpsertTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceOrderForUpsertTests.cs
@@ -1,0 +1,33 @@
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsImportServiceOrderForUpsertTests
+{
+    [Fact]
+    public void OrderForUpsert_UsesOneDeterministicCommonStockLockOrder()
+    {
+        var firstStock = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var secondStock = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        var holdings = new[]
+        {
+            new InstitutionalHolding
+            {
+                CommonStockId = secondStock,
+                InstitutionalHolderId = Guid.NewGuid(),
+                AccessionNumber = "second",
+            },
+            new InstitutionalHolding
+            {
+                CommonStockId = firstStock,
+                InstitutionalHolderId = Guid.NewGuid(),
+                AccessionNumber = "first",
+            },
+        };
+
+        var ordered = HoldingsImportService.OrderForUpsert(holdings);
+
+        Assert.Equal([firstStock, secondStock], ordered.Select(holding => holding.CommonStockId));
+    }
+}


### PR DESCRIPTION
## Summary
- order holding rows by parent stock and stable holding identity before each bulk upsert
- prevent concurrent replay and realtime batches from acquiring CommonStock FK locks in opposite orders
- add a deterministic ordering regression test

## Verification
- dotnet build tests/Equibles.UnitTests/Equibles.UnitTests.csproj
- dotnet vstest tests/Equibles.UnitTests/bin/Debug/net10.0/Equibles.UnitTests.dll (4,783 passed)