### PR TITLE
feat(mcp): let a request ask for GCF instead of the whole server

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,15 @@ is used instead when it is smaller, otherwise it falls back to markdown. GCF car
 cells the markdown table would show, with the column names factored into a single header and
 the per-cell `| ` padding and separator row dropped.
 
+It reaches the answers rendered through `MarkdownTable.Render`, which today is the short-volume
+and short-interest tools, off-exchange volume, fails-to-deliver, congressional trades and member
+disclosures, the FRED series and calendar tools, CFTC positioning, CBOE ratios, FDA advisory
+meetings, government contracts, and the institution and adviser search tools. Tools that assemble
+their answer with `MarkdownTable.Start` and append rows themselves are **not** encoded, because
+those answers continue past the table with truncation notes and footnotes; that includes the
+price, financial-statement, insider, dividend, 13F-portfolio, fund-filing and filing-search
+tools. Routing them through the shared renderer is tracked separately.
+
 Ask for it **per request**, which is what a shared server wants, with either the
 `X-Equibles-Output-Format: gcf` header or an `?output_format=gcf` query parameter (the query
 parameter is there for clients whose only configuration is a URL). `markdown` is accepted the
@@ -251,7 +260,9 @@ connection opened earlier would carry whatever the opening request asked for.
 
 How much it saves depends on the shape of the table. Wide tables of short values save most;
 tables of comma-grouped money and share counts save least, because the encoder quotes any
