### PR TITLE
fix(financial-facts): stop a payment-date instant collapsing a whole statement

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -39,6 +39,32 @@ public static class StatementLineFacts
     public const int MaxSupportedDurationDays = 380;
 
     /// <summary>
+    /// The statement's own reporting endpoint, and the facts that share it. A
+    /// filing re-reports comparative prior endpoints under one fiscal stamp, so
+    /// anchoring keeps a statement from mixing two reporting dates.
+    /// </summary>
+    /// <remarks>
+    /// A flow statement ends where its DURATIONS end. An instant is a point
+    /// disclosure whose date can fall after the period it is filed under — OPRA
+    /// tagged its 2023-01-12 dividend payment as FY2022 — and a plain maximum
+    /// over every fact then anchors the whole statement outside the fiscal year
+    /// and drops every real line with it. An all-instant statement, which is
+    /// every balance sheet, still anchors on its latest instant.
+    /// </remarks>
+    public static List<FinancialFact> AnchorToLatestPeriodEnd(
+        IReadOnlyCollection<FinancialFact> facts
+    )
+    {
+        if (facts.Count == 0)
+            return [];
+
+        var durations = facts.Where(f => f.PeriodType == FactPeriodType.Duration).ToList();
+        var anchoring = durations.Count > 0 ? durations : facts;
+        var statementPeriodEnd = anchoring.Max(f => f.PeriodEnd);
+        return facts.Where(f => f.PeriodEnd == statementPeriodEnd).ToList();
+    }
+
+    /// <summary>
     /// The currently-reported fact among a fiscal period's candidates. A 10-Q
     /// reports each flow line twice under that identity — the discrete quarter
     /// and the fiscal year-to-date — and a balance-sheet line carries the
@@ -82,6 +108,14 @@ public static class StatementLineFacts
         if (preferred.Count == 0)
             return null;
         candidates = preferred;
+
+        // A period a duration already measures is never read off an instant in the
+        // same bucket: the instant is a point disclosure whose date can fall after
+        // the period end, which would win the ordering below. Instant-only buckets
+        // — every balance-sheet concept — are untouched.
+        var durations = candidates.Where(f => f.PeriodType == FactPeriodType.Duration).ToList();
+        if (durations.Count > 0)
+            candidates = durations;
 
         return candidates
             .OrderByDescending(f => f.PeriodEnd)

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -171,8 +171,7 @@ public class FinancialStatementTools
                 // concept can retain an earlier end under the same (year, period). Anchor the
                 // statement to one actual period end before selecting line values so it cannot
                 // silently combine different balance dates or flow endpoints.
-                var statementPeriodEnd = facts.Max(f => f.PeriodEnd);
-                facts = facts.Where(f => f.PeriodEnd == statementPeriodEnd).ToList();
+                facts = StatementLineFacts.AnchorToLatestPeriodEnd(facts);
 
                 // A 10-Q tags each line under one fiscal (year, period) for both the
                 // discrete quarter and the fiscal year-to-date span, and re-reports prior

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -741,11 +741,7 @@ public class StockTabService
                 .ToList();
         }
         facts = facts.Where(f => f.FiscalPeriod == fiscalPeriod).ToList();
