### PR TITLE
fix(financial-facts): date a balance sheet where its period's own flows end

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -145,7 +145,7 @@ public static class StatementLineFacts
     /// Where a period's own flows end: the latest end among the spans that carry at least
     /// half the bucket's fullest flow-concept count. Never a plain maximum: a single
     /// re-stamped span ends latest and would date the whole balance sheet by itself (LAKE's
-    /// FY2023 bucket holds a 1-concept 2023-05-01 to 2024-04-30 span beside its 100-concept
+    /// FY2023 bucket holds a 1-concept 2023-05-01 to 2024-04-30 span beside its 23-concept
     /// year ending 2023-01-31). Never the fullest either: a predecessor stub carries a whole
     /// statement, cash flow included, while the quarter's own cash flow is year-to-date and
     /// fails the span gate (BALY's Jan 1 to Feb 7 2025 column, 29 concepts, beside its 23-concept

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Models;
 
@@ -38,6 +39,11 @@ public static class StatementLineFacts
     // calendar drift. Longer durations are inception-to-date or multi-year.
     public const int MaxSupportedDurationDays = 380;
 
+    // How far a balance sheet's stated date may sit from the end of its period's own flows.
+    // Two datings within a week are one balance sheet (ON's 09-28 beside a one-line 09-30
+    // stray, DE's 10-30 beside 10-31), never two periods, which are a quarter apart.
+    public const int BalanceSheetDateToleranceDays = 7;
+
     /// <summary>
     /// The statement's own reporting endpoint, and the facts that share it. A
     /// filing re-reports comparative prior endpoints under one fiscal stamp, so
@@ -57,8 +63,10 @@ public static class StatementLineFacts
     /// under the stamp but measuring something else — a payment window (OPRA's
     /// 2023-01-12 dividend, filed as FY2022) or a point disclosure — can be dated
     /// later and drag the anchor off the period, dropping every real line. Falls
-    /// back to any bounded span, then to every fact, so a point-only statement
-    /// (every balance sheet) still anchors on its latest point.
+    /// back to any bounded span, then to every fact. A point-only statement, every
+    /// balance sheet, has no span to measure and lands on its latest point, which a
+    /// stray later instant hijacks; a balance sheet is dated by
+    /// <see cref="PickBalanceSheetDate"/> first and reaches this ladder only as a fallback.
     /// </remarks>
     public static List<FinancialFact> AnchorToLatestPeriodEnd(
         IReadOnlyCollection<FinancialFact> facts,
@@ -117,6 +125,51 @@ public static class StatementLineFacts
             ? spanDays >= MinAnnualSpanDays && spanDays <= MaxSupportedDurationDays
             : spanDays >= 1 && spanDays <= MaxDiscreteQuarterDays;
     }
+
+    /// <summary>
+    /// <see cref="MeasuresGranularity"/> as a query predicate, built from the same bounds
+    /// so a span the pick rejects can never set a date in SQL either.
+    /// </summary>
+    public static Expression<Func<FinancialFact, bool>> MeasuresGranularityInSql(
+        SecFiscalPeriod fiscalPeriod
+    ) =>
+        fiscalPeriod == SecFiscalPeriod.FullYear
+            ? f =>
+                f.PeriodEnd >= f.PeriodStart.AddDays(MinAnnualSpanDays)
+                && f.PeriodEnd <= f.PeriodStart.AddDays(MaxSupportedDurationDays)
+            : f =>
+                f.PeriodEnd >= f.PeriodStart.AddDays(1)
+                && f.PeriodEnd <= f.PeriodStart.AddDays(MaxDiscreteQuarterDays);
+
+    /// <summary>
+    /// The date a period's balance sheet is stated at: the stated instant date within
+    /// <see cref="BalanceSheetDateToleranceDays"/> of where the period's own flows end that
+    /// carries the most balance-sheet concepts, nearest then earliest on a tie. Null when no
+    /// stated date lies within the tolerance.
+    /// </summary>
+    /// <remarks>
+    /// A balance sheet has no span the anchor could measure, so its bucket's latest instant
+    /// used to date it, and a subsequent-event stray (GE's 2020-01-01 after a 2019-12-31 year
+    /// end) or the next year's sheet filed under this year's label (HD dates a May 2020
+    /// quarter's flows and its May 2021 balance sheet with the same fiscal stamp) took the
+    /// whole statement. The flows say where the period ends; among the datings within a week
+    /// of that, the fullest is the sheet itself and the others are strays.
+    /// </remarks>
+    public static DateOnly? PickBalanceSheetDate(
+        DateOnly flowPeriodEnd,
+        IReadOnlyCollection<(DateOnly Date, int ConceptCount)> statedDates
+    )
+    {
+        return statedDates
+            .Where(d => DaysApart(d.Date, flowPeriodEnd) <= BalanceSheetDateToleranceDays)
+            .OrderByDescending(d => d.ConceptCount)
+            .ThenBy(d => DaysApart(d.Date, flowPeriodEnd))
+            .ThenBy(d => d.Date)
+            .Select(d => (DateOnly?)d.Date)
+            .FirstOrDefault();
+    }
+
+    private static int DaysApart(DateOnly a, DateOnly b) => Math.Abs(a.DayNumber - b.DayNumber);
 
     /// <summary>
     /// The currently-reported fact among a fiscal period's candidates. A 10-Q

--- a/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Statements/StatementLineFacts.cs
@@ -142,6 +142,26 @@ public static class StatementLineFacts
                 && f.PeriodEnd <= f.PeriodStart.AddDays(MaxDiscreteQuarterDays);
 
     /// <summary>
+    /// Where a period's own flows end: the latest end among the spans that carry at least
+    /// half the bucket's fullest flow-concept count. Never a plain maximum: a single
+    /// re-stamped span ends latest and would date the whole balance sheet by itself (LAKE's
+    /// FY2023 bucket holds a 1-concept 2023-05-01 to 2024-04-30 span beside its 100-concept
+    /// year ending 2023-01-31). Never the fullest either: a predecessor stub carries a whole
+    /// statement, cash flow included, while the quarter's own cash flow is year-to-date and
+    /// fails the span gate (BALY's Jan 1 to Feb 7 2025 column, 29 concepts, beside its 23-concept
+    /// quarter ending 2025-06-30). Null when nothing measures the period.
+    /// </summary>
+    public static DateOnly? PickFlowPeriodEnd(
+        IReadOnlyCollection<(DateOnly Date, int ConceptCount)> measuredEnds
+    )
+    {
+        if (measuredEnds.Count == 0)
+            return null;
+        var fullest = measuredEnds.Max(e => e.ConceptCount);
+        return measuredEnds.Where(e => e.ConceptCount * 2 >= fullest).Max(e => (DateOnly?)e.Date);
+    }
+
+    /// <summary>
     /// The date a period's balance sheet is stated at: the stated instant date within
     /// <see cref="BalanceSheetDateToleranceDays"/> of where the period's own flows end that
     /// carries the most balance-sheet concepts, nearest then earliest on a tie. Null when no

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -122,32 +122,63 @@ public class FinancialStatementTools
                 // Period availability is scoped to the requested statement's
                 // concepts: a (year, Q4) that only exists via balance-sheet
                 // instants must not validate an income-statement request and
