### PR TITLE
fix(statements): weigh every stated balance-sheet date the caller offers

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -43,11 +43,14 @@ public static class StatementLineFacts
     /// filing re-reports comparative prior endpoints under one fiscal stamp, so
     /// anchoring keeps a statement from mixing two reporting dates.
     /// </summary>
-    /// <param name="reportedPeriodEnd">
-    /// The date the period's own consolidated balance sheet states, or null when the
-    /// caller has none. A span of the right LENGTH can still measure another period
-    /// (a trailing-twelve-month window, or a later quarter stamped into this bucket),
-    /// and this is the only independent evidence of where the period ends.
+    /// <param name="reportedPeriodEnds">
+    /// The dates the period's own consolidated balance sheet states, empty when the caller has
+    /// none. A span of the right LENGTH can still measure another period (a
+    /// trailing-twelve-month window, or a later quarter stamped into this bucket), and this is
+    /// the only independent evidence of where the period ends. The caller must offer only dates
+    /// belonging to this fiscal year: a bucket also collects the balance sheets of ADJACENT
+    /// periods, a filing's prior-year comparative columns as well as post-period disclosures,
+    /// and anchoring on one publishes a period the company reported under a different label.
     /// </param>
     /// <remarks>
     /// A statement ends where the spans that MEASURE ITS PERIOD end. A fact filed
@@ -60,7 +63,7 @@ public static class StatementLineFacts
     public static List<FinancialFact> AnchorToLatestPeriodEnd(
         IReadOnlyCollection<FinancialFact> facts,
         SecFiscalPeriod fiscalPeriod,
-        DateOnly? reportedPeriodEnd
+        IReadOnlyCollection<DateOnly> reportedPeriodEnds
     )
     {
         if (facts.Count == 0)
@@ -68,19 +71,24 @@ public static class StatementLineFacts
 
         var conforming = facts.Where(f => MeasuresGranularity(f, fiscalPeriod)).ToList();
 
-        // The balance-sheet date settles which same-length span measures THIS period —
-        // but only at or above the latest span the entity itself measured. A filer can file
-        // its quarter-end balance sheet under the NEXT fiscal stamp (DELL), leaving only
-        // the prior year's same-quarter instant in this bucket; anchoring there would
-        // publish the comparative column in place of a complete statement. A period tagged
-        // only per-segment has no such span, so a confirmed date still anchors it.
-        if (reportedPeriodEnd is { } reported && conforming.Any(f => f.PeriodEnd == reported))
+        // The balance-sheet dates settle which same-length span measures THIS period, but only
+        // at or above the latest span the entity itself measured: below that span lies the
+        // comparative column, which DELL leaves here by filing each quarter-end balance sheet
+        // under the NEXT fiscal stamp. Every offered date is weighed rather than just the
+        // latest, or a stray one-tag instant masks the real year end (HOFT's 2025-03-31).
+        if (reportedPeriodEnds is { Count: > 0 })
         {
             var measured = conforming
                 .Where(f => string.IsNullOrEmpty(f.DimensionsKey))
                 .Select(f => (DateOnly?)f.PeriodEnd)
                 .Max();
-            if (measured is null || reported >= measured)
+            var confirmed = reportedPeriodEnds
+                .Where(d =>
+                    (measured is null || d >= measured) && conforming.Any(f => f.PeriodEnd == d)
+                )
+                .Select(d => (DateOnly?)d)
+                .Max();
+            if (confirmed is { } reported)
                 return facts.Where(f => f.PeriodEnd == reported).ToList();
         }
         var spans = facts

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -171,15 +171,15 @@ public class FinancialStatementTools
                 // concept can retain an earlier end under the same (year, period). Anchor the
                 // statement to one actual period end before selecting line values so it cannot
                 // silently combine different balance dates or flow endpoints.
-                // No balance-sheet date is loaded, and none is needed: this tool reads
+                // No balance-sheet dates are loaded, and none are needed: this tool reads
                 // GetConsolidatedByStock, so the latest conforming span IS the entity's own
                 // measured endpoint and the rule provably cannot move a consolidated-only
                 // fact set (StatementLineFactsAnchorTests). A surface that also loads
-                // DIMENSIONAL facts must pass one — see FinancialStatementsHelper.
+                // DIMENSIONAL facts must pass them — see FinancialStatementsHelper.
                 facts = StatementLineFacts.AnchorToLatestPeriodEnd(
                     facts,
                     selectedPeriod,
-                    reportedPeriodEnd: null
+                    reportedPeriodEnds: []
                 );
 
                 // A 10-Q tags each line under one fiscal (year, period) for both the

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -747,7 +747,7 @@ public class StockTabService
         facts = StatementLineFacts.AnchorToLatestPeriodEnd(
             facts,
             fiscalPeriod,
-            reportedPeriodEnd: null
+            reportedPeriodEnds: []
         );
 
         // The currently-reported fact per concept: span-aware so a quarter never

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
@@ -27,7 +27,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [revenue, operatingCashFlow, cashAtEndOfPeriod, dividendPaymentDate],
             SecFiscalPeriod.FullYear,
-            reportedPeriodEnd: null
+            reportedPeriodEnds: []
         );
 
         anchored