-        if (facts.Count > 0)
-        {
-            var statementPeriodEnd = facts.Max(f => f.PeriodEnd);
-            facts = facts.Where(f => f.PeriodEnd == statementPeriodEnd).ToList();
-        }
+        facts = StatementLineFacts.AnchorToLatestPeriodEnd(facts);
 
         // The currently-reported fact per concept: span-aware so a quarter never
         // shows the 10-Q's year-to-date figure, latest-ending so a comparative

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
@@ -1,0 +1,103 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+public class StatementLineFactsAnchorTests
+{
+    // The statement is anchored to one reporting endpoint before any line is picked, so a
+    // point disclosure filed under the fiscal stamp used to decide it for the whole
+    // statement: OPRA tagged the 2023-01-12 payment of its first dividend as FY2022, the
+    // maximum period end moved outside the fiscal year, and every 2022-12-31 line was
+    // dropped — the cash-flow statement rendered that one instant and nothing else.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_FlowStatementWithALaterInstant_AnchorsOnTheDurations()
+    {
+        var revenue = Duration(new DateOnly(2022, 1, 1), new DateOnly(2022, 12, 31), 1_000m);
+        var operatingCashFlow = Duration(
+            new DateOnly(2022, 1, 1),
+            new DateOnly(2022, 12, 31),
+            500m
+        );
+        var cashAtEndOfPeriod = Instant(new DateOnly(2022, 12, 31), 250m);
+        var dividendPaymentDate = Instant(new DateOnly(2023, 1, 12), 12_400_000m);
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd([
+            revenue,
+            operatingCashFlow,
+            cashAtEndOfPeriod,
+            dividendPaymentDate,
+        ]);
+
+        anchored
+            .Should()
+            .BeEquivalentTo(
+                [revenue, operatingCashFlow, cashAtEndOfPeriod],
+                "the statement ends where its durations end, and the period-end instant "
+                    + "shares that date"
+            );
+        anchored.Should().NotContain(dividendPaymentDate);
+    }
+
+    // The control: a balance sheet is every-fact-an-instant, so it must keep anchoring on
+    // its latest instant. Preferring durations there would leave nothing to anchor on.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_AllInstantStatement_AnchorsOnTheLatestInstant()
+    {
+        var comparative = Instant(new DateOnly(2021, 12, 31), 900m);
+        var currentAssets = Instant(new DateOnly(2022, 12, 31), 1_000m);
+        var currentLiabilities = Instant(new DateOnly(2022, 12, 31), 400m);
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd([
+            comparative,
+            currentAssets,
+            currentLiabilities,
+        ]);
+
+        anchored.Should().BeEquivalentTo([currentAssets, currentLiabilities]);
+    }
+
+    // A comparative duration under the same fiscal stamp must still lose to the current one.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_ComparativeDuration_AnchorsOnTheLatestDuration()
+    {
+        var priorYear = Duration(new DateOnly(2021, 1, 1), new DateOnly(2021, 12, 31), 800m);
+        var currentYear = Duration(new DateOnly(2022, 1, 1), new DateOnly(2022, 12, 31), 1_000m);
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd([priorYear, currentYear]);
+
+        anchored.Should().BeEquivalentTo([currentYear]);
+    }
+
+    [Fact]
+    public void AnchorToLatestPeriodEnd_NoFacts_ReturnsEmpty()
+    {
+        StatementLineFacts.AnchorToLatestPeriodEnd([]).Should().BeEmpty();
+    }
+
+    private static FinancialFact Instant(DateOnly instant, decimal value)
+    {
+        var fact = Duration(instant, instant, value);
+        fact.PeriodType = FactPeriodType.Instant;
+        return fact;
+    }
+
+    private static FinancialFact Duration(DateOnly start, DateOnly end, decimal value) =>
+        new()
+        {
+            CommonStockId = Guid.NewGuid(),
+            FinancialConceptId = Guid.NewGuid(),
+            Value = value,
+            Unit = "USD",
+            PeriodStart = start,
+            PeriodEnd = end,
+            FiscalYear = 2022,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            PeriodType = FactPeriodType.Duration,
+            Form = DocumentType.TwentyF,
+            FiledDate = new DateOnly(2024, 4, 24),
+            AccessionNumber = "0001437749-24-012913",
+        };
+}

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsPickInstantTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsPickInstantTests.cs
@@ -1,0 +1,68 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+public class StatementLineFactsPickInstantTests
+{
+    // Instants span zero days, so they qualify for every period — correct for a balance
+    // sheet, but it also admits a flow concept's point disclosure into an annual bucket,
+    // where its later date beats the year's own column on period end.
+    [Fact]
+    public void PickCurrentlyReported_BucketWithALaterInstant_PicksTheDuration()
+    {
+        var fiscalYear = Duration(new DateOnly(2022, 1, 1), new DateOnly(2022, 12, 31), 0m);
+        var paymentDate = Instant(new DateOnly(2023, 1, 12), 12_400_000m);
+
+        var picked = StatementLineFacts.PickCurrentlyReported(
+            [paymentDate, fiscalYear],
+            SecFiscalPeriod.FullYear
+        );
+
+        picked
+            .Should()
+            .BeSameAs(fiscalYear, "a period a duration measures is not read off an instant");
+    }
+
+    // The control: an instant-only bucket is every balance-sheet concept, and the rule above
+    // must never make one of those lines absent.
+    [Fact]
+    public void PickCurrentlyReported_InstantsOnly_PicksTheYearEndInstant()
+    {
+        var comparative = Instant(new DateOnly(2021, 12, 31), 900m);
+        var yearEnd = Instant(new DateOnly(2022, 12, 31), 1_000m);
+
+        var picked = StatementLineFacts.PickCurrentlyReported(
+            [comparative, yearEnd],
+            SecFiscalPeriod.FullYear
+        );
+
+        picked.Should().BeSameAs(yearEnd);
+    }
+
+    private static FinancialFact Instant(DateOnly instant, decimal value)
+    {
+        var fact = Duration(instant, instant, value);
+        fact.PeriodType = FactPeriodType.Instant;
+        return fact;
+    }
+
+    private static FinancialFact Duration(DateOnly start, DateOnly end, decimal value) =>
+        new()
+        {
+            CommonStockId = Guid.NewGuid(),
+            FinancialConceptId = Guid.NewGuid(),
+            Value = value,
+            Unit = "USD",
+            PeriodStart = start,
+            PeriodEnd = end,
+            FiscalYear = 2022,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            PeriodType = FactPeriodType.Duration,
+            Form = DocumentType.TwentyF,
+            FiledDate = new DateOnly(2024, 4, 24),
+            AccessionNumber = "0001437749-24-012913",
+        };
+}


