### PR TITLE
fix(statements): let the period's own balance-sheet date settle the anchor

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -69,10 +69,11 @@ public static class StatementLineFacts
         var conforming = facts.Where(f => MeasuresGranularity(f, fiscalPeriod)).ToList();
 
         // The balance-sheet date settles which same-length span measures THIS period —
-        // but only above the latest span the entity itself measured. A filer can file
+        // but only at or above the latest span the entity itself measured. A filer can file
         // its quarter-end balance sheet under the NEXT fiscal stamp (DELL), leaving only
-        // the prior year-end instant in this bucket; anchoring there would publish the
-        // comparative column in place of a complete statement.
+        // the prior year's same-quarter instant in this bucket; anchoring there would
+        // publish the comparative column in place of a complete statement. A period tagged
+        // only per-segment has no such span, so a confirmed date still anchors it.
         if (reportedPeriodEnd is { } reported && conforming.Any(f => f.PeriodEnd == reported))
         {
             var measured = conforming

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -43,6 +43,12 @@ public static class StatementLineFacts
     /// filing re-reports comparative prior endpoints under one fiscal stamp, so
     /// anchoring keeps a statement from mixing two reporting dates.
     /// </summary>
+    /// <param name="reportedPeriodEnd">
+    /// The date the period's own consolidated balance sheet states, or null when the
+    /// caller has none. A span of the right LENGTH can still measure another period
+    /// (a trailing-twelve-month window, or a later quarter stamped into this bucket),
+    /// and this is the only independent evidence of where the period ends.
+    /// </param>
     /// <remarks>
     /// A statement ends where the spans that MEASURE ITS PERIOD end. A fact filed
     /// under the stamp but measuring something else — a payment window (OPRA's
@@ -50,21 +56,32 @@ public static class StatementLineFacts
     /// later and drag the anchor off the period, dropping every real line. Falls
     /// back to any bounded span, then to every fact, so a point-only statement
     /// (every balance sheet) still anchors on its latest point.
-    ///
-    /// A conforming span belonging to ANOTHER period is still not separable here
-    /// (a trailing-twelve-month window, or a later quarter stamped into this
-    /// bucket) — the only arbiter is the period's own consolidated endpoint, which
-    /// lives in a different statement's concepts and is not loaded. See #8277.
     /// </remarks>
     public static List<FinancialFact> AnchorToLatestPeriodEnd(
         IReadOnlyCollection<FinancialFact> facts,
-        SecFiscalPeriod fiscalPeriod
+        SecFiscalPeriod fiscalPeriod,
+        DateOnly? reportedPeriodEnd
     )
     {
         if (facts.Count == 0)
             return [];
 
         var conforming = facts.Where(f => MeasuresGranularity(f, fiscalPeriod)).ToList();
+
+        // The balance-sheet date settles which same-length span measures THIS period —
+        // but only above the latest span the entity itself measured. A filer can file
+        // its quarter-end balance sheet under the NEXT fiscal stamp (DELL), leaving only
+        // the prior year-end instant in this bucket; anchoring there would publish the
+        // comparative column in place of a complete statement.
+        if (reportedPeriodEnd is { } reported && conforming.Any(f => f.PeriodEnd == reported))
+        {
+            var measured = conforming
+                .Where(f => string.IsNullOrEmpty(f.DimensionsKey))
+                .Select(f => (DateOnly?)f.PeriodEnd)
+                .Max();
+            if (measured is null || reported >= measured)
+                return facts.Where(f => f.PeriodEnd == reported).ToList();
+        }
         var spans = facts
             .Where(f =>
                 f.PeriodEnd > f.PeriodStart

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -171,7 +171,16 @@ public class FinancialStatementTools
                 // concept can retain an earlier end under the same (year, period). Anchor the
                 // statement to one actual period end before selecting line values so it cannot
                 // silently combine different balance dates or flow endpoints.
-                facts = StatementLineFacts.AnchorToLatestPeriodEnd(facts, selectedPeriod);
+                // No balance-sheet date is loaded, and none is needed: this tool reads
+                // GetConsolidatedByStock, so the latest conforming span IS the entity's own
+                // measured endpoint and the rule provably cannot move a consolidated-only
+                // fact set (StatementLineFactsAnchorTests). A surface that also loads
+                // DIMENSIONAL facts must pass one — see FinancialStatementsHelper.
+                facts = StatementLineFacts.AnchorToLatestPeriodEnd(
+                    facts,
+                    selectedPeriod,
+                    reportedPeriodEnd: null
+                );
 
                 // A 10-Q tags each line under one fiscal (year, period) for both the
                 // discrete quarter and the fiscal year-to-date span, and re-reports prior

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -741,7 +741,14 @@ public class StockTabService
                 .ToList();
         }
         facts = facts.Where(f => f.FiscalPeriod == fiscalPeriod).ToList();
-        facts = StatementLineFacts.AnchorToLatestPeriodEnd(facts, fiscalPeriod);
+        // Consolidated facts only (GetConsolidatedByStock above), so the latest conforming
+        // span is already the entity's own measured endpoint and no balance-sheet date can
+        // move the anchor — proved in StatementLineFactsAnchorTests.
+        facts = StatementLineFacts.AnchorToLatestPeriodEnd(
+            facts,
+            fiscalPeriod,
+            reportedPeriodEnd: null
+        );
 
         // The currently-reported fact per concept: span-aware so a quarter never
         // shows the 10-Q's year-to-date figure, latest-ending so a comparative

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
@@ -244,24 +244,54 @@ public class StatementLineFactsAnchorTests
         anchored.Should().BeEquivalentTo([quarter, alsoTheQuarter]);
     }
 
+    // The floor is a floor, not an equality: the confirmed date may sit ABOVE the latest
+    // consolidated span. A filer whose only consolidated span under the stamp is the
+    // comparative still gets its real quarter, and not the segment window past it.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_ReportedPeriodEndAboveTheMeasuredSpan_AnchorsThere()
+    {
+        var consolidatedComparative = Duration(
+            new DateOnly(2024, 9, 1),
+            new DateOnly(2024, 11, 29),
+            10m
+        );
+        var theQuarter = Dimensional(
+            Duration(new DateOnly(2024, 11, 30), new DateOnly(2025, 2, 28), 1_000m)
+        );
+        var alsoTheQuarter = Dimensional(
+            Duration(new DateOnly(2024, 11, 30), new DateOnly(2025, 2, 28), 500m)
+        );
+        var segmentWindow = Dimensional(
+            Duration(new DateOnly(2025, 3, 1), new DateOnly(2025, 3, 26), 7m)
+        );
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [consolidatedComparative, theQuarter, alsoTheQuarter, segmentWindow],
+            SecFiscalPeriod.Q1,
+            reportedPeriodEnd: new DateOnly(2025, 2, 28)
+        );
+
+        anchored.Should().BeEquivalentTo([theQuarter, alsoTheQuarter]);
+    }
+
     // The balance-sheet date is evidence, never an override. A filer can file its
