### PR TITLE
fix(financial-facts): a dimensional fact never sets a statement's endpoint

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -44,13 +44,14 @@ public static class StatementLineFacts
     /// anchoring keeps a statement from mixing two reporting dates.
     /// </summary>
     /// <remarks>
-    /// A flow statement ends where the spans that MEASURE ITS PERIOD end. A fact
-    /// filed under the stamp but measuring something else — a payment window
-    /// (OPRA's 2023-01-12 dividend, filed as FY2022), a point disclosure, a
-    /// cumulative or dimensional span — can be dated later and drag the anchor
-    /// off the period, dropping every real line. Falls back to any measured span,
-    /// then to every fact, so a point-only statement (every balance sheet) still
-    /// anchors on its latest point.
+    /// A statement ends where the CONSOLIDATED spans that measure its period end.
+    /// A fact filed under the stamp but measuring something else can be dated
+    /// later and drag the anchor off the period, dropping every real line: a
+    /// payment window (OPRA's 2023-01-12 dividend, filed as FY2022), a point
+    /// disclosure, or a dimensional span that is a trailing-twelve-month window
+    /// (HOFT) or a later quarter stamped into this bucket (GIS). Each rung falls
+    /// back to the next, so a filer who tags only dimensionally still renders and
+    /// a point-only statement (every balance sheet) still anchors on its point.
     /// </remarks>
     public static List<FinancialFact> AnchorToLatestPeriodEnd(
         IReadOnlyCollection<FinancialFact> facts,
@@ -61,19 +62,28 @@ public static class StatementLineFacts
             return [];
 
         var conforming = facts.Where(f => MeasuresGranularity(f, fiscalPeriod)).ToList();
-        var spans = facts.Where(f => f.PeriodEnd > f.PeriodStart).ToList();
+        var consolidated = conforming.Where(f => f.DimensionsKey == "").ToList();
+        var spans = facts
+            .Where(f =>
+                f.PeriodEnd > f.PeriodStart
+                && f.PeriodEnd.DayNumber - f.PeriodStart.DayNumber <= MaxSupportedDurationDays
+            )
+            .ToList();
         var anchoring =
-            conforming.Count > 0 ? conforming
+            consolidated.Count > 0 ? consolidated
+            : conforming.Count > 0 ? conforming
             : spans.Count > 0 ? spans
             : facts;
         var statementPeriodEnd = anchoring.Max(f => f.PeriodEnd);
         return facts.Where(f => f.PeriodEnd == statementPeriodEnd).ToList();
     }
 
-    // A span that measures exactly the requested granularity — the gate
-    // PickCurrentlyReported already applies to a line. Anchoring on anything else lands
-    // the statement on a date no line can serve, and it renders empty.
-    private static bool MeasuresGranularity(FinancialFact fact, SecFiscalPeriod fiscalPeriod)
+    /// <summary>
+    /// Whether a span measures exactly the requested granularity. Public so the anchor,
+    /// this file's pick and the commercial pick share ONE gate; two copies drift, and a
+    /// line the pick rejects must never set the statement's endpoint.
+    /// </summary>
+    public static bool MeasuresGranularity(FinancialFact fact, SecFiscalPeriod fiscalPeriod)
     {
         var spanDays = fact.PeriodEnd.DayNumber - fact.PeriodStart.DayNumber;
         return fiscalPeriod == SecFiscalPeriod.FullYear
@@ -112,15 +122,10 @@ public static class StatementLineFacts
         if (candidates.Count == 0)
             return null;
 
+        // The anchor applies MeasuresGranularity too, so the two must stay ONE
+        // expression: a line the pick would reject must never set the endpoint.
         var preferred = candidates
-            .Where(f =>
-            {
-                var spanDays = f.PeriodEnd.DayNumber - f.PeriodStart.DayNumber;
-                return fiscalPeriod == SecFiscalPeriod.FullYear
-                    ? spanDays == 0
-                        || spanDays >= MinAnnualSpanDays && spanDays <= MaxSupportedDurationDays
-                    : spanDays <= MaxDiscreteQuarterDays;
-            })
+            .Where(f => f.PeriodEnd == f.PeriodStart || MeasuresGranularity(f, fiscalPeriod))
             .ToList();
         if (preferred.Count == 0)
             return null;

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
@@ -173,6 +173,86 @@ public class StatementLineFactsAnchorTests
         anchored.Should().BeEquivalentTo([later]);
     }
 
