### PR TITLE
fix(financial-facts): align interim balance and flow fiscal identity

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -35,7 +35,7 @@ public class FinancialFactsImportService
     // Bump whenever parsing, fiscal identity, or quality filtering changes existing rows. The
     // per-company checkpoint forces a full Company Facts replay without racing the old worker
     // during an additive migration rollout.
-    internal const int CurrentImporterVersion = 4;
+    internal const int CurrentImporterVersion = 5;
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ISecEdgarClient _secEdgarClient;
@@ -335,15 +335,15 @@ public class FinancialFactsImportService
         // measures — the filing's fy/fp identifies the filing, not each
         // comparable-year value inside it (#982). Resolver returns null when
         // FYE info is missing or the duration shape is unrecognised; the
-        // original SEC-supplied identity is the fallback. Interim-instant
-        // classification is opted into only on the fp-less path, so fp-carrying
-        // values keep the exact identities they have always had.
+        // original SEC-supplied identity is the fallback. Instants and durations
+        // must use the same date-derived year; SEC fy names the filing and can
+        // differ from the calendar year in which the measured fiscal year ends.
         var resolved = FiscalPeriodResolver.Resolve(
             periodStart,
             value.End,
             stock.FiscalYearEndMonth,
             stock.FiscalYearEndDay,
-            classifyInterimInstants: !hasMappedFp
+            classifyInterimInstants: true
         );
         // With neither a mappable fp nor a date-derived identity the period cannot be
         // placed — defaulting would route the fact into the annual bucket (the

--- a/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportPeriodIdentityTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportPeriodIdentityTests.cs
@@ -248,9 +248,20 @@ public class FinancialFactsImportPeriodIdentityTests : IAsyncLifetime
         fact.FiscalPeriod.Should().Be(SecFiscalPeriod.FullYear);
     }
 
-    [Fact]
-    public async Task Import_OlderImporterVersion_ReplaysAndCorrectsExistingJnjFiscalYear()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Import_OlderImporterVersion_ReplaysAndCorrectsExistingFiscalIdentity(
+        bool interimInstant
+    )
     {
+        var periodStart = interimInstant ? new DateOnly(2020, 5, 3) : new DateOnly(2024, 12, 30);
+        var periodEnd = interimInstant ? periodStart : new DateOnly(2025, 12, 28);
+        var oldYear = interimInstant ? 2020 : 2026;
+        var expectedYear = interimInstant ? 2021 : 2025;
+        var period = interimInstant ? SecFiscalPeriod.Q1 : SecFiscalPeriod.FullYear;
+        var form = interimInstant ? DocumentType.TenQ : DocumentType.TenK;
+        var factId = Guid.NewGuid();
         var stock = new CommonStock
         {
             Id = Guid.NewGuid(),
@@ -258,7 +269,7 @@ public class FinancialFactsImportPeriodIdentityTests : IAsyncLifetime
             Name = "Johnson & Johnson",
             Cik = "0000200406",
             FiscalYearEndMonth = 1,
-            FiscalYearEndDay = 3,
+            FiscalYearEndDay = interimInstant ? 31 : 3,
         };
         var concept = new FinancialConcept
         {
@@ -287,9 +298,9 @@ public class FinancialFactsImportPeriodIdentityTests : IAsyncLifetime
                         Id = documentId,
                         CommonStock = stock,
                         Content = content,
-                        DocumentType = DocumentType.TenK,
+                        DocumentType = form,
                         ReportingDate = filed,
-                        ReportingForDate = new DateOnly(2025, 12, 28),
+                        ReportingForDate = periodEnd,
                         AccessionNumber = accession,
                     }
                 );