-    // quarter-end balance sheet under the NEXT fiscal stamp, leaving only the prior
-    // year-end instant under this one (DELL); anchoring on it would replace a complete
+    // quarter-end balance sheet under the NEXT fiscal stamp, leaving only the prior year's
+    // same-quarter instant under this one (DELL); anchoring on it would replace a complete
     // quarter with the comparative column.
     [Fact]
     public void AnchorToLatestPeriodEnd_ReportedPeriodEndBelowAMeasuredSpan_KeepsTheStatement()
     {
         var priorYearComparative = Duration(
-            new DateOnly(2016, 11, 5),
-            new DateOnly(2017, 2, 3),
+            new DateOnly(2024, 2, 3),
+            new DateOnly(2024, 5, 3),
             10m
         );
-        var quarter = Duration(new DateOnly(2017, 2, 4), new DateOnly(2017, 5, 5), 1_000m);
+        var quarter = Duration(new DateOnly(2025, 2, 1), new DateOnly(2025, 5, 2), 1_000m);
 
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [priorYearComparative, quarter],
             SecFiscalPeriod.Q1,
-            reportedPeriodEnd: new DateOnly(2017, 2, 3)
+            reportedPeriodEnd: new DateOnly(2024, 5, 3)
         );
 
         anchored.Should().BeEquivalentTo([quarter]);

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
@@ -26,7 +26,8 @@ public class StatementLineFactsAnchorTests
 
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [revenue, operatingCashFlow, cashAtEndOfPeriod, dividendPaymentDate],
-            SecFiscalPeriod.FullYear
+            SecFiscalPeriod.FullYear,
+            reportedPeriodEnd: null
         );
 
         anchored