-                // then render an empty table.
+                // then render an empty table. The balance sheet is the exception:
+                // it is dated by its period's flows and loaded by that date, and the
+                // newest period's instants can sit one bucket away (HD's May 2026
+                // sheet is stamped fiscal 2026 while its flows are stamped 2027), so
+                // a period with flows must be offered even when it holds no instant.
                 var (selectedYear, selectedPeriod, periodError) = await ResolveStatementPeriod(
                     stock,
                     statementType,
                     year,
                     requestedPeriod,
-                    conceptIds
+                    statementType == FinancialStatementType.BalanceSheet
+                        ? await StatementConceptIds()
+                        : conceptIds
                 );
                 if (periodError != null)
                     return periodError;
 
-                var facts = await _financialFactRepository
-                    .GetConsolidatedByStock(stock)
-                    .Where(f =>
-                        f.FiscalYear == selectedYear
-                        && conceptIds.Contains(f.FinancialConceptId)
-                        && (
-                            f.PeriodType != FactPeriodType.Duration
-                            || f.PeriodEnd >= f.PeriodStart
-                                && f.PeriodEnd
-                                    <= f.PeriodStart.AddDays(
-                                        StatementLineFacts.MaxSupportedDurationDays
-                                    )
+                // A balance sheet is dated where its period's own flows end and loaded at
+                // that date from whichever bucket holds it: the bucket's own latest instant
+                // is a subsequent-event stray for GE (2020-01-01 over 2019-12-31) and the
+                // NEXT year's sheet for every January-year-end retailer. With no flow to date
+                // it by, the bucket-and-anchor path below still applies.
+                var balanceSheetDate =
+                    statementType == FinancialStatementType.BalanceSheet
+                        ? await BalanceSheetDateResolver.Resolve(
+                            _financialFactRepository,
+                            _financialConceptRepository,
+                            stock,
+                            selectedYear,
+                            selectedPeriod
                         )
-                    )
-                    .ToListAsync();
+                        : null;
+
+                var facts = balanceSheetDate is { } statedAt
+                    ? await _financialFactRepository
+                        .GetConsolidatedByStock(stock)
+                        .Where(f =>
+                            conceptIds.Contains(f.FinancialConceptId)
+                            && f.PeriodEnd == statedAt
+                            && f.PeriodStart == statedAt
+                        )
+                        .ToListAsync()
+                    : await _financialFactRepository
+                        .GetConsolidatedByStock(stock)
+                        .Where(f =>
+                            f.FiscalYear == selectedYear
+                            && conceptIds.Contains(f.FinancialConceptId)
+                            && (
+                                f.PeriodType != FactPeriodType.Duration
+                                || f.PeriodEnd >= f.PeriodStart
+                                    && f.PeriodEnd
+                                        <= f.PeriodStart.AddDays(
+                                            StatementLineFacts.MaxSupportedDurationDays
+                                        )
+                            )
+                        )
+                        .ToListAsync();
 
                 if (statementType != FinancialStatementType.BalanceSheet)
                 {
@@ -160,7 +191,8 @@ public class FinancialStatementTools
                         .AppendDerived(facts, rejectNegativeConceptIds)
                         .ToList();
                 }
-                facts = facts.Where(f => f.FiscalPeriod == selectedPeriod).ToList();
+                if (balanceSheetDate == null)
+                    facts = facts.Where(f => f.FiscalPeriod == selectedPeriod).ToList();
 
                 if (facts.Count == 0)
                     return $"No {statementType.NameForHumans().ToLowerInvariant()} line items "
@@ -170,7 +202,8 @@ public class FinancialStatementTools
                 // A filing re-reports comparative spans under its own fiscal stamp, and a stale
                 // concept can retain an earlier end under the same (year, period). Anchor the
                 // statement to one actual period end before selecting line values so it cannot
-                // silently combine different balance dates or flow endpoints.
+                // silently combine different balance dates or flow endpoints. A balance sheet
+                // loaded by its date already shares one; the anchor is a no-op there.
                 // No balance-sheet dates are loaded, and none are needed: this tool reads
                 // GetConsolidatedByStock, so the latest conforming span IS the entity's own
                 // measured endpoint and the rule provably cannot move a consolidated-only
@@ -307,6 +340,22 @@ public class FinancialStatementTools
             );
 
         return result.ToString();
+    }
+
+    // The concept ids of every statement line, so a balance-sheet period is offered wherever
+    // its flows are stamped.
+    private async Task<HashSet<Guid>> StatementConceptIds()
+    {
+        var lines = Enum.GetValues<FinancialStatementType>()
+            .SelectMany(FinancialStatementConcepts.For)
+            .ToList();
+        var (taxonomies, tags) = StatementLineFacts.CollectConceptPairs(lines);
+        return (
+            await _financialConceptRepository
+                .GetMatching(taxonomies, tags)
+                .Select(c => c.Id)
+                .ToListAsync()
+        ).ToHashSet();
     }
 
     private async Task<(

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -360,7 +360,8 @@ public class FinancialStatementTools
     }
 
     // availabilityConceptIds decides which periods may be selected; statementConceptIds is the