+    // A dimensional span of conforming LENGTH is still the wrong period: HOFT's FY2025
+    // carried a 368-day trailing-twelve-month window ending 2025-05-04 against its real year
+    // ending 2025-02-02, and length alone cannot tell the two apart.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_DimensionalTrailingWindow_AnchorsOnTheConsolidatedYear()
+    {
+        var fiscalYear = Duration(new DateOnly(2024, 1, 29), new DateOnly(2025, 2, 2), 500m);
+        var trailingWindow = Dimensional(
+            Duration(new DateOnly(2024, 5, 1), new DateOnly(2025, 5, 4), 900m)
+        );
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [fiscalYear, trailingWindow],
+            SecFiscalPeriod.FullYear
+        );
+
+        anchored.Should().BeEquivalentTo([fiscalYear]);
+    }
+
+    // The same rung fixes a LATER period stamped into this bucket: GIS's fiscal year ends in
+    // May, so its FY2020 Q2 is the quarter ending 2019-11-24, and a dimensional FY2021 Q1
+    // span ending 2020-08-30 sat in the same bucket and won on date.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_DimensionalLaterQuarter_AnchorsOnTheConsolidatedQuarter()
+    {
+        var ownQuarter = Duration(new DateOnly(2019, 8, 26), new DateOnly(2019, 11, 24), 500m);
+        var laterQuarter = Dimensional(
+            Duration(new DateOnly(2020, 6, 1), new DateOnly(2020, 8, 30), 900m)
+        );
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [ownQuarter, laterQuarter],
+            SecFiscalPeriod.Q2
+        );
+
+        anchored.Should().BeEquivalentTo([ownQuarter]);
+    }
+
+    // The control: a filer that tags a period ONLY dimensionally must still render it, so the
+    // consolidated rung falls through rather than emptying the statement.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_DimensionalOnly_StillAnchorsOnTheLatestConformingSpan()
+    {
+        var earlier = Dimensional(
+            Duration(new DateOnly(2023, 1, 1), new DateOnly(2023, 12, 31), 10m)
+        );
+        var latest = Dimensional(
+            Duration(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31), 20m)
+        );
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [earlier, latest],
+            SecFiscalPeriod.FullYear
+        );
+
+        anchored.Should().BeEquivalentTo([latest]);
+    }
+
+    // An inception-to-date span is longer than any supported duration, so it cannot anchor a
+    // bucket that has no conforming span of its own.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_NoConformingSpan_IgnoresAnInceptionToDateSpan()
+    {
+        var stub = Duration(new DateOnly(2025, 1, 1), new DateOnly(2025, 6, 30), 10m);
+        var inceptionToDate = Duration(new DateOnly(1998, 1, 1), new DateOnly(2025, 9, 30), 20m);
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [stub, inceptionToDate],
+            SecFiscalPeriod.FullYear
+        );
+
+        anchored.Should().BeEquivalentTo([stub]);
+    }
+
+    private static FinancialFact Dimensional(FinancialFact fact)
+    {
+        fact.DimensionsKey = "srt:ConsolidationItemsAxis=us-gaap:OperatingSegmentsMember";
+        return fact;
+    }
+
     private static FinancialFact Instant(DateOnly instant, decimal value)
     {
         var fact = Duration(instant, instant, value);


### PR DESCRIPTION
## Problem

The fourth and final shape of the defect behind #4504, #4505 and #4506. Each earlier fix asked a narrower question:

| PR | Rule | What still gets through |
|---|---|---|
| #4504 | `PeriodType == Duration` | a zero-day `Duration` |
| #4505 | has any span | a span measuring the wrong thing |
| #4506 | span measures this period's **length** | a span of the right length, **wrong dates** |
| this | the **consolidated** span measuring this period | — |

**Length is not identity.** A trailing-twelve-month window is also 350-380 days, so it passes the annual gate.

- **HOFT FY2025** carries a dimensional 368-day TTM window ending **2025-05-04** beside its real year ending **2025-02-02**. The statement rendered three segment TTM figures instead of the fiscal year.
- **GIS FY2020 Q2** is a second, distinct shape the same rung fixes. GIS's fiscal year ends in May, so that bucket's own quarter ends **2019-11-24** (147 consolidated facts). A **dimensional FY2021 Q1** span ending **2020-08-30** sat in the same bucket and won on date.

## Fix

Anchor on **consolidated** conforming spans when any exist:

```csharp
var conforming   = facts.Where(f => MeasuresGranularity(f, fiscalPeriod)).ToList();
var consolidated = conforming.Where(f => f.DimensionsKey == "").ToList();
var anchoring = consolidated.Count > 0 ? consolidated
              : conforming.Count   > 0 ? conforming
              : spans.Count        > 0 ? spans
              : facts;
```

Every rung falls through, so a filer tagging a period **only** dimensionally still renders, and a point-only statement — every balance sheet — still anchors on its point. This matches the pick, which already prefers consolidated per concept and falls back to dimensional per concept, so a dimension-only *line* still renders, just at the consolidated *endpoint*.

### Both drift risks behind this bug family are closed too

1. **`MeasuresGranularity` is now public and `PickCurrentlyReported` calls it**, so the anchor and the pick are literally one expression instead of two that agreed by hand. Four shapes of this bug came from a gate that did not match its neighbour; the commercial pick shares the same method.
2. **The any-span rung is bounded to `MaxSupportedDurationDays`**, which the pick's pre-filter already applies, so an inception-to-date span (AZO carries an 8,360-day one) cannot anchor a bucket that has no conforming span.

## Measured on production

Counting only facts the pick accepts, so these are rendered lines.

| Statement | Buckets | Re-anchor | Gain | Lose | Empty after |
|---|---|---|---|---|---|
| Cash flow | 290,770 | 900 | 688 | 17 | 0 |
| Income statement | 289,551 | 341 | 334 | 4 | 0 |
| **Balance sheet** | **268,534** | **0** | — | — | — |

**The 21 buckets that render fewer lines had ZERO consolidated facts at the old anchor** — every one was showing dimensional figures at a date with no consolidated support, which is precisely the defect. Verified on GIS against its actual fiscal calendar (May year-end), not by inspection alone.

## Tests

`StatementLineFactsAnchorTests` +4: the HOFT trailing window, the GIS later-quarter stamp, the dimensional-only control, and the inception-to-date bound. Full suite: **4,801 passed, 0 failed**.

Closes the class opened by daniel3303/EquiblesCommercial#8277.

https://claude.ai/code/session_01SE71rLG6DQTLTpDr6BfcU7
