### PR TITLE
fix(financial-facts): repair filing-level fiscal identity on replay

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalPeriodResolver.cs
@@ -22,11 +22,9 @@ internal static class FiscalPeriodResolver
     /// <para>
     /// <paramref name="classifyInterimInstants"/> opts an instant that is NOT at the
     /// fiscal-year end into quarter classification (which fiscal quarter contains the
-    /// date). Off by default: callers with an SEC-supplied fp rely on the null
-    /// fallback there, and re-labelling their instants would rewrite fiscal
-    /// identities corpus-wide. Only fp-less values (6-K interim balance sheets,
-    /// which SEC serves with <c>fp = null</c>) opt in — for them the date is the
-    /// only identity available.
+    /// date). Company Facts and filing-level extraction opt in so instants and
+    /// durations share a date-derived identity; callers retaining source-supplied
+    /// labels may leave it disabled and handle the unresolved result themselves.
     /// </para>
     /// </summary>
     public static (int Year, SecFiscalPeriod Period)? Resolve(

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
@@ -64,7 +64,8 @@ public class XbrlFactExtractionService
     // envelopes; the re-drain classifies every stock's ListedSecurityType.
     // Version 5: preserve every cover-page symbol observation as dated issuer evidence.
     // Version 6: fill absent standard consolidated facts in foreign financial reports.
-    public const int CurrentVersion = 6;
+    // Version 7 replays derived fiscal identities for interim instants and existing rows.
+    public const int CurrentVersion = 7;
 
     private const int InsertBatchSize = 1000;
 
@@ -209,11 +210,24 @@ public class XbrlFactExtractionService
         }
 
         await BatchPersister.Persist(facts, InsertBatchSize, items => FlushFacts(items, false));
-        await BatchPersister.Persist(
-            consolidatedFills,
-            InsertBatchSize,
-            items => FlushFacts(items, true)
-        );
+        foreach (
+            var group in consolidatedFills.GroupBy(fact =>
+                FiscalPeriodResolver.Resolve(
+                    fact.PeriodStart,
+                    fact.PeriodEnd,
+                    stock.FiscalYearEndMonth,
+                    stock.FiscalYearEndDay,
+                    classifyInterimInstants: true
+                ) != null
+            )
+        )
+        {
+            await BatchPersister.Persist(
+                group.ToList(),
+                InsertBatchSize,
+                items => FlushFacts(items, true, refreshFiscalIdentity: group.Key)
+            );
+        }
         await PersistDimensions(document, dimensionsByKey, cancellationToken);
 
         return facts.Count + consolidatedFills.Count;
@@ -436,7 +450,8 @@ public class XbrlFactExtractionService
             periodStart,
             periodEnd,
             fiscalYearEndMonth,
-            fiscalYearEndDay
+            fiscalYearEndDay,
+            classifyInterimInstants: true
         );
         if (resolved != null)
             return resolved.Value;
@@ -668,7 +683,11 @@ public class XbrlFactExtractionService
         return value.Length <= maxLength ? value : value.Substring(0, maxLength);
     }
 
-    private async Task FlushFacts(List<FinancialFact> items, bool fillOnly)
+    private async Task FlushFacts(
+        List<FinancialFact> items,
+        bool fillOnly,
+        bool refreshFiscalIdentity = true
+    )
     {
         using var scope = _scopeFactory.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
@@ -688,9 +707,26 @@ public class XbrlFactExtractionService
                 f.AccessionNumber,
                 f.DimensionsKey,
             });
+        if (fillOnly && !refreshFiscalIdentity)
+        {
+            // Calendar fallback must not replace fiscal labels supplied by the SEC.
+            await upsert.NoUpdate().RunAsync();
+            return;
+        }
         if (fillOnly)
         {
-            await upsert.NoUpdate().RunAsync();
+            // Preserve authoritative values and provenance; fiscal labels are derived
+            // from the same natural-key dates and must follow the current resolver.
+            await upsert
+                .WhenMatched(
+                    (existing, incoming) =>
+                        new FinancialFact
+                        {
+                            FiscalYear = incoming.FiscalYear,
+                            FiscalPeriod = incoming.FiscalPeriod,
+                        }
+                )
+                .RunAsync();
             return;
         }
         await upsert