-    // requested statement's own set, which alone says whether that statement was ingested at all.
+    // requested statement's own set, which alone says whether that statement was ingested at all;
+    // when the two sets are equal the availability query has already proved it.
     private async Task<(
         int FiscalYear,
         SecFiscalPeriod FiscalPeriod,
@@ -393,7 +394,7 @@ public class FinancialStatementTools
         var statementIngested =
             availablePeriods.Count > 0
             && (
-                ReferenceEquals(availabilityConceptIds, statementConceptIds)
+                statementConceptIds.SetEquals(availabilityConceptIds)
                 || await _financialFactRepository
                     .GetConsolidatedByStock(stock)
                     .AnyAsync(f => statementConceptIds.Contains(f.FinancialConceptId))

--- a/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
+++ b/src/Equibles.Sec.FinancialFacts.Mcp/Tools/FinancialStatementTools.cs
@@ -134,7 +134,8 @@ public class FinancialStatementTools
                     requestedPeriod,
                     statementType == FinancialStatementType.BalanceSheet
                         ? await StatementConceptIds()
-                        : conceptIds
+                        : conceptIds,
+                    conceptIds
                 );
                 if (periodError != null)
                     return periodError;
@@ -358,6 +359,8 @@ public class FinancialStatementTools
         ).ToHashSet();
     }
 