@@ -297,16 +308,19 @@ public class FinancialFactsImportPeriodIdentityTests : IAsyncLifetime
                 .Add(
                     new FinancialFact
                     {
+                        Id = factId,
                         CommonStockId = stock.Id,
                         FinancialConceptId = concept.Id,
                         Unit = "USD",
-                        PeriodType = FactPeriodType.Duration,
-                        PeriodStart = new DateOnly(2024, 12, 30),
-                        PeriodEnd = new DateOnly(2025, 12, 28),
+                        PeriodType = interimInstant
+                            ? FactPeriodType.Instant
+                            : FactPeriodType.Duration,
+                        PeriodStart = periodStart,
+                        PeriodEnd = periodEnd,
                         Value = 94_200_000_000m,
-                        FiscalYear = 2026,
-                        FiscalPeriod = SecFiscalPeriod.FullYear,
-                        Form = DocumentType.TenK,
+                        FiscalYear = oldYear,
+                        FiscalPeriod = period,
+                        Form = form,
                         FiledDate = filed,
                         AccessionNumber = accession,
                     }
@@ -341,13 +355,13 @@ public class FinancialFactsImportPeriodIdentityTests : IAsyncLifetime
                             [
                                 new CompanyFactValue
                                 {
-                                    Start = new DateOnly(2024, 12, 30),
-                                    End = new DateOnly(2025, 12, 28),
+                                    Start = interimInstant ? null : periodStart,
+                                    End = periodEnd,
                                     Val = 94_200_000_000m,
                                     Accn = accession,
-                                    Fy = 2026,
-                                    Fp = "FY",
-                                    Form = "10-K",
+                                    Fy = oldYear,
+                                    Fp = interimInstant ? "Q1" : "FY",
+                                    Form = interimInstant ? "10-Q" : "10-K",
                                     Filed = filed,
                                 },
                             ],
@@ -377,8 +391,9 @@ public class FinancialFactsImportPeriodIdentityTests : IAsyncLifetime
         var status = await verify
             .Set<FinancialFactsSyncStatus>()
             .SingleAsync(s => s.CommonStockId == stock.Id, CancellationToken.None);
-        fact.FiscalYear.Should().Be(2025);
-        fact.FiscalPeriod.Should().Be(SecFiscalPeriod.FullYear);
+        fact.Id.Should().Be(factId, "replay updates the existing natural-key row");
+        fact.FiscalYear.Should().Be(expectedYear);
+        fact.FiscalPeriod.Should().Be(period);
         fact.DocumentId.Should().Be(documentId);
         status.ImporterVersion.Should().Be(FinancialFactsImportService.CurrentImporterVersion);
     }

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceInterimIdentityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsImportServiceInterimIdentityTests.cs
@@ -1,0 +1,74 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Integrations.Sec.Models.Responses;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class FinancialFactsImportServiceInterimIdentityTests
+{
+    [Theory]
+    [InlineData(1, 31, "2020-02-03", "2020-05-03", 2020, "Q1", 2021, SecFiscalPeriod.Q1)]
+    [InlineData(1, 31, "2020-05-04", "2020-08-02", 2020, "Q2", 2021, SecFiscalPeriod.Q2)]
+    [InlineData(1, 31, "2020-08-03", "2020-11-01", 2020, "Q3", 2021, SecFiscalPeriod.Q3)]
+    [InlineData(12, 31, "2024-01-01", "2024-03-31", 2025, "Q1", 2024, SecFiscalPeriod.Q1)]
+    [InlineData(9, 30, "2024-10-01", "2024-12-31", 2025, "FY", 2025, SecFiscalPeriod.Q1)]
+    public void MatchingBalanceAndFlowUseTheirMeasuredPeriod(
+        int month,
+        int day,
+        string start,
+        string end,
+        int wireYear,
+        string wirePeriod,
+        int expectedYear,
+        SecFiscalPeriod expectedPeriod
+    )
+    {
+        var stock = new CommonStock { FiscalYearEndMonth = month, FiscalYearEndDay = day };
+        var instant = Parse(stock, null, DateOnly.Parse(end), wireYear, wirePeriod);
+        var duration = Parse(
+            stock,
+            DateOnly.Parse(start),
+            DateOnly.Parse(end),
+            wireYear,
+            wirePeriod
+        );
+
+        instant.Should().Be((expectedYear, expectedPeriod));
+        duration.Should().Be(instant);
+    }
+
+    private static (int Year, SecFiscalPeriod Period) Parse(
+        CommonStock stock,
+        DateOnly? start,
+        DateOnly end,
+        int year,
+        string period
+    )
+    {
+        var value = new CompanyFactValue
+        {
+            Start = start,
+            End = end,
+            Fy = year,
+            Fp = period,
+            Val = 100,
+            Accn = "0000354950-20-000020",
+            Form = "10-Q",
+            Filed = end.AddDays(30),
+        };
+        var method = typeof(FinancialFactsImportService).GetMethod(
+            "TryBuildParsedFact",
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+        var parsed = method.Invoke(
+            null,
+            [FactTaxonomy.UsGaap, "Assets", "Assets", null, "USD", value, stock]
+        )!;
+        return (
+            (int)parsed.GetType().GetProperty("FiscalYear")!.GetValue(parsed)!,
+            (SecFiscalPeriod)parsed.GetType().GetProperty("FiscalPeriod")!.GetValue(parsed)!
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Interim balance-sheet instants kept the SEC filing's fiscal-year label while matching duration facts used the date-derived year. For January-year-end retailers this put a balance sheet one year away from its own income statement.

## Code changes

- Resolve interim instants by date even when SEC supplies `fp`, preserving the existing fallback when the calendar cannot resolve.
- Advance Company Facts importer version to 5 so existing rows replay and update their fiscal identity without duplicating facts.
- Add five matching balance/flow regressions and extend PostgreSQL replay coverage to interim instants.

## Validation

Five new cases failed before the fix and pass after it. All 4,867 unit tests and 46 financial-facts integration tests passed. Release solution build, full CSharpier check, and independent review passed.

Addresses daniel3303/EquiblesCommercial#8310. The existing exact-date balance-sheet read safeguards remain necessary during replay and for subsequent-event disclosures.
