### PR TITLE
docs(mcp): correct the GCF size claim to the whole-answer measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,11 +258,15 @@ the streamable HTTP transport works in both its stateless and session modes: the
 off that request and applies to it alone. A transport that instead dispatched calls on a
 connection opened earlier would carry whatever the opening request asked for.
 
-How much it saves depends on the shape of the table. Wide tables of short values save most;
-tables of comma-grouped money and share counts save least, because the encoder quotes any
-value containing a comma. Measured on real answers from three of the covered tools — 30
-sessions of daily short volume, 25 congressional trades, and 24 monthly observations of a FRED
-series — the wire is **11–14% shorter**.
+How much it saves depends on the shape of the answer. The table compresses, the prose around
+it does not, so a small table inside a long preamble saves least and a wide table of many
+short values saves most. Measured end to end against a deployed server on real answers from
+three of the covered tools, 30 sessions of daily short volume, 25 congressional trades and 24
+monthly observations of a FRED series, the answer text is **7 to 13% shorter** in characters.
+
+That is the text your client hands the model, not the HTTP payload. JSON escapes every
+quotation mark the encoder adds, so the transport bytes can grow on the same answer whose text
+shrank.
 
 It is deliberately conservative: **every cell value is preserved verbatim** (the compact-USD,
 comma-grouped, adaptive-decimal and em-dash formatting is untouched — GCF only changes the


### PR DESCRIPTION
## What

The README claimed GCF makes "the wire **11-14% shorter**". Both halves of that sentence are wrong, and this corrects them against production measurements.

## The number

That range came from a harness that called `MarkdownTable.Render` directly, so it measured the rendered table and nothing else. A real tool answer wraps the table in a preamble and footnotes that GCF cannot touch, so the end-to-end saving is smaller. Measured against a deployed server, same three shapes:

| Answer | Markdown | GCF | Saving |
|---|---|---|---|
| Daily short volume, 30 sessions | 2,402 | 2,185 | 9.0% |
| Congressional trades, 25 rows | 4,465 | 3,881 | 13.1% |
| FRED series, 24 monthly observations | 491 | 455 | 7.3% |

Congress lands within a point of the harness, which is the shape whose table dominates its answer. FRED collapses from 14% to 7% because a 24-row two-column table is a small part of a 491-character answer.

## The word "wire"

Raw SSE bytes **grew 28%** on the short-volume answer, because `System.Text.Json` escapes each `"` the encoder adds as `"`. The client decodes before the model sees it, so the saving is real, but it is in the answer text rather than on the wire. The README now says so, and drops the comma-grouping explanation: on production the worst case is FRED, which contains no commas at all.

## Verification

Measured through the deployed MCP server with a throwaway API key (since deleted, `401` confirmed), calling `GetShortVolume`, `GetCongressionalTrades` and `GetEconomicIndicator` with and without `X-Equibles-Output-Format: gcf`.

Documentation only, no code change.

https://claude.ai/code/session_01HphoJ2FxJ9T7v4RLUUMTmH