@@ -50,7 +51,8 @@ public class StatementLineFactsAnchorTests
 
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [comparative, currentAssets, currentLiabilities],
-            SecFiscalPeriod.FullYear
+            SecFiscalPeriod.FullYear,
+            reportedPeriodEnd: null
         );
 
         anchored.Should().BeEquivalentTo([currentAssets, currentLiabilities]);
@@ -65,7 +67,8 @@ public class StatementLineFactsAnchorTests
 
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [priorYear, currentYear],
-            SecFiscalPeriod.FullYear
+            SecFiscalPeriod.FullYear,
+            reportedPeriodEnd: null
         );
 
         anchored.Should().BeEquivalentTo([currentYear]);
@@ -90,7 +93,8 @@ public class StatementLineFactsAnchorTests
 
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [operatingCashFlow, dividendPaymentDate],
-            SecFiscalPeriod.FullYear
+            SecFiscalPeriod.FullYear,
+            reportedPeriodEnd: null
         );
 
         anchored
@@ -111,7 +115,8 @@ public class StatementLineFactsAnchorTests
 
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [earlier, latest],
-            SecFiscalPeriod.FullYear
+            SecFiscalPeriod.FullYear,
+            reportedPeriodEnd: null
         );
 
         anchored.Should().BeEquivalentTo([latest]);
@@ -120,7 +125,10 @@ public class StatementLineFactsAnchorTests
     [Fact]
     public void AnchorToLatestPeriodEnd_NoFacts_ReturnsEmpty()
     {
-        StatementLineFacts.AnchorToLatestPeriodEnd([], SecFiscalPeriod.FullYear).Should().BeEmpty();
+        StatementLineFacts
+            .AnchorToLatestPeriodEnd([], SecFiscalPeriod.FullYear, reportedPeriodEnd: null)
+            .Should()
+            .BeEmpty();
     }
 
     // A span that measures something OTHER than the period drags the anchor off it just as a
@@ -135,7 +143,8 @@ public class StatementLineFactsAnchorTests
 
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [quarter, twoQuarters],
-            SecFiscalPeriod.Q1
+            SecFiscalPeriod.Q1,
+            reportedPeriodEnd: null
         );
 
         anchored.Should().BeEquivalentTo([quarter]);
@@ -151,7 +160,8 @@ public class StatementLineFactsAnchorTests
 
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [fiscalYear, paymentWindow],
-            SecFiscalPeriod.FullYear
+            SecFiscalPeriod.FullYear,
+            reportedPeriodEnd: null
         );
 
         anchored.Should().BeEquivalentTo([fiscalYear]);
@@ -167,7 +177,8 @@ public class StatementLineFactsAnchorTests
 
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [earlier, later],
-            SecFiscalPeriod.FullYear
+            SecFiscalPeriod.FullYear,
+            reportedPeriodEnd: null
         );
 
         anchored.Should().BeEquivalentTo([later]);
@@ -187,7 +198,8 @@ public class StatementLineFactsAnchorTests
 
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [earlier, latest],
-            SecFiscalPeriod.FullYear
+            SecFiscalPeriod.FullYear,
+            reportedPeriodEnd: null
         );
 
         anchored.Should().BeEquivalentTo([latest]);
@@ -203,10 +215,150 @@ public class StatementLineFactsAnchorTests
 
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [stub, inceptionToDate],
-            SecFiscalPeriod.FullYear
+            SecFiscalPeriod.FullYear,
+            reportedPeriodEnd: null
         );
 
         anchored.Should().BeEquivalentTo([stub]);