@@ -52,7 +52,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [comparative, currentAssets, currentLiabilities],
             SecFiscalPeriod.FullYear,
-            reportedPeriodEnd: null
+            reportedPeriodEnds: []
         );
 
         anchored.Should().BeEquivalentTo([currentAssets, currentLiabilities]);
@@ -68,7 +68,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [priorYear, currentYear],
             SecFiscalPeriod.FullYear,
-            reportedPeriodEnd: null
+            reportedPeriodEnds: []
         );
 
         anchored.Should().BeEquivalentTo([currentYear]);
@@ -94,7 +94,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [operatingCashFlow, dividendPaymentDate],
             SecFiscalPeriod.FullYear,
-            reportedPeriodEnd: null
+            reportedPeriodEnds: []
         );
 
         anchored
@@ -116,7 +116,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [earlier, latest],
             SecFiscalPeriod.FullYear,
-            reportedPeriodEnd: null
+            reportedPeriodEnds: []
         );
 
         anchored.Should().BeEquivalentTo([latest]);
@@ -126,7 +126,7 @@ public class StatementLineFactsAnchorTests
     public void AnchorToLatestPeriodEnd_NoFacts_ReturnsEmpty()
     {
         StatementLineFacts
-            .AnchorToLatestPeriodEnd([], SecFiscalPeriod.FullYear, reportedPeriodEnd: null)
+            .AnchorToLatestPeriodEnd([], SecFiscalPeriod.FullYear, reportedPeriodEnds: [])
             .Should()
             .BeEmpty();
     }
@@ -144,7 +144,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [quarter, twoQuarters],
             SecFiscalPeriod.Q1,
-            reportedPeriodEnd: null
+            reportedPeriodEnds: []
         );
 
         anchored.Should().BeEquivalentTo([quarter]);
@@ -161,7 +161,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [fiscalYear, paymentWindow],
             SecFiscalPeriod.FullYear,
-            reportedPeriodEnd: null
+            reportedPeriodEnds: []
         );
 
         anchored.Should().BeEquivalentTo([fiscalYear]);
@@ -178,7 +178,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [earlier, later],
             SecFiscalPeriod.FullYear,
-            reportedPeriodEnd: null
+            reportedPeriodEnds: []
         );
 
         anchored.Should().BeEquivalentTo([later]);
@@ -199,7 +199,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [earlier, latest],
             SecFiscalPeriod.FullYear,
-            reportedPeriodEnd: null
+            reportedPeriodEnds: []
         );
 
         anchored.Should().BeEquivalentTo([latest]);
@@ -216,7 +216,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [stub, inceptionToDate],
             SecFiscalPeriod.FullYear,
-            reportedPeriodEnd: null
+            reportedPeriodEnds: []
         );
 
         anchored.Should().BeEquivalentTo([stub]);
@@ -238,10 +238,53 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [quarter, alsoTheQuarter, segmentWindow],
             SecFiscalPeriod.Q1,
-            reportedPeriodEnd: new DateOnly(2025, 2, 28)
+            reportedPeriodEnds: [new DateOnly(2025, 2, 28)]
         );
 
         anchored.Should().BeEquivalentTo([quarter, alsoTheQuarter]);
