### PR TITLE
fix(financial-facts): anchor a statement on spans that measure its own period

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -44,25 +44,41 @@ public static class StatementLineFacts
     /// anchoring keeps a statement from mixing two reporting dates.
     /// </summary>
     /// <remarks>
-    /// A flow statement ends where its measured SPANS end. A point disclosure
-    /// (OPRA's 2023-01-12 dividend payment, filed as FY2022) can be dated after
-    /// the period it is filed under, so a plain maximum anchors the statement
-    /// outside the fiscal year and drops every real line. A point is any fact
-    /// with no span, which filers tag both as an instant and as a zero-day
-    /// duration; a point-only statement, which is every balance sheet, still
+    /// A flow statement ends where the spans that MEASURE ITS PERIOD end. A fact
+    /// filed under the stamp but measuring something else — a payment window
+    /// (OPRA's 2023-01-12 dividend, filed as FY2022), a point disclosure, a
+    /// cumulative or dimensional span — can be dated later and drag the anchor
+    /// off the period, dropping every real line. Falls back to any measured span,
+    /// then to every fact, so a point-only statement (every balance sheet) still
     /// anchors on its latest point.
     /// </remarks>
     public static List<FinancialFact> AnchorToLatestPeriodEnd(
-        IReadOnlyCollection<FinancialFact> facts
+        IReadOnlyCollection<FinancialFact> facts,
+        SecFiscalPeriod fiscalPeriod
     )
     {
         if (facts.Count == 0)
             return [];
 
+        var conforming = facts.Where(f => MeasuresGranularity(f, fiscalPeriod)).ToList();
         var spans = facts.Where(f => f.PeriodEnd > f.PeriodStart).ToList();
-        var anchoring = spans.Count > 0 ? spans : facts;
+        var anchoring =
+            conforming.Count > 0 ? conforming
+            : spans.Count > 0 ? spans
+            : facts;
         var statementPeriodEnd = anchoring.Max(f => f.PeriodEnd);
         return facts.Where(f => f.PeriodEnd == statementPeriodEnd).ToList();
+    }
+
+    // A span that measures exactly the requested granularity — the gate
+    // PickCurrentlyReported already applies to a line. Anchoring on anything else lands
+    // the statement on a date no line can serve, and it renders empty.
+    private static bool MeasuresGranularity(FinancialFact fact, SecFiscalPeriod fiscalPeriod)
+    {
+        var spanDays = fact.PeriodEnd.DayNumber - fact.PeriodStart.DayNumber;
+        return fiscalPeriod == SecFiscalPeriod.FullYear
+            ? spanDays >= MinAnnualSpanDays && spanDays <= MaxSupportedDurationDays
+            : spanDays >= 1 && spanDays <= MaxDiscreteQuarterDays;
     }
 
     /// <summary>

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -171,7 +171,7 @@ public class FinancialStatementTools
                 // concept can retain an earlier end under the same (year, period). Anchor the
                 // statement to one actual period end before selecting line values so it cannot
                 // silently combine different balance dates or flow endpoints.
-                facts = StatementLineFacts.AnchorToLatestPeriodEnd(facts);
+                facts = StatementLineFacts.AnchorToLatestPeriodEnd(facts, selectedPeriod);
 
                 // A 10-Q tags each line under one fiscal (year, period) for both the
                 // discrete quarter and the fiscal year-to-date span, and re-reports prior

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -741,7 +741,7 @@ public class StockTabService
                 .ToList();
         }
         facts = facts.Where(f => f.FiscalPeriod == fiscalPeriod).ToList();
-        facts = StatementLineFacts.AnchorToLatestPeriodEnd(facts);
+        facts = StatementLineFacts.AnchorToLatestPeriodEnd(facts, fiscalPeriod);
 
         // The currently-reported fact per concept: span-aware so a quarter never
         // shows the 10-Q's year-to-date figure, latest-ending so a comparative

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
@@ -24,12 +24,10 @@ public class StatementLineFactsAnchorTests
         var cashAtEndOfPeriod = Instant(new DateOnly(2022, 12, 31), 250m);
         var dividendPaymentDate = Instant(new DateOnly(2023, 1, 12), 12_400_000m);
 