+    }
+
+    // A span of the right LENGTH can measure another period entirely. Adobe tags a 25-day
+    // segment window into its FY2025 Q1 bucket; it conforms, ends latest, and so anchored the
+    // quarter on 2025-03-26, rendering ONE line instead of the eleven of the real quarter.
+    // The company's own balance sheet for that quarter states 2025-02-28.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_ReportedPeriodEndWithAConformingSpan_AnchorsThere()
+    {
+        var quarter = Duration(new DateOnly(2024, 11, 30), new DateOnly(2025, 2, 28), 1_000m);
+        var alsoTheQuarter = Duration(new DateOnly(2024, 11, 30), new DateOnly(2025, 2, 28), 500m);
+        var segmentWindow = Dimensional(
+            Duration(new DateOnly(2025, 3, 1), new DateOnly(2025, 3, 26), 7m)
+        );
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [quarter, alsoTheQuarter, segmentWindow],
+            SecFiscalPeriod.Q1,
+            reportedPeriodEnd: new DateOnly(2025, 2, 28)
+        );
+
+        anchored.Should().BeEquivalentTo([quarter, alsoTheQuarter]);
+    }
+
+    // The balance-sheet date is evidence, never an override. A filer can file its
+    // quarter-end balance sheet under the NEXT fiscal stamp, leaving only the prior
+    // year-end instant under this one (DELL); anchoring on it would replace a complete
+    // quarter with the comparative column.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_ReportedPeriodEndBelowAMeasuredSpan_KeepsTheStatement()
+    {
+        var priorYearComparative = Duration(
+            new DateOnly(2016, 11, 5),
+            new DateOnly(2017, 2, 3),
+            10m
+        );
+        var quarter = Duration(new DateOnly(2017, 2, 4), new DateOnly(2017, 5, 5), 1_000m);
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [priorYearComparative, quarter],
+            SecFiscalPeriod.Q1,
+            reportedPeriodEnd: new DateOnly(2017, 2, 3)
+        );
+
+        anchored.Should().BeEquivalentTo([quarter]);
+    }
+
+    // A wrong balance-sheet date must change nothing. HOFT's FY2025 bucket carries a stray
+    // 2025-03-31 instant while its year ended 2025-02-02; no span ends there, so the ladder
+    // decides exactly as before.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_ReportedPeriodEndWithNoConformingSpan_FallsBack()
+    {
+        var trailingTwelveMonths = Duration(
+            new DateOnly(2024, 5, 6),
+            new DateOnly(2025, 5, 4),
+            1_000m
+        );
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [trailingTwelveMonths],
+            SecFiscalPeriod.FullYear,
+            reportedPeriodEnd: new DateOnly(2025, 3, 31)
+        );
+
+        anchored.Should().BeEquivalentTo([trailingTwelveMonths]);
+    }
+
+    // The proof behind the two OSS call sites passing null: over CONSOLIDATED facts the
+    // latest conforming span already IS the entity's own measured endpoint, so no date can
+    // move the anchor — above it nothing conforms, at or below it the floor refuses.
+    [Theory]
+    [InlineData(2021, 12, 31)]
+    [InlineData(2022, 6, 30)]
+    [InlineData(2022, 12, 31)]
+    [InlineData(2023, 3, 31)]
+    public void AnchorToLatestPeriodEnd_ConsolidatedFacts_AreUnmovedByAnyReportedEnd(
+        int year,
+        int month,
+        int day
+    )
+    {
+        var comparative = Duration(new DateOnly(2021, 1, 1), new DateOnly(2021, 12, 31), 900m);
+        var year2022 = Duration(new DateOnly(2022, 1, 1), new DateOnly(2022, 12, 31), 1_000m);
+        var closingCash = Instant(new DateOnly(2022, 12, 31), 250m);
+        List<FinancialFact> facts = [comparative, year2022, closingCash];
+
+        StatementLineFacts
+            .AnchorToLatestPeriodEnd(
+                facts,
+                SecFiscalPeriod.FullYear,
+                reportedPeriodEnd: new DateOnly(year, month, day)
+            )
+            .Should()
+            .BeEquivalentTo(
+                StatementLineFacts.AnchorToLatestPeriodEnd(
+                    facts,
+                    SecFiscalPeriod.FullYear,
+                    reportedPeriodEnd: null
+                )
+            );
+    }
+
+    // A balance sheet is every-fact-an-instant, so it has no conforming span to confirm and
+    // the rule can never fire — 0 of 268,534 balance-sheet buckets move on prod.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_AllInstantStatement_IgnoresTheReportedPeriodEnd()
+    {
+        var comparative = Instant(new DateOnly(2021, 12, 31), 900m);
+        var currentAssets = Instant(new DateOnly(2022, 12, 31), 1_000m);
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [comparative, currentAssets],
+            SecFiscalPeriod.FullYear,
+            reportedPeriodEnd: new DateOnly(2021, 12, 31)
+        );
+
+        anchored.Should().BeEquivalentTo([currentAssets]);
+    }
+
+    // A period a filer tagged only per-segment has no measured consolidated span to floor
+    // against, so a confirmed date still anchors it.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_DimensionalOnlyAtTheReportedEnd_StillAnchorsThere()
+    {
+        var segmentQuarter = Dimensional(
+            Duration(new DateOnly(2024, 11, 30), new DateOnly(2025, 2, 28), 40m)
+        );
+        var laterSegmentWindow = Dimensional(
+            Duration(new DateOnly(2025, 3, 1), new DateOnly(2025, 3, 26), 7m)
+        );
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [segmentQuarter, laterSegmentWindow],
+            SecFiscalPeriod.Q1,
+            reportedPeriodEnd: new DateOnly(2025, 2, 28)
+        );
+
+        anchored.Should().BeEquivalentTo([segmentQuarter]);
     }
 
     private static FinancialFact Dimensional(FinancialFact fact)