@@ -698,6 +734,8 @@ public class XbrlFactExtractionService
                 (existing, incoming) =>
                     new FinancialFact
                     {
+                        FiscalYear = incoming.FiscalYear,
+                        FiscalPeriod = incoming.FiscalPeriod,
                         Value = incoming.Value,
                         FiledDate = incoming.FiledDate,
                         DocumentId = incoming.DocumentId,

--- a/tests/Equibles.IntegrationTests/Sec/XbrlFactExtractionServiceExtractTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlFactExtractionServiceExtractTests.cs
@@ -65,9 +65,17 @@ public class XbrlFactExtractionServiceExtractTests : ParadeDbMcpTestBase
         dimension.Axis.Should().Be("srt:ProductOrServiceAxis");
         dimension.Member.Should().Be("aapl:IPhoneMember");
 
-        // Idempotency: a second sweep over the same envelope changes nothing.
+        // A version replay repairs derived labels without duplicating facts or dimensions.
+        var factId = fact.Id;
+        fact.FiscalYear = 2024;
+        fact.FiscalPeriod = SecFiscalPeriod.Q4;
+        await DbContext.SaveChangesAsync();
         var secondRun = await sut.Extract(document, CancellationToken.None);
         secondRun.Should().Be(1);
+        await DbContext.Entry(fact).ReloadAsync();
+        fact.Id.Should().Be(factId);
+        fact.FiscalYear.Should().Be(2025);
+        fact.FiscalPeriod.Should().Be(SecFiscalPeriod.Q1);
         (
             await DbContext
                 .Set<FinancialFact>()
@@ -122,6 +130,8 @@ public class XbrlFactExtractionServiceExtractTests : ParadeDbMcpTestBase
 
         // Model an authoritative API row occupying this exact natural key.
         consolidated.Value = 999m;
+        consolidated.FiscalYear = 2024;
+        consolidated.FiscalPeriod = SecFiscalPeriod.Q4;
         consolidated.DocumentId = null;
         consolidated.Frame = "CY2025Q1";
         await DbContext.SaveChangesAsync();
@@ -130,6 +140,8 @@ public class XbrlFactExtractionServiceExtractTests : ParadeDbMcpTestBase
 
         consolidated.Id.Should().Be(id);
         consolidated.Value.Should().Be(999m);
+        consolidated.FiscalYear.Should().Be(2025);
+        consolidated.FiscalPeriod.Should().Be(SecFiscalPeriod.Q1);
         consolidated.DocumentId.Should().BeNull();
         consolidated.Frame.Should().Be("CY2025Q1");
         (
@@ -139,6 +151,42 @@ public class XbrlFactExtractionServiceExtractTests : ParadeDbMcpTestBase
         )
             .Should()
             .Be(2);
+    }
+
+    [Fact]
+    public async Task Extract_ForeignInstantWithoutFye_PreservesExistingAnnualIdentity()
+    {
+        var envelope = InlineEnvelope()
+            .Replace("scheme=\"cik\"", "scheme=\"http://www.sec.gov/CIK\"")
+            .Replace(
+                "<xbrli:startDate>2025-01-01</xbrli:startDate><xbrli:endDate>2025-03-31</xbrli:endDate>",
+                "<xbrli:instant>2025-12-31</xbrli:instant>"
+            );
+        var document = await SeedDocument(envelope);
+        document.DocumentType = DocumentType.SixK;
+        document.ReportingDate = new DateOnly(2026, 2, 1);
+        document.ReportingForDate = new DateOnly(2025, 12, 31);
+        document.CommonStock.FiscalYearEndMonth = null;
+        document.CommonStock.FiscalYearEndDay = null;
+        await DbContext.SaveChangesAsync();
+        var sut = BuildSut();
+        await sut.Extract(document, CancellationToken.None);
+        var consolidated = await DbContext
+            .Set<FinancialFact>()
+            .SingleAsync(f => f.DocumentId == document.Id && f.DimensionsKey == "");
+        consolidated.FiscalYear = 2025;
+        consolidated.FiscalPeriod = SecFiscalPeriod.FullYear;
+        consolidated.Value = 999m;
+        consolidated.DocumentId = null;
+        await DbContext.SaveChangesAsync();
+
+        await sut.Extract(document, CancellationToken.None);
+        await DbContext.Entry(consolidated).ReloadAsync();
+
+        consolidated.FiscalYear.Should().Be(2025);
+        consolidated.FiscalPeriod.Should().Be(SecFiscalPeriod.FullYear);
+        consolidated.Value.Should().Be(999m);
+        consolidated.DocumentId.Should().BeNull();
     }
 
     private async Task<Document> SeedDocument(string envelope)

--- a/tests/Equibles.UnitTests/Sec/XbrlFactExtractionServiceResolveFiscalIdentityTests.cs
+++ b/tests/Equibles.UnitTests/Sec/XbrlFactExtractionServiceResolveFiscalIdentityTests.cs
@@ -13,6 +13,28 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class XbrlFactExtractionServiceResolveFiscalIdentityTests
 {
+    [Theory]
+    [InlineData(2025, 5, 4, 1, 31, 2026, SecFiscalPeriod.Q1)]
+    [InlineData(2025, 8, 3, 1, 31, 2026, SecFiscalPeriod.Q2)]
+    [InlineData(2025, 11, 2, 1, 31, 2026, SecFiscalPeriod.Q3)]
+    [InlineData(2024, 12, 31, 9, 30, 2025, SecFiscalPeriod.Q1)]
+    public void ResolveFiscalIdentity_InterimInstant_UsesReportedFiscalQuarter(
+        int year,
+        int month,
+        int day,
+        int fyeMonth,
+        int fyeDay,
+        int expectedYear,
+        SecFiscalPeriod expectedPeriod
+    )
+    {
+        var date = new DateOnly(year, month, day);
+        XbrlFactExtractionService
+            .ResolveFiscalIdentity(date, date, fyeMonth, fyeDay)
+            .Should()
+            .Be((expectedYear, expectedPeriod));
+    }
+
     [Fact]
     public void ResolveFiscalIdentity_KnownFye_UsesResolver()
     {


### PR DESCRIPTION
Filing-level extraction assigned non-calendar interim balance-sheet instants to calendar quarters, and replay left existing fiscal labels unchanged. Classify instants using the same fiscal resolver as durations, refresh derived labels during upsert, and advance extraction version to 7.

For foreign consolidated collisions, preserve authoritative amounts and provenance. Refresh labels only when fiscal resolution succeeds; missing metadata must not replace source-supplied annual labels with a calendar fallback.

Validation: four new identity cases and two persistence regressions failed before the fix. All 4,871 unit tests and eight extraction integration tests pass; Release build and full formatting check passed. Independent full-diff review and follow-up review passed.