-        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd([
-            revenue,
-            operatingCashFlow,
-            cashAtEndOfPeriod,
-            dividendPaymentDate,
-        ]);
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [revenue, operatingCashFlow, cashAtEndOfPeriod, dividendPaymentDate],
+            SecFiscalPeriod.FullYear
+        );
 
         anchored
             .Should()
@@ -50,11 +48,10 @@ public class StatementLineFactsAnchorTests
         var currentAssets = Instant(new DateOnly(2022, 12, 31), 1_000m);
         var currentLiabilities = Instant(new DateOnly(2022, 12, 31), 400m);
 
-        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd([
-            comparative,
-            currentAssets,
-            currentLiabilities,
-        ]);
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [comparative, currentAssets, currentLiabilities],
+            SecFiscalPeriod.FullYear
+        );
 
         anchored.Should().BeEquivalentTo([currentAssets, currentLiabilities]);
     }
@@ -66,7 +63,10 @@ public class StatementLineFactsAnchorTests
         var priorYear = Duration(new DateOnly(2021, 1, 1), new DateOnly(2021, 12, 31), 800m);
         var currentYear = Duration(new DateOnly(2022, 1, 1), new DateOnly(2022, 12, 31), 1_000m);
 
-        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd([priorYear, currentYear]);
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [priorYear, currentYear],
+            SecFiscalPeriod.FullYear
+        );
 
         anchored.Should().BeEquivalentTo([currentYear]);
     }
@@ -88,10 +88,10 @@ public class StatementLineFactsAnchorTests
             80_000_000m
         );
 
-        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd([
-            operatingCashFlow,
-            dividendPaymentDate,
-        ]);
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [operatingCashFlow, dividendPaymentDate],
+            SecFiscalPeriod.FullYear
+        );
 
         anchored
             .Should()
@@ -109,7 +109,10 @@ public class StatementLineFactsAnchorTests
         var earlier = Duration(new DateOnly(2025, 6, 30), new DateOnly(2025, 6, 30), 10m);
         var latest = Duration(new DateOnly(2025, 12, 31), new DateOnly(2025, 12, 31), 20m);
 
-        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd([earlier, latest]);
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [earlier, latest],
+            SecFiscalPeriod.FullYear
+        );
 
         anchored.Should().BeEquivalentTo([latest]);
     }
@@ -117,7 +120,57 @@ public class StatementLineFactsAnchorTests
     [Fact]
     public void AnchorToLatestPeriodEnd_NoFacts_ReturnsEmpty()
     {
-        StatementLineFacts.AnchorToLatestPeriodEnd([]).Should().BeEmpty();
+        StatementLineFacts.AnchorToLatestPeriodEnd([], SecFiscalPeriod.FullYear).Should().BeEmpty();
+    }
+
+    // A span that measures something OTHER than the period drags the anchor off it just as a
+    // point does: AZO's FY2021 Q1 carried a dimensional 167-day NetIncomeLoss ending
+    // 2021-02-13, which anchored the quarter on a date its own 83-day lines could not serve,
+    // and the statement rendered empty.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_QuarterWithALongerNonConformingSpan_AnchorsOnTheQuarter()
+    {
+        var quarter = Duration(new DateOnly(2020, 8, 30), new DateOnly(2020, 11, 21), 500m);
+        var twoQuarters = Duration(new DateOnly(2020, 8, 30), new DateOnly(2021, 2, 13), 900m);
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [quarter, twoQuarters],
+            SecFiscalPeriod.Q1
+        );
+
+        anchored.Should().BeEquivalentTo([quarter]);
+    }
+
+    // A payment filed as a short WINDOW rather than a single day: BHM tagged its dividend
+    // 2026-01-01 to 2026-01-15 under FY2025, which has a span and so passes a bare span rule.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_FullYearWithALaterShortWindow_AnchorsOnTheFiscalYear()
+    {
+        var fiscalYear = Duration(new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31), 500m);
+        var paymentWindow = Duration(new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 15), 80m);
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [fiscalYear, paymentWindow],
+            SecFiscalPeriod.FullYear
+        );
+
+        anchored.Should().BeEquivalentTo([fiscalYear]);
+    }
+
+    // The fallback: a statement whose facts measure no conforming span still anchors rather
+    // than emptying — here on the latest measured span.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_NoConformingSpan_FallsBackToTheLatestSpan()
+    {
+        var earlier = Duration(new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 2), 10m);
+        var later = Duration(new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 15), 20m);
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [earlier, later],
+            SecFiscalPeriod.FullYear
+        );
+
+        anchored.Should().BeEquivalentTo([later]);
     }
 
     private static FinancialFact Instant(DateOnly instant, decimal value)