### PR DESCRIPTION
## The shape

A statement is narrowed to one reporting endpoint — the anchor — before any line is picked. The gate that endpoint passes is a span's **length**, and a span of the right length can measure a different period.

Adobe tags a 25-day segment window into its FY2025 Q1 bucket. It conforms as a quarter, it ends latest, so it anchors the statement:

| | span | dimensions | tags |
|---|---|---|---|
| current anchor | 2025-03-01 → 2025-03-26 (25 days) | segment | 1 |
| the real quarter | 2024-11-30 → 2025-02-28 (90 days) | consolidated | 11 |
| Adobe's own balance sheet | 2025-02-28 | consolidated | 26 |

The FY2025 Q1 cash flow renders **one line** instead of eleven. Same for FY2024 Q1, and for Autodesk, General Mills, Conagra, Medtronic, Deere, Johnson Controls, TE Connectivity and Canopy Growth.

## The rule

`AnchorToLatestPeriodEnd` gains a `reportedPeriodEnd` — the date the period's own consolidated balance sheet states — and anchors there when a conforming span ends on that date.

The date is **evidence, not an override**. It applies only at or above the latest **consolidated** conforming span, because that span is the entity's own current column and anchoring below it publishes the comparative one. DELL files each quarter-end balance sheet under the *next* fiscal stamp, so its Q1 bucket holds only the prior year-end instant; without that floor the rule replaced a 14-line Q1 cash flow with a single line.

A wrong date changes nothing: no span ends there, so the existing ladder decides unchanged.

## Why both call sites here pass null

Over `GetConsolidatedByStock` the latest conforming span already *is* the measured endpoint, so a confirmed date either equals it (no move) or has no span (refused). Proved by `AnchorToLatestPeriodEnd_ConsolidatedFacts_AreUnmovedByAnyReportedEnd`, and measured on production: **0 of 283,520** consolidated cash-flow buckets and **0 of 285,754** income-statement buckets move. The surface that also loads dimensional facts supplies the date instead.

## Verification

- 4,808 unit tests green; six new anchor tests, all three mutants of the new rule killed (floor removed, floor counting dimensional spans, rule disabled).
- Production simulation over the whole corpus, dimensional scope: cash flow 685 of 290,770 buckets move (548 gain lines, 11 lose), income statement 252 of 289,551 (249 gain, 1 lose), **balance sheet 0 of 268,534**, and none renders empty.
- All 12 buckets that lose lines currently render **zero consolidated lines** — every one is a dimensional stub from another period. General Mills FY2020 Q2 goes from a 3-line June–August 2020 segment window to the real 2-line quarter ending 2019-11-24, which its 25-tag balance sheet confirms.
- Janus Henderson — the case that blocked the previous attempt at this — is untouched on every statement and period.

https://claude.ai/code/session_01SE71rLG6DQTLTpDr6BfcU7