### PR TITLE
fix(financial-facts): treat a zero-day duration as the point disclosure it is

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -44,12 +44,13 @@ public static class StatementLineFacts
     /// anchoring keeps a statement from mixing two reporting dates.
     /// </summary>
     /// <remarks>
-    /// A flow statement ends where its DURATIONS end. An instant is a point
-    /// disclosure whose date can fall after the period it is filed under — OPRA
-    /// tagged its 2023-01-12 dividend payment as FY2022 — and a plain maximum
-    /// over every fact then anchors the whole statement outside the fiscal year
-    /// and drops every real line with it. An all-instant statement, which is
-    /// every balance sheet, still anchors on its latest instant.
+    /// A flow statement ends where its measured SPANS end. A point disclosure
+    /// (OPRA's 2023-01-12 dividend payment, filed as FY2022) can be dated after
+    /// the period it is filed under, so a plain maximum anchors the statement
+    /// outside the fiscal year and drops every real line. A point is any fact
+    /// with no span, which filers tag both as an instant and as a zero-day
+    /// duration; a point-only statement, which is every balance sheet, still
+    /// anchors on its latest point.
     /// </remarks>
     public static List<FinancialFact> AnchorToLatestPeriodEnd(
         IReadOnlyCollection<FinancialFact> facts
@@ -58,8 +59,8 @@ public static class StatementLineFacts
         if (facts.Count == 0)
             return [];
 
-        var durations = facts.Where(f => f.PeriodType == FactPeriodType.Duration).ToList();
-        var anchoring = durations.Count > 0 ? durations : facts;
+        var spans = facts.Where(f => f.PeriodEnd > f.PeriodStart).ToList();
+        var anchoring = spans.Count > 0 ? spans : facts;
         var statementPeriodEnd = anchoring.Max(f => f.PeriodEnd);
         return facts.Where(f => f.PeriodEnd == statementPeriodEnd).ToList();
     }
@@ -109,13 +110,13 @@ public static class StatementLineFacts
             return null;
         candidates = preferred;
 
-        // A period a duration already measures is never read off an instant in the
-        // same bucket: the instant is a point disclosure whose date can fall after
-        // the period end, which would win the ordering below. Instant-only buckets
-        // — every balance-sheet concept — are untouched.
-        var durations = candidates.Where(f => f.PeriodType == FactPeriodType.Duration).ToList();
-        if (durations.Count > 0)
-            candidates = durations;
+        // A period a measured span already covers is never read off a point
+        // disclosure in the same bucket, whose date can fall after the period end
+        // and would win the ordering below. Point-only buckets — every
+        // balance-sheet concept — are untouched.
+        var spans = candidates.Where(f => f.PeriodEnd > f.PeriodStart).ToList();
+        if (spans.Count > 0)
+            candidates = spans;
 
         return candidates
             .OrderByDescending(f => f.PeriodEnd)

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
@@ -71,6 +71,49 @@ public class StatementLineFactsAnchorTests
         anchored.Should().BeEquivalentTo([currentYear]);
     }
 
+    // The same poison arrives tagged as a zero-day DURATION, not an instant: DHC filed its
+    // 2026-01-09 dividend payment that way under FY2025, and gating on PeriodType alone let
+    // it anchor the statement past the 2025-12-31 year end.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_FlowStatementWithALaterZeroDayDuration_AnchorsOnTheMeasuredSpans()
+    {
+        var operatingCashFlow = Duration(
+            new DateOnly(2025, 1, 1),
+            new DateOnly(2025, 12, 31),
+            500m
+        );
+        var dividendPaymentDate = Duration(
+            new DateOnly(2026, 1, 9),
+            new DateOnly(2026, 1, 9),
+            80_000_000m
+        );
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd([
+            operatingCashFlow,
+            dividendPaymentDate,
+        ]);
+
+        anchored
+            .Should()
+            .BeEquivalentTo(
+                [operatingCashFlow],
+                "a zero-day duration is a point disclosure, whatever its PeriodType says"
+            );
+    }
+
+    // The control for the zero-day shape: a statement of nothing but points must still
+    // anchor on its latest point rather than return empty.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_ZeroDayDurationsOnly_AnchorsOnTheLatestPoint()
+    {
+        var earlier = Duration(new DateOnly(2025, 6, 30), new DateOnly(2025, 6, 30), 10m);
+        var latest = Duration(new DateOnly(2025, 12, 31), new DateOnly(2025, 12, 31), 20m);
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd([earlier, latest]);
+
+        anchored.Should().BeEquivalentTo([latest]);
+    }
+
     [Fact]
     public void AnchorToLatestPeriodEnd_NoFacts_ReturnsEmpty()
     {

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsPickInstantTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsPickInstantTests.cs
@@ -26,6 +26,21 @@ public class StatementLineFactsPickInstantTests
             .BeSameAs(fiscalYear, "a period a duration measures is not read off an instant");
     }
 
