### PR TITLE
fix(financial-facts): stop a payment-date instant charting as the fiscal year

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialFactsTools.cs
@@ -684,7 +684,16 @@ public class FinancialFactsTools
             .ToList();
         if (preferredSpan.Count > 0)
         {
-            candidates = preferredSpan;
+            // A period a duration fact already measures is never read off an instant in
+            // the same bucket: the instant is a declaration/record-date disclosure, and
+            // because it falls after the period end it wins the ordering below (a filer
+            // tagging a 2023-01-12 dividend payment as FY2022 published it as the FY2022
+            // dividend). Instant-only buckets — every balance-sheet concept — are
+            // untouched.
+            var durations = preferredSpan
+                .Where(f => f.PeriodType == FactPeriodType.Duration)
+                .ToList();
+            candidates = durations.Count > 0 ? durations : preferredSpan;
         }
         else if (fiscalPeriod == SecFiscalPeriod.FullYear)
         {

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactInstantTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsToolsPickBestFactInstantTests.cs
@@ -1,0 +1,119 @@
+using System.Reflection;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Mcp.Tools;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialFactsToolsPickBestFactInstantTests
+{
+    // Instants qualify for every period because a balance-sheet line has no duration. That
+    // also let a flow concept's declaration/record-date instant into an annual bucket, where
+    // it ends after the fiscal year and so beat the year's own column on period end: a filer
+    // that tagged the 2023-01-12 payment of its first dividend as FY2022 published $12.4M of
+    // dividends for a year it paid none.
+    [Fact]
+    public void PickBestFact_AnnualGroupWithAnInstantAfterThePeriod_PicksTheDuration()
+    {
+        var stockId = Guid.NewGuid();
+        var conceptId = Guid.NewGuid();
+        var fiscalYear = MakeFact(
+            stockId,
+            conceptId,
+            value: 0m,
+            periodStart: new DateOnly(2022, 1, 1),
+            periodEnd: new DateOnly(2022, 12, 31),
+            fiscalPeriod: SecFiscalPeriod.FullYear
+        );
+        var paymentDate = MakeInstant(
+            stockId,
+            conceptId,
+            value: 12_400_000m,
+            instant: new DateOnly(2023, 1, 12),
+            fiscalPeriod: SecFiscalPeriod.FullYear
+        );
+        var conceptPriority = new Dictionary<Guid, int> { [conceptId] = 0 };
+        var method = typeof(FinancialFactsTools).GetMethod(
+            "PickBestFact",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var picked = (FinancialFact)
+            method!.Invoke(null, [new[] { paymentDate, fiscalYear }, conceptPriority, false, null]);
+
+        picked
+            .Should()
+            .BeSameAs(fiscalYear, "a period a duration measures is not read off an instant");
+    }
+
+    // The control: a balance-sheet bucket holds only instants, so the period-end instant still
+    // wins over a re-stated comparative one. The rule above must never make a balance line absent.
+    [Fact]
+    public void PickBestFact_AnnualGroupOfInstantsOnly_PicksTheYearEndInstant()
+    {
+        var stockId = Guid.NewGuid();
+        var conceptId = Guid.NewGuid();
+        var comparative = MakeInstant(
+            stockId,
+            conceptId,
+            value: 900m,
+            instant: new DateOnly(2021, 12, 31),
+            fiscalPeriod: SecFiscalPeriod.FullYear
+        );
+        var yearEnd = MakeInstant(
+            stockId,
+            conceptId,
+            value: 1_000m,
+            instant: new DateOnly(2022, 12, 31),
+            fiscalPeriod: SecFiscalPeriod.FullYear
+        );
+        var conceptPriority = new Dictionary<Guid, int> { [conceptId] = 0 };
+        var method = typeof(FinancialFactsTools).GetMethod(
+            "PickBestFact",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+
+        var picked = (FinancialFact)
+            method!.Invoke(null, [new[] { comparative, yearEnd }, conceptPriority, false, null]);
+
+        picked.Should().BeSameAs(yearEnd);
+    }
+
+    private static FinancialFact MakeInstant(
+        Guid stockId,
+        Guid conceptId,
+        decimal value,
+        DateOnly instant,
+        SecFiscalPeriod fiscalPeriod
+    )
+    {
+        var fact = MakeFact(stockId, conceptId, value, instant, instant, fiscalPeriod);
+        fact.PeriodType = FactPeriodType.Instant;
+        return fact;
+    }
+
+    private static FinancialFact MakeFact(
+        Guid stockId,
+        Guid conceptId,
+        decimal value,
+        DateOnly periodStart,
+        DateOnly periodEnd,
+        SecFiscalPeriod fiscalPeriod
+    ) =>
+        new()
+        {
+            CommonStockId = stockId,
+            FinancialConceptId = conceptId,
+            Value = value,
+            Unit = "USD",
+            PeriodStart = periodStart,
+            PeriodEnd = periodEnd,
+            FiscalYear = 2022,
+            FiscalPeriod = fiscalPeriod,
+            PeriodType = FactPeriodType.Duration,
+            Form = DocumentType.TwentyF,
+            FiledDate = new DateOnly(2024, 4, 24),
+            AccessionNumber = "0001437749-24-012913",
+        };
+}


### PR DESCRIPTION
## Problem

`PickBestFact` lets an instant qualify for every fiscal bucket — correct for a balance-sheet concept, wrong for a flow one. A filer that tags a dividend's payment or record DATE inside an annual bucket produces an instant that ends **after** the fiscal year, so it wins the `PeriodEnd DESC` pick over the year's own cash-flow column.

Opera (OPRA) tagged the 2023-01-12 payment of its first dividend as FY2022. `GetFinancialFact("OPRA", "dividends-paid")` returned $12.4M for a year the company paid nothing.

Measured on the production corpus: **409 (stock, alias, fiscal period) buckets** hold both an instant and a span-conforming duration where the instant wins. Every one falls in a flow family (dividends-paid, stock-issued, debt-repaid, revenue, EPS, weighted-average shares, …) — **zero** balance-sheet families, so nothing that should read an instant changes.

## Change

Once the span gate has run, keep only the duration candidates when the bucket has any; otherwise keep the candidates unchanged. An instant-only bucket — every balance-sheet concept — is untouched, so the rule can never make a balance line absent.

## Tests

`FinancialFactsToolsPickBestFactInstantTests` — the OPRA bucket picks the duration, and the control (an instants-only annual bucket) still picks the year-end instant. The first fails on `main`.

`tests/Equibles.UnitTests`: 4785 passed, 0 failed.

The commercial repo carries the same fix in its twin (`FinancialFactSeriesProvider.PickBestFact`), so the portal and the MCP tool cannot disagree.

https://claude.ai/code/session_01SE71rLG6DQTLTpDr6BfcU7