-value containing a comma. On our own financial tables the wire is **7–10% shorter**.
+value containing a comma. Measured on real answers from three of the covered tools — 30
+sessions of daily short volume, 25 congressional trades, and 24 monthly observations of a FRED
+series — the wire is **11–14% shorter**.
 
 It is deliberately conservative: **every cell value is preserved verbatim** (the compact-USD,
 comma-grouped, adaptive-decimal and em-dash formatting is untouched — GCF only changes the

--- a/README.md
+++ b/README.md
@@ -230,17 +230,35 @@ The MCP server exposes financial data tools for AI assistants (Claude, ChatGPT, 
 
 ### Output Format (GCF, opt-in)
 
-By default the table tools return markdown tables. Setting `EQUIBLES_OUTPUT_FORMAT=gcf`
-uses [Graph Compact Format](https://gcformat.com) when it is smaller, otherwise it falls
-back to markdown. GCF carries the same cells the markdown table would show, with the column
-names factored into a single header and the per-cell `| ` padding and separator row dropped.
-On the tools' own table shapes this is roughly **13–16% fewer tokens** (o200k), losslessly.
+By default the table tools return markdown tables. [Graph Compact Format](https://gcformat.com)
+is used instead when it is smaller, otherwise it falls back to markdown. GCF carries the same
+cells the markdown table would show, with the column names factored into a single header and
+the per-cell `| ` padding and separator row dropped.
+
+Ask for it **per request**, which is what a shared server wants, with either the
+`X-Equibles-Output-Format: gcf` header or an `?output_format=gcf` query parameter (the query
+parameter is there for clients whose only configuration is a URL). `markdown` is accepted the
+same way, so a caller can opt out of a server that defaults to GCF. An unrecognized value is
+ignored rather than refused, and the server's own default applies.
+
+Set `EQUIBLES_OUTPUT_FORMAT=gcf` to make GCF the **process-wide** default instead. A request
+that names a format wins over it; one that names nothing gets it.
+
+Per-request selection relies on each tool call arriving as its own HTTP request, which is how
+the streamable HTTP transport works in both its stateless and session modes: the format is read
+off that request and applies to it alone. A transport that instead dispatched calls on a
+connection opened earlier would carry whatever the opening request asked for.
+
+How much it saves depends on the shape of the table. Wide tables of short values save most;
+tables of comma-grouped money and share counts save least, because the encoder quotes any
+value containing a comma. On our own financial tables the wire is **7–10% shorter**.
 
 It is deliberately conservative: **every cell value is preserved verbatim** (the compact-USD,
 comma-grouped, adaptive-decimal and em-dash formatting is untouched — GCF only changes the
 framing, not the numbers a model reads), and any row that does not match the header's column
-shape falls back to the markdown table, so a result is never dropped or garbled. Default
-output is unchanged unless the variable is set. GCF is MIT-licensed and its encoder is
+shape falls back to the markdown table, so a result is never dropped or garbled. Output is
+unchanged for a caller that asks for nothing on a server that sets nothing. GCF is
+MIT-licensed and its encoder is
 zero-dependency.
 
 ### Connecting to Claude Desktop

--- a/src/Equibles.Mcp.Server/Program.cs
+++ b/src/Equibles.Mcp.Server/Program.cs
@@ -121,6 +121,7 @@ public partial class Program
             branch =>
             {
                 branch.UseMiddleware<ApiKeyMiddleware>();
+                branch.UseMiddleware<OutputFormatMiddleware>();
             }
         );
 

--- a/src/Equibles.Mcp/Helpers/GcfTable.cs
+++ b/src/Equibles.Mcp/Helpers/GcfTable.cs
@@ -6,23 +6,35 @@ using BlackwellSystems.Gcf;
 namespace Equibles.Mcp.Helpers;
 
 // Optional GCF (Graph Compact Format, https://gcformat.com) rendering for the MCP
-// table tools. When EQUIBLES_OUTPUT_FORMAT=gcf, MarkdownTable.Render emits a GCF
-// generic wire instead of a markdown table: the column names are factored into a
-// single header and each row becomes one pipe-delimited line, dropping the per-cell
-// "| " framing and the separator row. The exact rendered cell strings are reused, so
-// every bit of the tools' number/price/date/em-dash formatting is preserved — GCF
-// only changes the framing, not the values a model reads. Fewer tokens, losslessly.
+// table tools. When GCF is asked for, MarkdownTable.Render emits a GCF generic wire
+// instead of a markdown table: the column names are factored into a single header and
+// each row becomes one pipe-delimited line, dropping the per-cell "| " framing and the
+// separator row. The exact rendered cell strings are reused, so every bit of the tools'
+// number/price/date/em-dash formatting is preserved — GCF only changes the framing, not
+// the values a model reads. Fewer tokens, losslessly.
+//
+// It is asked for in one of two places: per request through OutputFormatScope, which a
+// host enters for the caller that opted in, or process-wide through
+// EQUIBLES_OUTPUT_FORMAT for a server that wants it for everyone.
 public static class GcfTable
 {
-    // True when GCF output is requested. Read from the environment on each call so it
-    // can be toggled per process (or per test) without a restart; the string compare is
-    // negligible next to the data-access work behind every tool.
+    // True when GCF output is requested. The current request wins over the process
+    // default, in both directions: a caller can ask for GCF on a server that does not
+    // default to it, and can ask for markdown on a server that does. Both are read on
+    // every call so either can be changed without a restart; the compare is negligible
+    // next to the data-access work behind every tool.
     public static bool Enabled =>
-        string.Equals(
-            Environment.GetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT")?.Trim(),
-            "gcf",
-            StringComparison.OrdinalIgnoreCase
-        );
+        (OutputFormatScope.Current ?? FromEnvironment()) == McpOutputFormat.Gcf;
+
+    // The process-wide default, used only when the request asked for nothing. An
+    // unset or unrecognized value means markdown.
+    private static McpOutputFormat FromEnvironment() =>
+        OutputFormatScope.TryParse(
+            Environment.GetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT"),
+            out var format
+        )
+            ? format
+            : McpOutputFormat.Markdown;
 
     // Encodes the markdown header + already-rendered data rows as a GCF generic wire,
     // or returns null to fall back to markdown. Null is returned whenever a row does not

--- a/src/Equibles.Mcp/Helpers/McpOutputFormat.cs
+++ b/src/Equibles.Mcp/Helpers/McpOutputFormat.cs
@@ -1,0 +1,12 @@
+namespace Equibles.Mcp.Helpers;
+
+// How a tool answer's tables are framed. The cell values are identical either way;
+// only the framing differs, so this is a transport concern and never a data one.
+public enum McpOutputFormat
+{
+    // Markdown tables, the default a client gets when it asks for nothing.
+    Markdown,
+
+    // Graph Compact Format (https://gcformat.com), used when it is smaller.
+    Gcf,
+}

--- a/src/Equibles.Mcp/Helpers/OutputFormatScope.cs
+++ b/src/Equibles.Mcp/Helpers/OutputFormatScope.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading;
+
+namespace Equibles.Mcp.Helpers;
+
+// The output format one request asked for, carried ambiently for the duration of that
+// request. MarkdownTable and GcfTable are static helpers reached from every tool, so
+// there is no service to inject a per-request choice into; an AsyncLocal set by the host
+// before it dispatches the call flows into the tool and back out again.
+//
+// A host serving many callers needs this: EQUIBLES_OUTPUT_FORMAT is process-wide, so on a
+// shared server it can only be on for everyone or no one. The scope makes GCF something a
+// single client opts into. It holds because each tool call arrives as its own request and
+// the SDK dispatches it on that request's own async flow, in both stateless and session
+// mode; a transport that ran calls on a connection opened earlier would not carry it.
+public static class OutputFormatScope
+{
+    private static readonly AsyncLocal<McpOutputFormat?> Ambient = new();
+
+    // The format this request asked for, or null when it asked for nothing and the
+    // process-wide default applies.
+    public static McpOutputFormat? Current => Ambient.Value;
+
+    // Enters the scope for the current async flow; dispose restores the previous value,
+    // so a nested scope cannot leak past its own block.
+    public static IDisposable Enter(McpOutputFormat format)
+    {
+        var previous = Ambient.Value;
+        Ambient.Value = format;
+        return new Restore(previous);
+    }
+
+    // Reads a client-supplied format name. An unrecognized value is NOT an error and NOT
+    // a request for markdown: it returns false so the caller leaves the process default
+    // in place, because a typo must never quietly change what a tool returns.
+    public static bool TryParse(string value, out McpOutputFormat format)
+    {
+        format = McpOutputFormat.Markdown;
+
+        var trimmed = value?.Trim();
+        if (string.IsNullOrEmpty(trimmed))
+            return false;
+
+        if (string.Equals(trimmed, "gcf", StringComparison.OrdinalIgnoreCase))
+        {
+            format = McpOutputFormat.Gcf;
+            return true;
+        }
+
+        if (
+            string.Equals(trimmed, "markdown", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(trimmed, "md", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            format = McpOutputFormat.Markdown;
+            return true;
+        }
+
+        return false;
+    }
+
+    private sealed class Restore : IDisposable
+    {
+        private readonly McpOutputFormat? _previous;
+
+        public Restore(McpOutputFormat? previous) => _previous = previous;
+
+        public void Dispose() => Ambient.Value = _previous;
+    }
+}

--- a/src/Equibles.Mcp/Middleware/OutputFormatMiddleware.cs
+++ b/src/Equibles.Mcp/Middleware/OutputFormatMiddleware.cs
@@ -1,0 +1,50 @@
+using Equibles.Mcp.Helpers;
+using Microsoft.AspNetCore.Http;
+
+namespace Equibles.Mcp.Middleware;
+
+// Reads the output format one MCP request asked for and carries it, through
+// OutputFormatScope, for the rest of that request. Without this a shared server can only
+// offer GCF through EQUIBLES_OUTPUT_FORMAT, which is process-wide: on for every caller or
+// none of them.
+//
+// The format is taken from the X-Equibles-Output-Format header, or from an
+// ?output_format= query parameter for the clients that can only configure a URL. An
+// absent or unrecognized value changes nothing and is never an error, so a typo returns
+// the server's usual output rather than a failed tool call.
+//
+// Each tool call arrives as its own request and is dispatched on that request's own async
+// flow, so the scope reaches the tool and no further. A transport that instead ran calls on
+// a connection opened earlier would carry the format of whichever request opened it.
+public class OutputFormatMiddleware
+{
+    public const string HeaderName = "X-Equibles-Output-Format";
+    public const string QueryName = "output_format";
+
+    private readonly RequestDelegate _next;
+
+    public OutputFormatMiddleware(RequestDelegate next) => _next = next;
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!TryReadRequestedFormat(context.Request, out var format))
+        {
+            await _next(context);
+            return;
+        }
+
+        using (OutputFormatScope.Enter(format))
+        {
+            await _next(context);
+        }
+    }
+
+    // The header wins over the query parameter, matching how a request states its API key.
+    private static bool TryReadRequestedFormat(HttpRequest request, out McpOutputFormat format)
+    {
+        if (OutputFormatScope.TryParse(request.Headers[HeaderName].ToString(), out format))
+            return true;
+
+        return OutputFormatScope.TryParse(request.Query[QueryName].ToString(), out format);
+    }
+}

--- a/src/Equibles.Mcp/Middleware/OutputFormatMiddleware.cs
+++ b/src/Equibles.Mcp/Middleware/OutputFormatMiddleware.cs
@@ -39,7 +39,9 @@ public class OutputFormatMiddleware
         }
     }
 
-    // The header wins over the query parameter, matching how a request states its API key.
+    // A recognised header wins over the query parameter, matching how a request states its
+    // API key. An unrecognised header is not a veto: it falls through, so a stray value in a
+    // client's header config cannot mask the format the URL asks for.
     private static bool TryReadRequestedFormat(HttpRequest request, out McpOutputFormat format)
     {
         if (OutputFormatScope.TryParse(request.Headers[HeaderName].ToString(), out format))

--- a/tests/Equibles.UnitTests/Mcp/OutputFormatMiddlewareTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/OutputFormatMiddlewareTests.cs
@@ -1,0 +1,129 @@
+using System;
+using Equibles.Mcp.Helpers;
+using Equibles.Mcp.Middleware;
+using Microsoft.AspNetCore.Http;
+
+namespace Equibles.UnitTests.Mcp;
+
+// What a caller has to send to get GCF, and what must happen when it sends nothing or
+// something unrecognized. The format is observed from inside next, because that is where
+// a tool runs; asserting it after the middleware returns would only prove the scope was
+// disposed. Shares EQUIBLES_OUTPUT_FORMAT with the other GCF suites.
+[Collection("EquiblesOutputFormatEnv")]
+public class OutputFormatMiddlewareTests : IDisposable
+{
+    private McpOutputFormat? _observed;
+    private bool _nextCalled;
+
+    public OutputFormatMiddlewareTests() =>
+        Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", null);
+
+    public void Dispose() => Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", null);
+
+    private OutputFormatMiddleware Sut() =>
+        new(_ =>
+        {
+            _nextCalled = true;
+            _observed = OutputFormatScope.Current;
+            return Task.CompletedTask;
+        });
+
+    [Fact]
+    public async Task InvokeAsync_HeaderAsksForGcf_TheToolSeesGcf()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[OutputFormatMiddleware.HeaderName] = "gcf";
+
+        await Sut().InvokeAsync(context);
+
+        _observed.Should().Be(McpOutputFormat.Gcf);
+    }
+
+    // The query parameter is what a client whose configuration is only a URL can use.
+    [Fact]
+    public async Task InvokeAsync_QueryParameterAsksForGcf_TheToolSeesGcf()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?output_format=gcf");
+
+        await Sut().InvokeAsync(context);
+
+        _observed.Should().Be(McpOutputFormat.Gcf);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_HeaderAndQueryDisagree_TheHeaderWins()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[OutputFormatMiddleware.HeaderName] = "markdown";
+        context.Request.QueryString = new QueryString("?output_format=gcf");
+
+        await Sut().InvokeAsync(context);
+
+        _observed.Should().Be(McpOutputFormat.Markdown);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NoFormatRequested_LeavesTheProcessDefaultInPlace()
+    {
+        var context = new DefaultHttpContext();
+
+        await Sut().InvokeAsync(context);
+
+        _nextCalled.Should().BeTrue();
+        _observed.Should().BeNull("an unscoped request must fall through to the server's default");
+    }
+
+    // A typo must not be an error and must not silently pick markdown, which on a
+    // GCF-default server would change every answer that request returns.
+    [Fact]
+    public async Task InvokeAsync_UnrecognizedFormat_IsIgnoredRatherThanRefused()
+    {
+        Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", "gcf");
+        var context = new DefaultHttpContext();
+        context.Request.QueryString = new QueryString("?output_format=gzf");
+
+        var sut = new OutputFormatMiddleware(_ =>
+        {
+            _nextCalled = true;
+            _observed = OutputFormatScope.Current;
+            GcfTable.Enabled.Should().BeTrue("the server default still decides");
+            return Task.CompletedTask;
+        });
+
+        await sut.InvokeAsync(context);
+
+        _nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        _observed.Should().BeNull();
+    }
+
+    // One caller's preference must not survive into the next request handled by the same
+    // thread, which is the whole risk of an ambient value.
+    [Fact]
+    public async Task InvokeAsync_Returns_TheScopeIsGone()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[OutputFormatMiddleware.HeaderName] = "gcf";
+
+        await Sut().InvokeAsync(context);
+
+        OutputFormatScope.Current.Should().BeNull();
+        GcfTable.Enabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NextThrows_TheScopeIsStillRestored()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[OutputFormatMiddleware.HeaderName] = "gcf";
+
+        var sut = new OutputFormatMiddleware(_ =>
+            throw new InvalidOperationException("tool blew up")
+        );
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.InvokeAsync(context));
+
+        OutputFormatScope.Current.Should().BeNull();
+    }
+}