+    // The same poison tagged as a zero-day duration rather than an instant.
+    [Fact]
+    public void PickCurrentlyReported_BucketWithALaterZeroDayDuration_PicksTheMeasuredSpan()
+    {
+        var fiscalYear = Duration(new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31), 0m);
+        var paymentDate = Duration(new DateOnly(2026, 1, 9), new DateOnly(2026, 1, 9), 80_000_000m);
+
+        var picked = StatementLineFacts.PickCurrentlyReported(
+            [paymentDate, fiscalYear],
+            SecFiscalPeriod.FullYear
+        );
+
+        picked.Should().BeSameAs(fiscalYear);
+    }
+
     // The control: an instant-only bucket is every balance-sheet concept, and the rule above
     // must never make one of those lines absent.
     [Fact]


### PR DESCRIPTION
## Problem

#4504 gated on `PeriodType`, which closed only half the bug class.

Filers tag a payment or declaration date **both ways**. OPRA's 2023-01-12 dividend arrived as an `Instant`; DHC's 2026-01-09 dividend arrived as a `Duration` whose `PeriodStart == PeriodEnd`. The second kind sails through a `PeriodType == Duration` preference and still anchors a whole statement past its fiscal year end — the exact symptom #4504 was written to stop.

OPRA proves both variants coexist inside one filer: its FY2022 poison is `DividendsPaid` as an `Instant`, while its 2023-06-13 payment of the same tag arrived as a zero-day `Duration`.

## Fix

A **point** is any fact with no measured span, whatever its `PeriodType` says:

```csharp
var spans = facts.Where(f => f.PeriodEnd > f.PeriodStart).ToList();
var anchoring = spans.Count > 0 ? spans : facts;
```

Same rule in `PickCurrentlyReported`. Both fall back unchanged when a statement or bucket holds only points — which is every balance sheet. Verified corpus-wide: **zero** facts carry `PeriodType = Instant` with `PeriodEnd > PeriodStart`, so this rule is a strict superset of the one it replaces and can never reclassify an instant.

## Measured on the production corpus

Counting the **dimensional** facts the commercial statement query also loads — the gap in #4504's own consolidated-only measurement.

| Statement | Buckets | Re-anchor |
|---|---|---|
| Cash flow | 290,770 | 1,626 |
| Income statement | 289,551 | 232 |
| **Balance sheet** | **268,534** | **0** |

- **1,442 buckets gain** lines, median **1** rendered line today against **10** after.
- **3 buckets render fewer lines, and all three are the fix working.** AZO FY2021 Q1 anchored on a 2021-03-15 `RepaymentsOfDebt` point and rendered two payment-date artifacts; it now anchors on its real measured quarter and renders that instead. Fewer lines, and they are the true ones.
- The residual (1,858) is **six times** what #4504 closed (295), so this is the larger half of the defect.

## Tests

`StatementLineFactsAnchorTests` +2 (zero-day duration poison; the points-only control) and `StatementLineFactsPickInstantTests` +1. Full suite: **4,794 passed, 0 failed**.

Found by an independent review of #4504 before it reached production.

https://claude.ai/code/session_01SE71rLG6DQTLTpDr6BfcU7