+    }
+
+    // A bucket can carry several stated balance-sheet dates, and the LATEST is not always a
+    // balance sheet: HOFT's FY2025 bucket holds its real 25-tag year end at 2025-02-02 beside a
+    // one-tag stray at 2025-03-31. Taking only the maximum let the stray mask the year and the
+    // ladder published a dimensional trailing-twelve-month window instead.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_StrayLaterReportedEnd_StillAnchorsOnTheStatedYear()
+    {
+        var fiscalYear = Duration(new DateOnly(2024, 1, 29), new DateOnly(2025, 2, 2), 1_000m);
+        var alsoTheYear = Duration(new DateOnly(2024, 1, 29), new DateOnly(2025, 2, 2), 500m);
+        var trailingTwelveMonths = Dimensional(
+            Duration(new DateOnly(2024, 5, 1), new DateOnly(2025, 5, 4), 7m)
+        );
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [fiscalYear, alsoTheYear, trailingTwelveMonths],
+            SecFiscalPeriod.FullYear,
+            reportedPeriodEnds: [new DateOnly(2025, 3, 31), new DateOnly(2025, 2, 2)]
+        );
+
+        anchored.Should().BeEquivalentTo([fiscalYear, alsoTheYear]);
+    }
+
+    // Weighing every stated date does not weaken the floor: a bucket whose dates ALL sit below
+    // the entity's own measured span keeps that span, which is DELL's comparative-column shape.
+    [Fact]
+    public void AnchorToLatestPeriodEnd_EveryReportedEndBelowTheMeasuredSpan_KeepsTheStatement()
+    {
+        var priorYearComparative = Duration(
+            new DateOnly(2024, 2, 3),
+            new DateOnly(2024, 5, 3),
+            10m
+        );
+        var quarter = Duration(new DateOnly(2025, 2, 1), new DateOnly(2025, 5, 2), 1_000m);
+
+        var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
+            [priorYearComparative, quarter],
+            SecFiscalPeriod.Q1,
+            reportedPeriodEnds: [new DateOnly(2024, 5, 3), new DateOnly(2024, 2, 3)]
+        );
+
+        anchored.Should().BeEquivalentTo([quarter]);
     }
 
     // The floor is a floor, not an equality: the confirmed date may sit ABOVE the latest
@@ -268,7 +311,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [consolidatedComparative, theQuarter, alsoTheQuarter, segmentWindow],
             SecFiscalPeriod.Q1,
-            reportedPeriodEnd: new DateOnly(2025, 2, 28)
+            reportedPeriodEnds: [new DateOnly(2025, 2, 28)]
         );
 
         anchored.Should().BeEquivalentTo([theQuarter, alsoTheQuarter]);
@@ -291,7 +334,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [priorYearComparative, quarter],
             SecFiscalPeriod.Q1,
-            reportedPeriodEnd: new DateOnly(2024, 5, 3)
+            reportedPeriodEnds: [new DateOnly(2024, 5, 3)]
         );
 
         anchored.Should().BeEquivalentTo([quarter]);
@@ -312,7 +355,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [trailingTwelveMonths],
             SecFiscalPeriod.FullYear,
-            reportedPeriodEnd: new DateOnly(2025, 3, 31)
+            reportedPeriodEnds: [new DateOnly(2025, 3, 31)]
         );
 
         anchored.Should().BeEquivalentTo([trailingTwelveMonths]);
@@ -341,14 +384,14 @@ public class StatementLineFactsAnchorTests
             .AnchorToLatestPeriodEnd(
                 facts,
                 SecFiscalPeriod.FullYear,
-                reportedPeriodEnd: new DateOnly(year, month, day)
+                reportedPeriodEnds: [new DateOnly(year, month, day)]
             )
             .Should()
             .BeEquivalentTo(
                 StatementLineFacts.AnchorToLatestPeriodEnd(
                     facts,
                     SecFiscalPeriod.FullYear,
-                    reportedPeriodEnd: null
+                    reportedPeriodEnds: []
                 )
             );
     }
@@ -364,7 +407,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [comparative, currentAssets],
             SecFiscalPeriod.FullYear,
-            reportedPeriodEnd: new DateOnly(2021, 12, 31)
+            reportedPeriodEnds: [new DateOnly(2021, 12, 31)]
         );
 
         anchored.Should().BeEquivalentTo([currentAssets]);
@@ -385,7 +428,7 @@ public class StatementLineFactsAnchorTests
         var anchored = StatementLineFacts.AnchorToLatestPeriodEnd(
             [segmentQuarter, laterSegmentWindow],
             SecFiscalPeriod.Q1,
-            reportedPeriodEnd: new DateOnly(2025, 2, 28)
+            reportedPeriodEnds: [new DateOnly(2025, 2, 28)]
         );
 
         anchored.Should().BeEquivalentTo([segmentQuarter]);