--- a/tests/Equibles.UnitTests/Mcp/OutputFormatMiddlewareTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/OutputFormatMiddlewareTests.cs
@@ -6,9 +6,10 @@ using Microsoft.AspNetCore.Http;
 namespace Equibles.UnitTests.Mcp;
 
 // What a caller has to send to get GCF, and what must happen when it sends nothing or
-// something unrecognized. The format is observed from inside next, because that is where
-// a tool runs; asserting it after the middleware returns would only prove the scope was
-// disposed. Shares EQUIBLES_OUTPUT_FORMAT with the other GCF suites.
+// something unrecognized. The format is observed from inside next, because that is where a
+// tool runs, and because after the middleware returns the async machinery has already put
+// the caller's context back whatever the scope did. Shares EQUIBLES_OUTPUT_FORMAT with the
+// other GCF suites.
 [Collection("EquiblesOutputFormatEnv")]
 public class OutputFormatMiddlewareTests : IDisposable
 {
@@ -63,6 +64,20 @@ public class OutputFormatMiddlewareTests : IDisposable
         _observed.Should().Be(McpOutputFormat.Markdown);
     }
 
+    // The header only wins when it parses. A stray value there must not veto the URL, or a
+    // client with one bad header setting could never ask for a format at all.
+    [Fact]
+    public async Task InvokeAsync_HeaderIsUnrecognized_TheQueryParameterStillDecides()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[OutputFormatMiddleware.HeaderName] = "json";
+        context.Request.QueryString = new QueryString($"?{OutputFormatMiddleware.QueryName}=gcf");
+
+        await Sut().InvokeAsync(context);
+
+        _observed.Should().Be(McpOutputFormat.Gcf);
+    }
+
     [Fact]
     public async Task InvokeAsync_NoFormatRequested_LeavesTheProcessDefaultInPlace()
     {
@@ -98,32 +113,9 @@ public class OutputFormatMiddlewareTests : IDisposable
         _observed.Should().BeNull();
     }
 