### PR DESCRIPTION
## Problem

The third and final shape of the defect behind #4504 and #4505. Each earlier fix asked a narrower question than the bug requires:

| PR | Rule | What still gets through |
|---|---|---|
| #4504 | `PeriodType == Duration` | a zero-day `Duration` |
| #4505 | has any span at all | a span that measures the **wrong thing** |
| this | span measures **this period** | — |

Two live production shapes survive #4505:

**1. A payment filed as a short WINDOW, not a single day.** It has a span, so a bare span rule accepts it.
- **BHM FY2025** — `PaymentsOfDividends` 2026-01-01 → 2026-01-15 (14 days) against a 2025-12-31 year end.
- **MNDY FY2025** — `PaymentsForRepurchaseOfCommonStock` 2026-01-01 → 2026-01-02 (1 day).
- Both **consolidated**, both drag the anchor past the fiscal year end.

**2. A span of simply the wrong length.** **AZO FY2021 Q1** carries a dimensional 167-day `NetIncomeLoss` ending 2021-02-13. That anchored the quarter on a date its own 83-day lines cannot serve, every line then failed the pick's `MaxDiscreteQuarterDays` gate, and **the statement rendered empty**.

The root cause is structural: the pick has a granularity gate and the anchor did not, so the two disagreed about which endpoint the statement has.

## Fix

`AnchorToLatestPeriodEnd` now takes the bucket's `SecFiscalPeriod` — all three call sites already held it — and anchors on facts whose span measures that granularity, the same gate `PickCurrentlyReported` applies to a line:

```csharp
var conforming = facts.Where(f => MeasuresGranularity(f, fiscalPeriod)).ToList();
var spans = facts.Where(f => f.PeriodEnd > f.PeriodStart).ToList();
var anchoring = conforming.Count > 0 ? conforming : spans.Count > 0 ? spans : facts;
```

Falls back to any measured span, then to every fact, so a **point-only statement — every balance sheet — still anchors on its latest point**, unchanged.

## Measured on the production corpus

Counting only facts the **pick would actually accept**, so these are rendered lines rather than candidates. (A raw candidate count shows 171 buckets "losing" tags; every one of those tags is a non-conforming span the pick already rejects, so none of them ever rendered.)

| Statement | Buckets re-anchoring | Gain lines | **Lose lines** | Rendered nothing before | Rendered nothing after |
|---|---|---|---|---|---|
| Cash flow | 602 | 601 | **0** | 600 | 0 |
| Income statement | 424 | 424 | **0** | 423 | 0 |
| **Balance sheet** | **0** | — | — | — | — |

- **No bucket loses a renderable line.** 1,025 gain them.
- **1,023 of the 1,026 rendered nothing at all before** — this is the AZO shape, an empty statement, not a wrong cell.
- Median rendered lines: cash flow 0 → 2, income statement 0 → 12.

## Tests

`StatementLineFactsAnchorTests` +3: the non-conforming longer span (AZO), the short payment window (BHM), and the fallback that keeps a statement anchoring when nothing conforms. Full suite: **4,797 passed, 0 failed**.

Found by an independent review of #4505 before it reached production.

https://claude.ai/code/session_01SE71rLG6DQTLTpDr6BfcU7