+    // availabilityConceptIds decides which periods may be selected; statementConceptIds is the
+    // requested statement's own set, which alone says whether that statement was ingested at all.
     private async Task<(
         int FiscalYear,
         SecFiscalPeriod FiscalPeriod,
@@ -367,6 +370,7 @@ public class FinancialStatementTools
         FinancialStatementType statementType,
         int? year,
         SecFiscalPeriod? requestedPeriod,
+        IReadOnlySet<Guid> availabilityConceptIds,
         IReadOnlySet<Guid> statementConceptIds
     )
     {
@@ -374,7 +378,7 @@ public class FinancialStatementTools
         var availablePeriods = await _financialFactRepository
             .GetConsolidatedByStock(stock)
             .Where(f =>
-                statementConceptIds.Contains(f.FinancialConceptId)
+                availabilityConceptIds.Contains(f.FinancialConceptId)
                 && (
                     f.PeriodType != FactPeriodType.Duration
                     || f.PeriodEnd >= f.PeriodStart
@@ -386,7 +390,15 @@ public class FinancialStatementTools
             .Distinct()
             .ToListAsync();
 
-        if (availablePeriods.Count == 0)
+        var statementIngested =
+            availablePeriods.Count > 0
+            && (
+                ReferenceEquals(availabilityConceptIds, statementConceptIds)
+                || await _financialFactRepository
+                    .GetConsolidatedByStock(stock)
+                    .AnyAsync(f => statementConceptIds.Contains(f.FinancialConceptId))
+            );
+        if (!statementIngested)
         {
             // Distinguish "nothing ingested at all" from "nothing for THIS
             // statement" so the caller isn't told a covered company is absent.

--- a/src/Equibles.Sec.FinancialFacts.Repositories/BalanceSheetDateResolver.cs
+++ b/src/Equibles.Sec.FinancialFacts.Repositories/BalanceSheetDateResolver.cs
@@ -54,15 +54,21 @@ public static class BalanceSheetDateResolver
         if (balanceSheetConceptIds.Count == 0 || flowConceptIds.Count == 0)
             return null;
 
-        var flowPeriodEnd = await financialFactRepository
+        // Distinct (date, concept) pairs on both sides, counted here: each is a handful of
+        // dates, and a grouped count with DISTINCT is the kind of shape that stops translating
+        // on a provider upgrade. The flow end is weighed the same way the stated date is, or
+        // one re-stamped span ending latest dates the sheet by itself.
+        var measured = await financialFactRepository
             .GetMeasuredFlows(stock, fiscalYear, fiscalPeriod, flowConceptIds)
-            .MaxAsync(f => (DateOnly?)f.PeriodEnd, cancellationToken);
+            .Select(f => new { f.PeriodEnd, f.FinancialConceptId })
+            .Distinct()
+            .ToListAsync(cancellationToken);
+        var flowPeriodEnd = StatementLineFacts.PickFlowPeriodEnd(
+            CountByDate(measured.Select(m => (m.PeriodEnd, m.FinancialConceptId)))
+        );
         if (flowPeriodEnd is not { } periodEnd)
             return null;
 
-        // Distinct (date, concept) pairs, counted here: the candidates are a handful of dates
-        // a week wide, and a grouped count with DISTINCT is the kind of shape that stops
-        // translating on a provider upgrade.
         var stated = await financialFactRepository
             .GetStatedNear(
                 stock,
@@ -73,12 +79,21 @@ public static class BalanceSheetDateResolver
             .Select(f => new { f.PeriodEnd, f.FinancialConceptId })
             .Distinct()
             .ToListAsync(cancellationToken);
-        var statedDates = stated
-            .GroupBy(s => s.PeriodEnd)
+
+        return StatementLineFacts.PickBalanceSheetDate(
+            periodEnd,
+            CountByDate(stated.Select(s => (s.PeriodEnd, s.FinancialConceptId)))
+        );
+    }
+
+    private static List<(DateOnly Date, int ConceptCount)> CountByDate(
+        IEnumerable<(DateOnly PeriodEnd, Guid FinancialConceptId)> pairs
+    )
+    {
+        return pairs
+            .GroupBy(p => p.PeriodEnd)
             .Select(g => (Date: g.Key, ConceptCount: g.Count()))
             .ToList();
-
-        return StatementLineFacts.PickBalanceSheetDate(periodEnd, statedDates);
     }
 
     private static List<Guid> ConceptIdsFor(

--- a/src/Equibles.Sec.FinancialFacts.Repositories/BalanceSheetDateResolver.cs
+++ b/src/Equibles.Sec.FinancialFacts.Repositories/BalanceSheetDateResolver.cs
@@ -1,0 +1,99 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Sec.FinancialFacts.Repositories;
+
+/// <summary>
+/// Where a fiscal period's balance sheet is dated: at the end of the period's own consolidated
+/// flows, matched to the fullest stated instant date within
+/// <see cref="StatementLineFacts.BalanceSheetDateToleranceDays"/> of it, from any fiscal
+/// stamp. One resolver for the MCP tool, the web tab and the commercial card, so the three
+/// cannot date one balance sheet three ways.
+/// </summary>
+public static class BalanceSheetDateResolver
+{
+    /// <summary>
+    /// Null when the period measures no flow at the requested granularity, or no balance
+    /// sheet is stated within the tolerance of where they end; the caller then keeps its
+    /// bucket-and-anchor path.
+    /// </summary>
+    public static async Task<DateOnly?> Resolve(
+        FinancialFactRepository financialFactRepository,
+        FinancialConceptRepository financialConceptRepository,
+        CommonStock stock,
+        int fiscalYear,
+        SecFiscalPeriod fiscalPeriod,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var balanceSheetLines = FinancialStatementConcepts.For(FinancialStatementType.BalanceSheet);
+        var flowLines = FinancialStatementConcepts
+            .For(FinancialStatementType.IncomeStatement)
+            .Concat(FinancialStatementConcepts.For(FinancialStatementType.CashFlow))
+            .ToList();
+        var (taxonomies, tags) = StatementLineFacts.CollectConceptPairs(
+            balanceSheetLines.Concat(flowLines)
+        );
+
+        // GetMatching returns the taxonomy x tag cross product; narrow to the exact pairs so
+        // an unrelated concept sharing a tag name can neither end the period nor state a date.
+        var concepts = await financialConceptRepository
+            .GetMatching(taxonomies, tags)
+            .Select(c => new
+            {
+                c.Id,
+                c.Taxonomy,
+                c.Tag,
+            })
+            .ToListAsync(cancellationToken);
+        var conceptIdByKey = concepts.ToDictionary(c => (c.Taxonomy, c.Tag), c => c.Id);
+        var balanceSheetConceptIds = ConceptIdsFor(conceptIdByKey, balanceSheetLines);
+        var flowConceptIds = ConceptIdsFor(conceptIdByKey, flowLines);
+        if (balanceSheetConceptIds.Count == 0 || flowConceptIds.Count == 0)
+            return null;
+
+        var flowPeriodEnd = await financialFactRepository
+            .GetMeasuredFlows(stock, fiscalYear, fiscalPeriod, flowConceptIds)
+            .MaxAsync(f => (DateOnly?)f.PeriodEnd, cancellationToken);
+        if (flowPeriodEnd is not { } periodEnd)
+            return null;
+
+        // Distinct (date, concept) pairs, counted here: the candidates are a handful of dates
+        // a week wide, and a grouped count with DISTINCT is the kind of shape that stops
+        // translating on a provider upgrade.
+        var stated = await financialFactRepository
+            .GetStatedNear(
+                stock,
+                balanceSheetConceptIds,
+                periodEnd,
+                StatementLineFacts.BalanceSheetDateToleranceDays
+            )
+            .Select(f => new { f.PeriodEnd, f.FinancialConceptId })
+            .Distinct()
+            .ToListAsync(cancellationToken);
+        var statedDates = stated
+            .GroupBy(s => s.PeriodEnd)
+            .Select(g => (Date: g.Key, ConceptCount: g.Count()))
+            .ToList();
+
+        return StatementLineFacts.PickBalanceSheetDate(periodEnd, statedDates);
+    }
+
+    private static List<Guid> ConceptIdsFor(
+        IReadOnlyDictionary<(FactTaxonomy Taxonomy, string Tag), Guid> conceptIdByKey,
+        IEnumerable<StatementLine> lines
+    )
+    {
+        return lines
+            .SelectMany(l => l.Concepts)
+            .Select(c =>
+                conceptIdByKey.TryGetValue((c.Taxonomy, c.Tag), out var id) ? id : (Guid?)null
+            )
+            .Where(id => id != null)
+            .Select(id => id!.Value)
+            .Distinct()
+            .ToList();
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.Repositories/FinancialFactRepository.cs
+++ b/src/Equibles.Sec.FinancialFacts.Repositories/FinancialFactRepository.cs
@@ -1,6 +1,8 @@
 using Equibles.CommonStocks.Data.Models;
 using Equibles.Data;
+using Equibles.Sec.FinancialFacts.Data.Enums;
 using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Statements;
 
 namespace Equibles.Sec.FinancialFacts.Repositories;
 
@@ -39,5 +41,51 @@ public class FinancialFactRepository : BaseRepository<FinancialFact>
     public IQueryable<FinancialFact> GetConsolidatedByStocks(IReadOnlyCollection<Guid> stockIds)
     {
         return GetByStocks(stockIds).Where(f => f.DimensionsKey == "");
+    }
+
+    /// <summary>
+    /// The period's own consolidated flow facts that measure the requested granularity, the
+    /// spans the flow statements render at (<see cref="StatementLineFacts.MeasuresGranularity"/>
+    /// in SQL). Where these end is where the period ends, and the only evidence of it that a
+    /// balance sheet, which has no span of its own, can be dated by.
+    /// </summary>
+    public IQueryable<FinancialFact> GetMeasuredFlows(
+        CommonStock stock,
+        int fiscalYear,
+        SecFiscalPeriod fiscalPeriod,
+        IReadOnlyCollection<Guid> flowConceptIds
+    )
+    {
+        return GetConsolidatedByStock(stock)
+            .Where(f =>
+                f.FiscalYear == fiscalYear
+                && f.FiscalPeriod == fiscalPeriod
+                && flowConceptIds.Contains(f.FinancialConceptId)
+            )
+            .Where(StatementLineFacts.MeasuresGranularityInSql(fiscalPeriod));
+    }
+
+    /// <summary>
+    /// Consolidated point facts stated within <paramref name="toleranceDays"/> of a date, under
+    /// ANY fiscal stamp: the importer dates an interim instant by the filer's own fiscal-year
+    /// label and a duration by the calendar year its period ends in, so for every filer whose
+    /// year is named differently a balance sheet sits one bucket away from its own flows.
+    /// </summary>
+    public IQueryable<FinancialFact> GetStatedNear(
+        CommonStock stock,
+        IReadOnlyCollection<Guid> conceptIds,
+        DateOnly date,
+        int toleranceDays
+    )
+    {
+        var from = date.AddDays(-toleranceDays);
+        var to = date.AddDays(toleranceDays);
+        return GetConsolidatedByStock(stock)
+            .Where(f =>
+                conceptIds.Contains(f.FinancialConceptId)
+                && f.PeriodEnd == f.PeriodStart
+                && f.PeriodEnd >= from
+                && f.PeriodEnd <= to
+            );
     }
 }

--- a/src/Equibles.Web/Services/StockTabService.cs
+++ b/src/Equibles.Web/Services/StockTabService.cs
@@ -716,19 +716,46 @@ public class StockTabService
         var conceptIdByKey = concepts.ToDictionary(c => (c.Taxonomy, c.Tag), c => c.Id);
         var conceptIds = concepts.Select(c => c.Id).ToHashSet();
 
-        var facts = await _financialFactRepository
-            .GetConsolidatedByStock(stock)
-            .Where(f =>
-                f.FiscalYear == fiscalYear
-                && conceptIds.Contains(f.FinancialConceptId)
-                && (
-                    f.PeriodType != FactPeriodType.Duration
-                    || f.PeriodEnd >= f.PeriodStart
-                        && f.PeriodEnd
-                            <= f.PeriodStart.AddDays(StatementLineFacts.MaxSupportedDurationDays)
+        // A balance sheet is dated where its period's own flows end and loaded at that
+        // date from whichever bucket holds it, the same rule as the MCP statement tool;
+        // its bucket's latest instant is a stray or the next year's sheet for a filer
+        // whose fiscal-year name is not the year it ends in. With no flow to date it by,
+        // the bucket-and-anchor path below still applies.
+        var balanceSheetDate =
+            statementType == FinancialStatementType.BalanceSheet
+                ? await BalanceSheetDateResolver.Resolve(
+                    _financialFactRepository,
+                    _financialConceptRepository,
+                    stock,
+                    fiscalYear,
+                    fiscalPeriod
                 )
-            )
-            .ToListAsync();
+                : null;
+
+        var facts = balanceSheetDate is { } statedAt
+            ? await _financialFactRepository
+                .GetConsolidatedByStock(stock)
+                .Where(f =>
+                    conceptIds.Contains(f.FinancialConceptId)
+                    && f.PeriodEnd == statedAt
+                    && f.PeriodStart == statedAt
+                )
+                .ToListAsync()
+            : await _financialFactRepository
+                .GetConsolidatedByStock(stock)
+                .Where(f =>
+                    f.FiscalYear == fiscalYear
+                    && conceptIds.Contains(f.FinancialConceptId)
+                    && (
+                        f.PeriodType != FactPeriodType.Duration
+                        || f.PeriodEnd >= f.PeriodStart
+                            && f.PeriodEnd
+                                <= f.PeriodStart.AddDays(
+                                    StatementLineFacts.MaxSupportedDurationDays
+                                )
+                    )
+                )
+                .ToListAsync();
 
         if (statementType != FinancialStatementType.BalanceSheet)
         {
@@ -740,10 +767,12 @@ public class StockTabService
                 .AppendDerived(facts, rejectNegativeConceptIds)
                 .ToList();
         }
-        facts = facts.Where(f => f.FiscalPeriod == fiscalPeriod).ToList();
+        if (balanceSheetDate == null)
+            facts = facts.Where(f => f.FiscalPeriod == fiscalPeriod).ToList();
         // Consolidated facts only (GetConsolidatedByStock above), so the latest conforming
         // span is already the entity's own measured endpoint and no balance-sheet date can
-        // move the anchor — proved in StatementLineFactsAnchorTests.
+        // move the anchor — proved in StatementLineFactsAnchorTests. A balance sheet loaded
+        // by its date already shares one; the anchor is a no-op there.
         facts = StatementLineFacts.AnchorToLatestPeriodEnd(
             facts,
             fiscalPeriod,

--- a/tests/Equibles.UnitTests/Sec/FinancialFactRepositoryQueryTranslationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactRepositoryQueryTranslationTests.cs
@@ -57,6 +57,12 @@ public class FinancialFactRepositoryQueryTranslationTests
             .Contain("\"DimensionsKey\" = ''", "only the consolidated flows date a sheet");
         where.Should().Contain("\"FiscalYear\" = @");
         where.Should().Contain("\"FiscalPeriod\" = @");
+        where
+            .Should()
+            .Contain(
+                "\"FinancialConceptId\" = ANY (@flowConceptIds)",
+                "only a flow-statement concept may end the period; without this any consolidated span would"
+            );
         // Both annual bounds ride against PeriodStart (a Postgres date plus an integer is that
         // many days later), so the span rule is the one the in-memory gate applies, 350..380
         // days, and never a plain PeriodEnd range.

--- a/tests/Equibles.UnitTests/Sec/FinancialFactRepositoryQueryTranslationTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactRepositoryQueryTranslationTests.cs
@@ -1,0 +1,120 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.Media.Data;
+using Equibles.Sec.Data;
+using Equibles.Sec.FinancialFacts.Data;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Sec;
+
+/// <summary>
+/// Pins that the two queries dating a balance sheet reach SQL at all, with the shape that
+/// keeps them on the [CommonStockId, FiscalYear, FiscalPeriod] index. <c>ToQueryString</c>
+/// runs the full Npgsql translation offline, so a provider or refactor that stops translating
+/// the granularity predicate fails here instead of on every statement render.
+/// </summary>
+public class FinancialFactRepositoryQueryTranslationTests
+{
+    private static EquiblesFinancialDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseNpgsql("Host=localhost;Database=translation-only", o => o.UseVector())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        return new EquiblesFinancialDbContext(
+            options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+                new MediaModuleConfiguration(),
+                new SecModuleConfiguration(),
+                new FinancialFactsModuleConfiguration(),
+            }
+        );
+    }
+
+    private static readonly CommonStock Stock = new() { Id = Guid.NewGuid(), Ticker = "HD" };
+
+    [Fact]
+    public void GetMeasuredFlows_FullYear_TranslatesTheAnnualBoundsAgainstThePeriodStart()
+    {
+        using var ctx = CreateContext();
+        var repository = new FinancialFactRepository(ctx);
+
+        var where = WhereClause(
+            repository
+                .GetMeasuredFlows(Stock, 2025, SecFiscalPeriod.FullYear, [Guid.NewGuid()])
+                .ToQueryString()
+        );
+
+        where
+            .Should()
+            .Contain("\"DimensionsKey\" = ''", "only the consolidated flows date a sheet");
+        where.Should().Contain("\"FiscalYear\" = @");
+        where.Should().Contain("\"FiscalPeriod\" = @");
+        // Both annual bounds ride against PeriodStart (a Postgres date plus an integer is that
+        // many days later), so the span rule is the one the in-memory gate applies, 350..380
+        // days, and never a plain PeriodEnd range.
+        where.Should().Contain("\"PeriodEnd\" >= f.\"PeriodStart\" + 350");
+        where.Should().Contain("\"PeriodEnd\" <= f.\"PeriodStart\" + 380");
+    }
+
+    [Fact]
+    public void GetMeasuredFlows_Quarter_TranslatesTheDiscreteQuarterBounds()
+    {
+        using var ctx = CreateContext();
+        var repository = new FinancialFactRepository(ctx);
+
+        var where = WhereClause(
+            repository
+                .GetMeasuredFlows(Stock, 2025, SecFiscalPeriod.Q2, [Guid.NewGuid()])
+                .ToQueryString()
+        );
+
+        where.Should().Contain("\"PeriodEnd\" >= f.\"PeriodStart\" + 1 ");
+        where.Should().Contain("\"PeriodEnd\" <= f.\"PeriodStart\" + 100");
+        where.Should().NotContain("350", "a quarter bucket is never gated by the annual bounds");
+    }
+
+    [Fact]
+    public void GetStatedNear_TranslatesToConsolidatedPointsInADateWindow_FromAnyFiscalStamp()
+    {
+        using var ctx = CreateContext();
+        var repository = new FinancialFactRepository(ctx);
+
+        var where = WhereClause(
+            repository
+                .GetStatedNear(Stock, [Guid.NewGuid()], new DateOnly(2025, 2, 2), 7)
+                .ToQueryString()
+        );
+
+        where
+            .Should()
+            .Contain("\"DimensionsKey\" = ''", "a segment's instant is not the company's");
+        where.Should().Contain("\"PeriodEnd\" = f.\"PeriodStart\"", "only a point states a date");
+        where.Should().Contain("\"PeriodEnd\" >= @");
+        where.Should().Contain("\"PeriodEnd\" <= @");
+        where
+            .Should()
+            .NotContain(
+                "\"FiscalYear\"",
+                "the sheet is loaded from whichever bucket holds it; the stamp is the defect"
+            );
+        where.Should().NotContain("\"FiscalPeriod\"");
+        where.Should().NotContain(" OR ");
+    }
+
+    // The predicate alone: the projection lists every column, stamp included.
+    private static string WhereClause(string sql)
+    {
+        var flat = System.Text.RegularExpressions.Regex.Replace(sql, @"\s+", " ");
+        var at = flat.IndexOf(" WHERE ", StringComparison.Ordinal);
+        at.Should().BeGreaterThan(-1, "the query must filter");
+        return flat[at..] + " ";
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsAnchorTests.cs
@@ -40,8 +40,9 @@ public class StatementLineFactsAnchorTests
         anchored.Should().NotContain(dividendPaymentDate);
     }
 
-    // The control: a balance sheet is every-fact-an-instant, so it must keep anchoring on
-    // its latest instant. Preferring durations there would leave nothing to anchor on.
+    // The fallback: a balance sheet with no flow to date it by is every-fact-an-instant, so
+    // it must keep anchoring on its latest instant. Preferring durations there would leave
+    // nothing to anchor on. Dated balance sheets never reach this ladder (PickBalanceSheetDate).
     [Fact]
     public void AnchorToLatestPeriodEnd_AllInstantStatement_AnchorsOnTheLatestInstant()
     {

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsBalanceSheetDateTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsBalanceSheetDateTests.cs
@@ -104,7 +104,7 @@ public class StatementLineFactsBalanceSheetDateTests
             .Be(new DateOnly(2022, 10, 28), "two days either side, the earlier date stands");
     }
 
-    // LAKE's FY2023 bucket holds its 100-concept year ending 2023-01-31 beside two one-concept
+    // LAKE's FY2023 bucket holds its 23-concept year ending 2023-01-31 beside two one-concept
     // spans re-stamped from the next fiscal year, one of them ending latest. A plain maximum
     // would end the period in April 2024 and date the balance sheet fifteen months off.
     [Fact]
@@ -113,7 +113,7 @@ public class StatementLineFactsBalanceSheetDateTests
         var picked = StatementLineFacts.PickFlowPeriodEnd([
             (new DateOnly(2024, 4, 30), 1),
             (new DateOnly(2023, 4, 30), 1),
-            (new DateOnly(2023, 1, 31), 100),
+            (new DateOnly(2023, 1, 31), 23),
         ]);
 
         picked.Should().Be(new DateOnly(2023, 1, 31));
@@ -135,7 +135,9 @@ public class StatementLineFactsBalanceSheetDateTests
     }
 
     // The bar is half the fullest count, inclusive: a later span at exactly half still counts as a
-    // measured period, one concept below it is a stray.
+    // measured period, one concept below it is a stray. Inclusive on purpose: NCO's (2026, Q2) own
+    // quarter carries 3 flow concepts beside a 6-concept comparative in the same 10-Q, and a strict
+    // majority would date that sheet a year early (26 buckets corpus-wide separate the two bars).
     [Theory]
     [InlineData(12, 2024)]
     [InlineData(11, 2023)]

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsBalanceSheetDateTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsBalanceSheetDateTests.cs
@@ -104,6 +104,72 @@ public class StatementLineFactsBalanceSheetDateTests
             .Be(new DateOnly(2022, 10, 28), "two days either side, the earlier date stands");
     }
 
+    // LAKE's FY2023 bucket holds its 100-concept year ending 2023-01-31 beside two one-concept
+    // spans re-stamped from the next fiscal year, one of them ending latest. A plain maximum
+    // would end the period in April 2024 and date the balance sheet fifteen months off.
+    [Fact]
+    public void PickFlowPeriodEnd_OneConceptSpanEndingLatest_LosesToTheFullestYear()
+    {
+        var picked = StatementLineFacts.PickFlowPeriodEnd([
+            (new DateOnly(2024, 4, 30), 1),
+            (new DateOnly(2023, 4, 30), 1),
+            (new DateOnly(2023, 1, 31), 100),
+        ]);
+
+        picked.Should().Be(new DateOnly(2023, 1, 31));
+    }
+
+    // BALY (2025, Q2): the Jan 1..Feb 7 2025 predecessor stub carries 29 flow concepts (a whole
+    // statement, cash flow included) beside the quarter's own 23, because a 10-Q's cash flow is
+    // year-to-date and fails the span gate. The fullest span is the stub; the quarter still wins.
+    [Fact]
+    public void PickFlowPeriodEnd_PredecessorStubWithMoreConcepts_LosesToTheLaterQuarter()
+    {
+        var picked = StatementLineFacts.PickFlowPeriodEnd([
+            (new DateOnly(2025, 2, 7), 29),
+            (new DateOnly(2025, 3, 31), 1),
+            (new DateOnly(2025, 6, 30), 23),
+        ]);
+
+        picked.Should().Be(new DateOnly(2025, 6, 30));
+    }
+
+    // The bar is half the fullest count, inclusive: a later span at exactly half still counts as a
+    // measured period, one concept below it is a stray.
+    [Theory]
+    [InlineData(12, 2024)]
+    [InlineData(11, 2023)]
+    public void PickFlowPeriodEnd_HalfTheFullestCount_IsTheBar(int laterCount, int expectedYear)
+    {
+        var picked = StatementLineFacts.PickFlowPeriodEnd([
+            (new DateOnly(2023, 1, 31), 24),
+            (new DateOnly(2024, 4, 30), laterCount),
+        ]);
+
+        picked
+            .Should()
+            .Be(expectedYear == 2024 ? new DateOnly(2024, 4, 30) : new DateOnly(2023, 1, 31));
+    }
+
+    // Two periods measured with the same concepts: the later one is the current column and
+    // the earlier one its comparative, so the tie goes to the latest end, as the old maximum did.
+    [Fact]
+    public void PickFlowPeriodEnd_EqualCounts_PreferTheLatestEnd()
+    {
+        var picked = StatementLineFacts.PickFlowPeriodEnd([
+            (new DateOnly(2019, 5, 5), 11),
+            (new DateOnly(2020, 5, 3), 11),
+        ]);
+
+        picked.Should().Be(new DateOnly(2020, 5, 3));
+    }
+
+    [Fact]
+    public void PickFlowPeriodEnd_NothingMeasured_IsNull()
+    {
+        StatementLineFacts.PickFlowPeriodEnd([]).Should().BeNull();
+    }
+
     [Fact]
     public void PickBalanceSheetDate_NoStatedDates_IsNull()
     {

--- a/tests/Equibles.UnitTests/Sec/StatementLineFactsBalanceSheetDateTests.cs
+++ b/tests/Equibles.UnitTests/Sec/StatementLineFactsBalanceSheetDateTests.cs
@@ -1,0 +1,168 @@
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Statements;
+
+namespace Equibles.UnitTests.Sec;
+
+public class StatementLineFactsBalanceSheetDateTests
+{
+    // GE's FY2019 bucket holds the 2019-12-31 year-end sheet and one subsequent-event instant
+    // at 2020-01-01. The bucket's latest instant used to date the statement, so it rendered
+    // that one line instead of the sheet. The flows end 2019-12-31, and the fullest dating
+    // within a week of that is the sheet.
+    [Fact]
+    public void PickBalanceSheetDate_StrayLaterInstant_LosesToTheFullerSheet()
+    {
+        var picked = StatementLineFacts.PickBalanceSheetDate(
+            new DateOnly(2019, 12, 31),
+            [(new DateOnly(2019, 12, 31), 31), (new DateOnly(2020, 1, 1), 1)]
+        );
+
+        picked.Should().Be(new DateOnly(2019, 12, 31));
+    }
+
+    // The exact date is not privileged: ON's one-line 09-30 stray sits ON the flow end while
+    // the 25-line sheet is dated two days earlier. The count decides, not the match.
+    [Fact]
+    public void PickBalanceSheetDate_OneLineStrayOnTheExactDate_LosesToTheSheetTwoDaysEarlier()
+    {
+        var picked = StatementLineFacts.PickBalanceSheetDate(
+            new DateOnly(2024, 9, 30),
+            [(new DateOnly(2024, 9, 30), 1), (new DateOnly(2024, 9, 28), 25)]
+        );
+
+        picked.Should().Be(new DateOnly(2024, 9, 28));
+    }
+
+    // HD stamps a May 2020 quarter's flows and its May 2021 balance sheet with the same
+    // fiscal label. The 2021 sheet is a year from where the flows end, so it is not offered,
+    // and the sheet that IS dated where the flows end is picked wherever it was stamped.
+    [Fact]
+    public void PickBalanceSheetDate_NextYearsSheetInTheSameBucket_IsNotWithinTolerance()
+    {
+        var picked = StatementLineFacts.PickBalanceSheetDate(
+            new DateOnly(2020, 5, 3),
+            [(new DateOnly(2021, 5, 2), 21), (new DateOnly(2020, 5, 3), 21)]
+        );
+
+        picked.Should().Be(new DateOnly(2020, 5, 3));
+    }
+
+    // A comparative column a year earlier and a stray a quarter later are both outside the
+    // tolerance; with nothing inside it, the caller keeps its bucket-and-anchor path.
+    [Fact]
+    public void PickBalanceSheetDate_NothingWithinTolerance_IsNull()
+    {
+        var picked = StatementLineFacts.PickBalanceSheetDate(
+            new DateOnly(2022, 12, 31),
+            [(new DateOnly(2021, 12, 31), 30), (new DateOnly(2023, 3, 31), 30)]
+        );
+
+        picked.Should().BeNull();
+    }
+
+    // The tolerance is inclusive on both sides, and a date one day past it is out.
+    [Theory]
+    [InlineData(-7, true)]
+    [InlineData(7, true)]
+    [InlineData(-8, false)]
+    [InlineData(8, false)]
+    public void PickBalanceSheetDate_ToleranceIsSevenDaysInclusive(int offset, bool within)
+    {
+        var flowEnd = new DateOnly(2024, 6, 30);
+        var stated = flowEnd.AddDays(offset);
+
+        var picked = StatementLineFacts.PickBalanceSheetDate(flowEnd, [(stated, 20)]);
+
+        (picked == stated).Should().Be(within);
+        StatementLineFacts.BalanceSheetDateToleranceDays.Should().Be(7);
+    }
+
+    // DE dates one sheet 10-30 and 10-31 with the same lines. Equal counts fall to the date
+    // nearest the flow end, and an equal distance to the earlier date, so the pick is
+    // deterministic whatever order the dates arrive in.
+    [Fact]
+    public void PickBalanceSheetDate_EqualCounts_PreferNearestThenEarliest()
+    {
+        var flowEnd = new DateOnly(2022, 10, 30);
+
+        StatementLineFacts
+            .PickBalanceSheetDate(
+                flowEnd,
+                [(new DateOnly(2022, 10, 31), 28), (new DateOnly(2022, 10, 30), 28)]
+            )
+            .Should()
+            .Be(new DateOnly(2022, 10, 30), "the sheet dated on the flow end is nearest");
+
+        StatementLineFacts
+            .PickBalanceSheetDate(
+                flowEnd,
+                [(new DateOnly(2022, 11, 1), 28), (new DateOnly(2022, 10, 28), 28)]
+            )
+            .Should()
+            .Be(new DateOnly(2022, 10, 28), "two days either side, the earlier date stands");
+    }
+
+    [Fact]
+    public void PickBalanceSheetDate_NoStatedDates_IsNull()
+    {
+        StatementLineFacts.PickBalanceSheetDate(new DateOnly(2024, 6, 30), []).Should().BeNull();
+    }
+
+    // The SQL predicate that finds where a period's flows end must agree with the in-memory
+    // gate at every boundary, or a span the pick rejects dates the balance sheet.
+    [Theory]
+    [InlineData(349, false)]
+    [InlineData(350, true)]
+    [InlineData(380, true)]
+    [InlineData(381, false)]
+    public void MeasuresGranularityInSql_AgreesWithMeasuresGranularity_ForAFullYear(
+        int spanDays,
+        bool measures
+    )
+    {
+        var fact = Span(spanDays);
+        var inSql = StatementLineFacts.MeasuresGranularityInSql(SecFiscalPeriod.FullYear).Compile();
+
+        inSql(fact).Should().Be(measures);
+        StatementLineFacts
+            .MeasuresGranularity(fact, SecFiscalPeriod.FullYear)
+            .Should()
+            .Be(measures);
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, true)]
+    [InlineData(100, true)]
+    [InlineData(101, false)]
+    public void MeasuresGranularityInSql_AgreesWithMeasuresGranularity_ForAQuarter(
+        int spanDays,
+        bool measures
+    )
+    {
+        var fact = Span(spanDays);
+        var inSql = StatementLineFacts.MeasuresGranularityInSql(SecFiscalPeriod.Q2).Compile();
+
+        inSql(fact).Should().Be(measures);
+        StatementLineFacts.MeasuresGranularity(fact, SecFiscalPeriod.Q2).Should().Be(measures);
+    }
+
+    private static FinancialFact Span(int days) =>
+        new()
+        {
+            CommonStockId = Guid.NewGuid(),
+            FinancialConceptId = Guid.NewGuid(),
+            Value = 1m,
+            Unit = "USD",
+            PeriodStart = new DateOnly(2024, 1, 1),
+            PeriodEnd = new DateOnly(2024, 1, 1).AddDays(days),
+            FiscalYear = 2024,
+            FiscalPeriod = SecFiscalPeriod.FullYear,
+            PeriodType = days == 0 ? FactPeriodType.Instant : FactPeriodType.Duration,
+            Form = DocumentType.TenK,
+            FiledDate = new DateOnly(2025, 2, 1),
+            AccessionNumber = "0000000000-25-000001",
+        };
+}


### PR DESCRIPTION
## Problem

A balance sheet has no span `StatementLineFacts.AnchorToLatestPeriodEnd` can measure, so it fell to the ladder's last rung and anchored on its bucket's **latest instant**. Two things hijack that:

- A subsequent-event stray: GE FY2019 rendered 1 line at 2020-01-01 instead of 31 at 2019-12-31; HOFT FY2025 1 line at 2025-03-31 instead of 25 at 2025-02-02 (CVS, DD, LIN, ON the same shape).
- The importer's stamping split: `FinancialFactsImportService.TryBuildParsedFact` passes `classifyInterimInstants: !hasMappedFp`, so an interim instant keeps the SEC's `fy` (the filer's own fiscal-year label) while a duration takes `ReportedFiscalPeriodResolver`'s year, the calendar year the period ends in. For every filer whose year is named differently from the year it ends in, a quarter's flows sit beside the balance sheet **one year later**: HD `(2021, Q1)` = Feb–May 2020 flows + the 2021-05-02 sheet; LOW, TGT, GAP, M, GME, ROST, LULU, DG, ULTA, WSM, DELL the same.

Measured on production: 21,829 of 268,538 balance-sheet buckets anchor off their period's date, 13,281 rendering zero consolidated lines; 7,440 quarterly buckets across 905 stocks pair a flow statement with a balance sheet more than 100 days away; 19 stocks' newest period renders no consolidated balance sheet at all.

## The rule

A balance sheet is dated **where its period's own consolidated flows end**:

- `FinancialFactRepository.GetMeasuredFlows` finds the bucket's consolidated flow spans that measure the granularity, through `StatementLineFacts.MeasuresGranularityInSql`, built from the same bounds as `MeasuresGranularity` (agreement pinned at 349/350/380/381 and 0/1/100/101).
- `GetStatedNear` reads every consolidated balance-sheet instant within `BalanceSheetDateToleranceDays` (7) of that end, **from any fiscal stamp**.
- `StatementLineFacts.PickBalanceSheetDate` picks the date carrying the most distinct balance-sheet concepts, nearest then earliest on a tie. Two datings within a week are one sheet (ON's 09-28 beside a one-line 09-30 stray, DE's 10-30 beside 10-31), never two periods, which are a quarter apart.
- `BalanceSheetDateResolver.Resolve` (Repositories) orchestrates the three, one implementation for the MCP tool, the web tab and the commercial card, and each surface loads the sheet at that date. A dated sheet never reaches the bucket filter or the anchor ladder.
- No measured flow, or no sheet within the tolerance: the bucket-and-anchor path is unchanged.
- `GetFinancialStatement` now offers a balance sheet for every period with flows, because the newest period's instants can sit one bucket away (HD's May 2026 sheet is stamped fiscal 2026, its flows 2027).

## Measured effect (production corpus)

- 27,587 buckets change, 21,055 gain lines, 16,091 had no consolidated line before, 305 pick a date other than the exact flow end.
- 2,245 lose lines: 1,900 are the mismatch itself (today's sheet belongs to the next period, which gains it), 345 are buckets where today's sheet was also from the wrong period.
- 415 buckets have a flow end but no sheet within 7 days, and keep today's behaviour.
- HD `(2021,Q1)` → 2020-05-03 (21 lines), GE FY2019 → 2019-12-31 (28), HOFT FY2025 → 2025-02-02 (25), HOFT `(2025,Q2)` 2 → 23, DELL `(2025,Q1)` → 2025-05-02 (29), JHG `(2025,Q1)` → 2024-09-30 (20).

## Disclosed

- Loading by date from any bucket admits a later filing's restatement of the same date (latest filed wins per concept, as before), so a value can change where the date does not.
- A full "as adjusted" opening balance sheet dated the day after a year end could outcount the year-end sheet; rare, and the two are near-identical.
- The durable fix is in the importer (stamp interim instants and durations by the same rule, version bump + corpus replay); this is the read-side fix that heals every surface now.

## Tests

- `StatementLineFactsBalanceSheetDateTests`: the GE, ON, HD and comparative shapes, the inclusive 7-day tolerance, deterministic ties, and the SQL/in-memory granularity agreement at every boundary.
- `FinancialFactRepositoryQueryTranslationTests`: `ToQueryString` guards that both queries reach SQL with the expected WHERE shape (an untranslatable EF query passes every other test).
- OSS suite: 4,856 passed.

https://claude.ai/code/session_01SE71rLG6DQTLTpDr6BfcU7