### PR DESCRIPTION
Follow-up to #4509, which fixed the general case but left its own headline company wrong.

## The shape

The anchor took **one** date: `MAX(PeriodEnd)` over the bucket's consolidated balance-sheet instants. A stray instant can therefore mask the real one.

HOFT FY2025 states three:

| instant | consolidated balance-sheet tags |
|---|---|
| 2025-02-02 | **25**, the real fiscal year end |
| 2025-02-03 | 2 |
| 2025-03-31 | **1**, a stray |

The maximum is the one-tag stray. No span ends there, so the rule correctly declined to act on it and the ladder took over, anchoring on the latest conforming span: a **dimensional trailing-twelve-month window** ending 2025-05-04. The income statement rendered 7 dimensional lines instead of the year's 16 consolidated ones. Both instants are tagged in the same FY2025 10-K (`0001185185-25-000321`), so accession scoping cannot separate them.

## The rule

`AnchorToLatestPeriodEnd` now takes a **collection** of `reportedPeriodEnds` and anchors on the latest one that also has a conforming span ending there. Nothing is loosened: each candidate still needs its own conforming span and still has to clear the consolidated floor, so a date below the entity's own measured span is refused whether or not a later date would have been usable. No counting, no threshold, no notion of "enough tags". The two tests that were already there are simply applied to every offered date instead of to one.

**The caller must offer only dates belonging to that fiscal year.** A `(year, period)` bucket also collects the balance sheets of adjacent periods, in both directions: a filing's prior-year comparative columns, and post-period disclosures like HOFT's. Janus Henderson's FY2019 Q2 states four instants, all from one 10-Q filed 2019-07-31, of which three are comparatives (2017-12-31, 2018-03-31, 2018-12-31). Offering every stated date without that restriction anchors it on 2018-12-31 and renders the October-December 2018 quarter, revenue $545.1M and EPS $0.54, under the FY2019 Q2 label. So the parameter's doc comment states the contract, and the commercial caller (the only surface that loads dimensional facts) restricts the dates to the fiscal year the filer itself reported, falling back to the single latest date when the filer states no such year, or when none of its dates falls inside it.

Both call sites here pass `[]` and remain provably unmoved: a consolidated-only fact set's latest conforming span already IS its measured endpoint, so a confirmed date is either equal to it or has no span at all. Measured: 0 of 283,524 cash-flow and 0 of 285,758 income-statement consolidated-only buckets change, under the single-date rule and this one alike.

## Measured against the deployed rule, whole corpus

| statement / fact scope | buckets | changed | gain | lose | empty after |
|---|---|---|---|---|---|
| cash flow / with dimensional | 290,774 | **55** | 50 | 0 | 0 |
| income statement / with dimensional | 289,555 | **14** | 14 | 0 | 0 |
| cash flow / consolidated only | 283,524 | **0** | — | — | — |
| income statement / consolidated only | 285,758 | **0** | — | — | — |
| balance sheet | 268,538 | **0** | — | — | — |

**All 69 changed buckets render zero consolidated lines today, and all 69 render consolidated lines after.** The rule only ever replaces a dimensional stub; the five cash-flow buckets that gain no net line still move onto a date their own balance sheet states. HOFT FY2025's income statement goes from 7 lines to 16, anchored on 2025-02-02. Janus Henderson, Adobe, Autodesk, General Mills, Conagra, Medtronic, Deere, Johnson Controls, TE Connectivity, Kraft Heinz, AZTA and DELL are unchanged from #4509 in every year and period. Home Depot MOVES, in eight cash-flow buckets, and every move is a fix: its fiscal 2021 runs 2020-02-03 to 2021-01-31, so FY2021 Q1 is the quarter ending 2020-05-03, where the deployed rule anchors on a post-period stray at 2021-03-31 and renders one line against eleven.

## Verification

- 4,835 unit tests pass. Mutants killed include a revert to the single-`MAX` rule this fixes, dropping the consolidated floor, and widening the candidates when the filer's year is unknown.
- New tests cover the HOFT stray, the DELL comparative below the floor, an all-instant statement, a dimension-only period, and the consolidated-only invariance as a theory.

https://claude.ai/code/session_01SE71rLG6DQTLTpDr6BfcU7
