### PR TITLE
revert(financial-facts): drop the consolidated anchor rung from #4507

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -44,14 +44,17 @@ public static class StatementLineFacts
     /// anchoring keeps a statement from mixing two reporting dates.
     /// </summary>
     /// <remarks>
-    /// A statement ends where the CONSOLIDATED spans that measure its period end.
-    /// A fact filed under the stamp but measuring something else can be dated
-    /// later and drag the anchor off the period, dropping every real line: a
-    /// payment window (OPRA's 2023-01-12 dividend, filed as FY2022), a point
-    /// disclosure, or a dimensional span that is a trailing-twelve-month window
-    /// (HOFT) or a later quarter stamped into this bucket (GIS). Each rung falls
-    /// back to the next, so a filer who tags only dimensionally still renders and
-    /// a point-only statement (every balance sheet) still anchors on its point.
+    /// A statement ends where the spans that MEASURE ITS PERIOD end. A fact filed
+    /// under the stamp but measuring something else — a payment window (OPRA's
+    /// 2023-01-12 dividend, filed as FY2022) or a point disclosure — can be dated
+    /// later and drag the anchor off the period, dropping every real line. Falls
+    /// back to any bounded span, then to every fact, so a point-only statement
+    /// (every balance sheet) still anchors on its latest point.
+    ///
+    /// A conforming span belonging to ANOTHER period is still not separable here
+    /// (a trailing-twelve-month window, or a later quarter stamped into this
+    /// bucket) — the only arbiter is the period's own consolidated endpoint, which
+    /// lives in a different statement's concepts and is not loaded. See #8277.
     /// </remarks>
     public static List<FinancialFact> AnchorToLatestPeriodEnd(
         IReadOnlyCollection<FinancialFact> facts,
@@ -62,7 +65,6 @@ public static class StatementLineFacts
             return [];
 
         var conforming = facts.Where(f => MeasuresGranularity(f, fiscalPeriod)).ToList();
-        var consolidated = conforming.Where(f => f.DimensionsKey == "").ToList();
         var spans = facts
             .Where(f =>
                 f.PeriodEnd > f.PeriodStart
@@ -70,8 +72,7 @@ public static class StatementLineFacts
             )
             .ToList();
         var anchoring =
-            consolidated.Count > 0 ? consolidated
-            : conforming.Count > 0 ? conforming
+            conforming.Count > 0 ? conforming
             : spans.Count > 0 ? spans
             : facts;
         var statementPeriodEnd = anchoring.Max(f => f.PeriodEnd);

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
@@ -173,44 +173,6 @@ public class StatementLineFactsAnchorTests
         anchored.Should().BeEquivalentTo([later]);
     }
 
-    // A dimensional span of conforming LENGTH is still the wrong period: HOFT's FY2025
-    // carried a 368-day trailing-twelve-month window ending 2025-05-04 against its real year
-    // ending 2025-02-02, and length alone cannot tell the two apart.
-    [Fact]
-    public void AnchorToLatestPeriodEnd_DimensionalTrailingWindow_AnchorsOnTheConsolidatedYear()
-    {
-        var fiscalYear = Duration(new DateOnly(2024, 1, 29), new DateOnly(2025, 2, 2), 500m);
-        var trailingWindow = Dimensional(
-            Duration(new DateOnly(2024, 5, 1), new DateOnly(2025, 5, 4), 900m)
-        );
-
-        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
-            [fiscalYear, trailingWindow],
-            SecFiscalPeriod.FullYear
-        );
-
-        anchored.Should().BeEquivalentTo([fiscalYear]);
-    }
-
-    // The same rung fixes a LATER period stamped into this bucket: GIS's fiscal year ends in
-    // May, so its FY2020 Q2 is the quarter ending 2019-11-24, and a dimensional FY2021 Q1
-    // span ending 2020-08-30 sat in the same bucket and won on date.
-    [Fact]
-    public void AnchorToLatestPeriodEnd_DimensionalLaterQuarter_AnchorsOnTheConsolidatedQuarter()
-    {
-        var ownQuarter = Duration(new DateOnly(2019, 8, 26), new DateOnly(2019, 11, 24), 500m);
-        var laterQuarter = Dimensional(
-            Duration(new DateOnly(2020, 6, 1), new DateOnly(2020, 8, 30), 900m)
-        );
-
-        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
-            [ownQuarter, laterQuarter],
-            SecFiscalPeriod.Q2
-        );
-
-        anchored.Should().BeEquivalentTo([ownQuarter]);
-    }
-
     // The control: a filer that tags a period ONLY dimensionally must still render it, so the
     // consolidated rung falls through rather than emptying the statement.
     [Fact]


### PR DESCRIPTION
## Why

#4507 preferred **consolidated** conforming spans so a dimensional trailing-twelve-month window (HOFT) or a later dimensional quarter (GIS) could not set a statement's endpoint. An independent review found it introduces a **worse** failure than it fixes. Production confirms it, so this reverts the rung before it reaches a deploy.

### The counter-example: JHG FY2025 Q1

| Span | Days | Dimensions | Concepts |
|---|---|---|---|
| 2025-01-01 → **2025-03-31** | 89 | dimensional | 3 |
| 2024-07-01 → **2024-09-30** | 91 | **consolidated** | 14 |

The period's real endpoint is **2025-03-31** — 20 consolidated balance-sheet instants sit there. The consolidated rung anchors on **2024-09-30** and renders a complete, internally consistent **July–September 2024 income statement labelled FY2025 Q1**.

Balance sheets do not move, so a reader sees a 2025-03-31 balance sheet beside a Q3-2024 income statement and cash flow. **There is no visible tell.** Rendering three correctly-dated lines, which is today's behaviour, is strictly better than a plausible wrong-period statement.

**Scale:** 935 buckets land on the balance-sheet-confirmed period end (real fixes), but **54 land 80+ days off it** (2–640 days, 11 stocks including UAA, JHG, MFIC, TAP), and that is a lower bound.

### Why no in-bucket rule fixes it

GIS and JHG are **mirror images** — two conforming spans ending in different periods, one consolidated and one dimensional. In GIS the consolidated one is real; in JHG the dimensional one is. Latest-wins is right for JHG, consolidated-wins for GIS, and span overlap or move-distance each break one of the two.

The fiscal calendar cannot arbitrate either: **JHG stores `FiscalYearEndMonth = 6` while its own consolidated annual spans run January to December.** The metadata is wrong for exactly the filer that needs it.

The only reliable arbiter is the period's own **consolidated point disclosure** (its balance-sheet instant), which lives in a *different statement's* concept set and is never loaded. Closing this needs a wider load or a two-pass anchor — tracked in daniel3303/EquiblesCommercial#8277, not an in-bucket rule.

### Also a correction to #4507

Its message said the rung "matches the pick, which already prefers consolidated per concept". That describes the **commercial** pick; OSS `PickCurrentlyReported` has no `DimensionsKey` step.

## What is kept

Both are behaviour-preserving and were independently verified as such:

1. **`MeasuresGranularity` is public and the anchor plus both picks call it**, so the gates are one expression rather than three agreeing by hand. Four shapes of this bug family came from gate drift, so this is the durable part of #4507.
2. **The any-span rung stays bounded** to `MaxSupportedDurationDays`, which the pick's pre-filter already applies.

The two tests pinning the reverted rung are removed; the dimensional-only control and the inception-to-date bound stay. Suite: **4,799 passed, 0 failed**.

https://claude.ai/code/session_01SE71rLG6DQTLTpDr6BfcU7