### PR DESCRIPTION
## Problem

A statement is anchored to one reporting endpoint before any line is picked, and the anchor was the maximum period end over **every** fact:

```csharp
var statementPeriodEnd = facts.Max(f => f.PeriodEnd);
facts = facts.Where(f => f.PeriodEnd == statementPeriodEnd).ToList();
```

An instant is a point disclosure whose date can fall *after* the period it is filed under. One such fact moves the anchor outside the fiscal year and drops every real line with it. OPRA tagged the 2023-01-12 payment of its first dividend as FY2022, so its FY2022 cash-flow statement anchored on 2023-01-12 and rendered that single instant instead of the statement.

This is the sibling defect to #4503 — same cause, but it collapses the whole statement rather than one cell.

## Fix

- `StatementLineFacts.AnchorToLatestPeriodEnd` — a flow statement ends where its **durations** end; an all-instant statement (every balance sheet) still anchors on its latest instant. The three hand-rolled copies now share it: the MCP `GetFinancialStatement` tool, the web stock tab, and the commercial `FinancialStatementsHelper` behind the ALVIS Financials card. (The commercial /stocks Financials tab is a different surface and never came through here.)
- `StatementLineFacts.PickCurrentlyReported` — the same duration-outranks-instant rule inside a concept bucket.

## Measured on the production corpus

| Shape | Buckets | Flips |
|---|---|---|
| Statement anchor — cash flow | 290,770 | 262 |
| Statement anchor — income statement | 289,533 | 33 |
| **Statement anchor — balance sheet** | **268,534** | **0** |
| Per-concept pick | 10,297,283 | 256 |

- **No bucket loses a line**; 279 gain them — a median of **1** rendered line today against **11** after.
- Every poisoning tag is a flow family: `PaymentsOfDividendsCommonStock` (70), `ProceedsFromIssuanceOfCommonStock` (64), `PaymentsOfDividends` (50), `RepaymentsOfDebt` (17). Zero balance-sheet families, the same gate that made #4503 safe.
- OPRA FY2022 cash flow: 1 line today → 11 after.

## Tests

`StatementLineFactsAnchorTests` (4) and `StatementLineFactsPickInstantTests` (2), each with the all-instant balance-sheet control. Full suite: **4,791 passed, 0 failed**.

https://claude.ai/code/session_01SE71rLG6DQTLTpDr6BfcU7