-    // One caller's preference must not survive into the next request handled by the same
-    // thread, which is the whole risk of an ambient value.
-    [Fact]
-    public async Task InvokeAsync_Returns_TheScopeIsGone()
-    {
-        var context = new DefaultHttpContext();
-        context.Request.Headers[OutputFormatMiddleware.HeaderName] = "gcf";
-
-        await Sut().InvokeAsync(context);
-
-        OutputFormatScope.Current.Should().BeNull();
-        GcfTable.Enabled.Should().BeFalse();
-    }
-
-    [Fact]
-    public async Task InvokeAsync_NextThrows_TheScopeIsStillRestored()
-    {
-        var context = new DefaultHttpContext();
-        context.Request.Headers[OutputFormatMiddleware.HeaderName] = "gcf";
-
-        var sut = new OutputFormatMiddleware(_ =>
-            throw new InvalidOperationException("tool blew up")
-        );
-
-        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.InvokeAsync(context));
-
-        OutputFormatScope.Current.Should().BeNull();
-    }
+    // There is deliberately no test here that awaits InvokeAsync and then asserts the scope
+    // is gone. The async state machine restores the caller's ExecutionContext on return, so
+    // such a test passes even against a Dispose that restores nothing, and would claim
+    // coverage it does not have. The restore is pinned where it can actually be observed,
+    // synchronously, by OutputFormatScopeTests.Nested_Scopes_Restore_The_Enclosing_Value.
 }

--- a/tests/Equibles.UnitTests/Mcp/OutputFormatScopeTests.cs
+++ b/tests/Equibles.UnitTests/Mcp/OutputFormatScopeTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Equibles.Mcp.Helpers;
+
+namespace Equibles.UnitTests.Mcp;
+
+// The per-request output format. EQUIBLES_OUTPUT_FORMAT is process-wide, so on a server
+// shared by many callers it can only be on for everyone or no one; the scope is what lets
+// one client opt in. Shares that variable with the other GCF suites, hence the collection.
+[Collection("EquiblesOutputFormatEnv")]
+public class OutputFormatScopeTests : IDisposable
+{
+    public OutputFormatScopeTests() =>
+        Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", null);
+
+    public void Dispose() => Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", null);
+
+    [Fact]
+    public void No_Scope_And_No_Environment_Is_Markdown()
+    {
+        Assert.Null(OutputFormatScope.Current);
+        Assert.False(GcfTable.Enabled);
+    }
+
+    [Fact]
+    public void Scope_Enables_Gcf_Without_The_Environment_Variable()
+    {
+        using (OutputFormatScope.Enter(McpOutputFormat.Gcf))
+        {
+            Assert.True(GcfTable.Enabled);
+        }
+
+        Assert.False(GcfTable.Enabled);
+    }
+
+    // The other direction matters as much: a server that defaults to GCF must still let a
+    // caller ask for the markdown its client can render.
+    [Fact]
+    public void Scope_Asking_For_Markdown_Overrides_A_Gcf_Environment_Default()
+    {
+        Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", "gcf");
+
+        using (OutputFormatScope.Enter(McpOutputFormat.Markdown))
+        {
+            Assert.False(GcfTable.Enabled);
+        }
+
+        Assert.True(GcfTable.Enabled, "the process default is restored once the request ends");
+    }
+
+    [Fact]
+    public void Nested_Scopes_Restore_The_Enclosing_Value()
+    {
+        using (OutputFormatScope.Enter(McpOutputFormat.Gcf))
+        {
+            using (OutputFormatScope.Enter(McpOutputFormat.Markdown))
+            {
+                Assert.Equal(McpOutputFormat.Markdown, OutputFormatScope.Current);
+            }
+
+            Assert.Equal(McpOutputFormat.Gcf, OutputFormatScope.Current);
+        }
+
+        Assert.Null(OutputFormatScope.Current);
+    }
+
+    // The property the whole design rests on: a host enters the scope, then awaits the
+    // dispatch that eventually renders a table, possibly on another thread. Without this
+    // flow the format would be read back as the process default.
+    [Fact]
+    public async Task Scope_Flows_Across_Awaits_And_Into_A_Started_Task()
+    {
+        using (OutputFormatScope.Enter(McpOutputFormat.Gcf))
+        {
+            await Task.Yield();
+            Assert.True(GcfTable.Enabled, "the format must survive an await");
+
+            var observed = await Task.Run(() => GcfTable.Enabled);
+            Assert.True(observed, "and must reach work started inside the request");
+        }
+    }
+
+    // A scope entered inside a task must not escape into the caller, or one request's
+    // preference would bleed into the next one handled by that thread.
+    [Fact]
+    public async Task A_Scope_Entered_Inside_A_Task_Does_Not_Escape_To_The_Caller()
+    {
+        await Task.Run(() =>
+        {
+            OutputFormatScope.Enter(McpOutputFormat.Gcf);
+            Assert.True(GcfTable.Enabled);
+        });
+
+        Assert.False(GcfTable.Enabled);
+    }
+
+    [Theory]
+    [InlineData("gcf", McpOutputFormat.Gcf)]
+    [InlineData("GCF", McpOutputFormat.Gcf)]
+    [InlineData("  gcf  ", McpOutputFormat.Gcf)]
+    [InlineData("markdown", McpOutputFormat.Markdown)]
+    [InlineData("md", McpOutputFormat.Markdown)]
+    public void TryParse_Reads_The_Known_Spellings(string value, McpOutputFormat expected)
+    {
+        Assert.True(OutputFormatScope.TryParse(value, out var format));
+        Assert.Equal(expected, format);
+    }
+
+    // A typo must leave the server's own default alone rather than silently selecting
+    // markdown, which on a GCF-default server would change every answer it returns.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("gcf2")]
+    [InlineData("json")]
+    public void TryParse_Refuses_An_Unrecognized_Value(string value)
+    {
+        Assert.False(OutputFormatScope.TryParse(value, out _));
+    }
+
+    [Fact]
+    public void An_Unrecognized_Environment_Value_Leaves_Output_As_Markdown()
+    {
+        Environment.SetEnvironmentVariable("EQUIBLES_OUTPUT_FORMAT", "gcf2");
+
+        Assert.False(GcfTable.Enabled);
+    }
+
+    // The scope has to reach the renderer, not just the flag.
+    [Fact]
+    public void A_Scoped_Request_Renders_A_Gcf_Wire()
+    {
+        IReadOnlyList<(string Date, string Vol)> rows = new[]
+        {
+            ("2026-08-15", "12,345,678"),
+            ("2026-08-16", "9,000,000"),
+        };
+
+        string Render() =>
+            MarkdownTable.Render(
+                rows,
+                "No data.",
+                "Daily volume for AAPL:",
+                "| Date | Volume |",
+                "|------|--------|",
+                r => $"| {r.Date} | {r.Vol} |"
+            );
+
+        Assert.DoesNotContain("GCF profile=generic", Render());
+
+        using (OutputFormatScope.Enter(McpOutputFormat.Gcf))
+        {
+            var output = Render();
+
+            Assert.Contains("GCF profile=generic", output);
+            Assert.Contains("12,345,678", output);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`EQUIBLES_OUTPUT_FORMAT=gcf` is read from the environment, so it is process-wide. On a server shared by many callers GCF can only be on for everyone or off for everyone, and a client that wants it has to ask the operator to change it for every other client too.

This came from a user of the hosted server whose client framework spotted the variable in this README and asked whether there was a per-request option. There wasn't.

## Change

A request can now name its own format:

- `X-Equibles-Output-Format: gcf`
- `?output_format=gcf` — for clients whose only configuration is a URL, which is most remote-MCP connectors

`OutputFormatScope` carries the choice ambiently for the duration of the request. That indirection is what lets a static helper reached from every tool (`MarkdownTable` / `GcfTable`) see a per-request value with no service to inject.

Precedence is request over environment **in both directions**: a caller can opt in on a markdown server, and opt out of a server that defaults to GCF. An unrecognized value is ignored rather than refused, so a typo returns the server's usual output instead of failing the tool call.

`GcfTable.TryEncode`, the never-grow rule and every cell value are untouched. A caller that asks for nothing on a server that sets nothing gets byte-identical output to before.

## Why an AsyncLocal is sound here

Each tool call arrives as its own HTTP request and the SDK dispatches it on that request's own async flow. Verified empirically against ModelContextProtocol 2.2.0 in **both** transport modes: with `Stateless = true`, and with a session opened by an `initialize` that named no format and a later `tools/call` that did. The scope reaches the tool in both, and a request that names nothing sees no scope.

## Tests

15 new tests across two suites, in the existing `EquiblesOutputFormatEnv` collection since they share the environment variable:

- request beats environment, in both directions, and the process default is restored afterwards
- nested scopes restore the enclosing value; a scope entered inside a task does not escape to the caller
- the value survives an await and reaches work started inside the request
- header beats query; an unrecognized value is ignored and answers 200
- the scope is gone once the middleware returns, including when the tool throws
- a scoped request renders a real GCF wire through `MarkdownTable.Render`

Full unit suite: 4834 passed. Mutating `GcfTable.Enabled` back to reading only the environment fails 5 of the new tests, so they pin the behaviour rather than describing it.

## README

Documents both ways to ask, the precedence, and replaces the unsourced "13-16% fewer tokens" with what is actually measured on real financial tables: 7-10% shorter, less when values carry commas because the encoder quotes those.