### PR TITLE
fix(holdings): preserve filed values for principal positions

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -23,6 +23,14 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
             .IsUnique()
             .AreNullsDistinct(false);
 
+        // Principal-value repair must scan only principal rows, not the full holdings corpus.
+        builder
+            .Entity<InstitutionalHolding>()
+            .HasIndex(h => new { h.ShareType, h.Id })
+            .HasDatabaseName("IX_InstitutionalHolding_Principal")
+            .HasFilter("\"ShareType\" = 1")
+            .IsCreatedConcurrently();
+
         // Covering index for the per-stock ownership-trend GROUP BY on the stock
         // Holdings page. Postgres-specific `INCLUDE` is not expressible via the
         // [Index] attribute, so it lives here. Holders / value / shares ride along

--- a/src/Equibles.Holdings.HostedService/Services/HoldingValueFallbackRepairService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingValueFallbackRepairService.cs
@@ -143,6 +143,11 @@ public class HoldingValueFallbackRepairService
 
     public async Task<int> Repair(CancellationToken cancellationToken)
     {
+        var principalValues = await RunPhase(
+            "principal-values",
+            RepairPrincipalValues,
+            cancellationToken
+        );
         var revisedFiled = await RunPhase("revise-filed", ReviseFiledPublishes, cancellationToken);
         var healedZeros = await RunPhase("stuck-zeros", HealStuckZeros, cancellationToken);
         var resetImplausible = await RunPhase(
@@ -171,7 +176,72 @@ public class HoldingValueFallbackRepairService
             );
         }
 
-        return revisedFiled + healedZeros + resetImplausible + markedUnavailable;
+        return principalValues + revisedFiled + healedZeros + resetImplausible + markedUnavailable;
+    }
+
+    internal static IQueryable<InstitutionalHolding> BuildPrincipalCandidateQuery(
+        EquiblesFinancialDbContext dbContext
+    ) =>
+        dbContext
+            .Set<InstitutionalHolding>()
+            .Include(h => h.ManagerEntries)
+            .Where(h =>
+                h.ShareType == ShareType.Principal
+                && (
+                    h.FiledValue > 0
+                        ? h.Value != h.FiledValue
+                            || h.ValueSource != ValueSource.Filed
+                            || h.ValuePending
+                            || h.ValueUnavailable
+                        : h.Value != 0 || h.ValuePending || !h.ValueUnavailable
+                )
+            )
+            .OrderBy(h => h.Id)
+            .Take(MaxRowsPerCycle);
+
+    private async Task<int> RepairPrincipalValues(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        ExtendCommandTimeout(dbContext);
+        await using var transaction = dbContext.Database.IsRelational()
+            ? await dbContext.Database.BeginTransactionAsync(cancellationToken)
+            : null;
+        var rows = await BuildPrincipalCandidateQuery(dbContext).ToListAsync(cancellationToken);
+        if (rows.Count == 0)
+            return 0;
+        foreach (var holding in rows)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (holding.FiledValue is > 0)
+            {
+                HoldingsValueRecalculator.ApplyFiledValue(holding);
+                holding.ValueUnavailable = false;
+            }
+            else
+            {
+                holding.Value = 0;
+                holding.ValuePending = false;
+                holding.ValueUnavailable = true;
+                holding.ValueSource = ValueSource.Derived;
+                foreach (var entry in holding.ManagerEntries)
+                    entry.Value = 0;
+            }
+        }
+        await dbContext.SaveChangesAsync(cancellationToken);
+        await HoldingsRollupRefresher.Refresh(
+            dbContext,
+            rows.Select(h => h.AccessionNumber).ToHashSet(),
+            rows.Select(h => h.ReportDate).ToHashSet(),
+            cancellationToken
+        );
+        if (transaction != null)
+            await transaction.CommitAsync(cancellationToken);
+        _logger.LogInformation(
+            "Repaired filed values for {Count} principal-denominated positions",
+            rows.Count
+        );
+        return rows.Count;
     }
 
     // One phase's failure must not starve the phases after it; only cancellation propagates.
@@ -212,6 +282,7 @@ public class HoldingValueFallbackRepairService
             .Include(h => h.ManagerEntries)
             .Where(h =>
                 !h.ValuePending
+                && h.ShareType == ShareType.Shares
                 && !h.ValueUnavailable
                 && h.ValueSource == ValueSource.Filed
                 && h.ValueLastRetryAt == null
@@ -463,6 +534,7 @@ public class HoldingValueFallbackRepairService
             .Include(h => h.ManagerEntries)
             .Where(h =>
                 !h.ValuePending
+                && h.ShareType == ShareType.Shares
                 && h.ValueSource != ValueSource.Filed
                 && h.Shares > 0
                 && (decimal)h.Value > HoldingValueSanityGuard.MaxPlausibleSharePrice * h.Shares

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsImportService.cs
@@ -1775,9 +1775,8 @@ public class HoldingsImportService
         long ParseLongField(string field) => ParseLong(GetValue(row, field));
 
         var shares = ParseLongField("SSHPRNAMT");
-        // The filed market value is not what gets published (Value is always derived from
-        // shares × closing price, the only basis 13D/G positions can share), but it is kept
-        // alongside it so the derivation can be audited against its source.
+        // Keep filed value for audit and fallback; principal-denominated positions use it
+        // directly because their quantity cannot be multiplied by an equity share price.
         var reportedValue = ParseLongField("VALUE");
         var votingAuthSole = ParseLongField("VOTING_AUTH_SOLE");
         var votingAuthShared = ParseLongField("VOTING_AUTH_SHARED");
@@ -1813,7 +1812,8 @@ public class HoldingsImportService
         // shares comes from filer-controlled SSHPRNAMT; an oversized count makes the decimal
         // product exceed Int64, so range-check before the cast (mirrors Filing13DGXmlParser)
         // instead of throwing OverflowException and aborting the whole filing's import.
-        var product = shares * shareCountFactor * closePrice;
+        var product =
+            shareType == ShareType.Principal ? 0m : shares * shareCountFactor * closePrice;
         var value =
             canValue && product >= long.MinValue && product <= long.MaxValue ? (long)product : 0L;
         var valuePending = !canValue;
@@ -1853,7 +1853,7 @@ public class HoldingsImportService
         var filedValue =
             filedDollars > 0 && filedDollars <= long.MaxValue ? (long?)filedDollars : null;
 
-        if (value > 0 && filedValue.HasValue)
+        if (shareType == ShareType.Shares && value > 0 && filedValue.HasValue)
         {
             context.ValueBasisAudit.Record(
                 cusip,
@@ -1875,6 +1875,16 @@ public class HoldingsImportService
         {
             value = filedValue.Value;
             valueSource = ValueSource.Filed;
+        }
+
+        // PRN states a principal amount, never a share quantity compatible with an equity price.
+        // Preserve the source quantity and publish only the filing's own monetary value.
+        if (shareType == ShareType.Principal)
+        {
+            value = filedValue ?? 0L;
+            valuePending = false;
+            valueUnavailable = !filedValue.HasValue;
+            valueSource = filedValue.HasValue ? ValueSource.Filed : ValueSource.Derived;
         }
 
         var (otherManagerNumber, sharedManagerNumbers) = ParseOtherManagerAttribution(

--- a/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
+++ b/src/Equibles.Holdings.HostedService/Services/HoldingsValueRecalculator.cs
@@ -53,7 +53,7 @@ public class HoldingsValueRecalculator
 
         var pendingPairs = await lookupContext
             .Set<InstitutionalHolding>()
-            .Where(h => h.ValuePending)
+            .Where(h => h.ValuePending && h.ShareType == ShareType.Shares)
             .Select(h => new
             {
                 h.CommonStockId,
@@ -178,6 +178,7 @@ public class HoldingsValueRecalculator
                 .Include(h => h.ManagerEntries)
                 .Where(h =>
                     h.ValuePending
+                    && h.ShareType == ShareType.Shares
                     && h.CommonStockId == pair.CommonStockId
                     && h.ListedTicker == pair.ListedTicker
                     && h.ReportDate == pair.ReportDate
@@ -306,6 +307,7 @@ public class HoldingsValueRecalculator
                 .Include(h => h.ManagerEntries)
                 .Where(h =>
                     h.ValuePending
+                    && h.ShareType == ShareType.Shares
                     && h.CommonStockId == stockId
                     && h.ListedTicker == listedTicker
                     && h.ReportDate == reportDate

--- a/src/Equibles.Holdings.HostedService/Services/ImpossiblePositionRepairService.cs
+++ b/src/Equibles.Holdings.HostedService/Services/ImpossiblePositionRepairService.cs
@@ -58,7 +58,7 @@ public class ImpossiblePositionRepairService
         // than a false accusation, and no worse than this pass has ever done.
         var candidates = await dbContext
             .Set<InstitutionalHolding>()
-            .Where(h => !h.ValueUnavailable && h.Shares > 0)
+            .Where(h => h.ShareType == ShareType.Shares && !h.ValueUnavailable && h.Shares > 0)
             .Join(
                 dbContext.Set<CommonStock>(),
                 h => h.CommonStockId,

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -178,6 +178,7 @@ public class InstitutionalHoldingsTools
                 // both rank and denominator, so a separate raw aggregate/page query would scan
                 // the combined-quarter view twice and could rank a sibling class incorrectly.
                 var holdings = await allHoldings
+                    .Where(h => h.ShareType == ShareType.Shares)
                     .AsNoTracking()
                     .Select(h => new TopHolderRow
                     {
@@ -747,15 +748,18 @@ public class InstitutionalHoldingsTools
                 // The exact listing held: a GOOG position must not render as GOOGL, and a
                 // sibling ETF split must not rescale this row.
                 var listedTicker = h.ListedTicker ?? h.CommonStock.Ticker;
-                var shares = SplitAdjustment.AdjustShareCount(
-                    h.Shares,
-                    targetDate,
-                    PriceSeriesSplitScope.ForListing(
-                        SplitsFor(splitsByStock, h.CommonStockId),
-                        h.CommonStock.Ticker,
-                        listedTicker
-                    )
-                );
+                var shares =
+                    h.ShareType == ShareType.Principal
+                        ? h.Shares
+                        : SplitAdjustment.AdjustShareCount(
+                            h.Shares,
+                            targetDate,
+                            PriceSeriesSplitScope.ForListing(
+                                SplitsFor(splitsByStock, h.CommonStockId),
+                                h.CommonStock.Ticker,
+                                listedTicker
+                            )
+                        );
                 var pct = Percentage.Of(h.Value, totalValue);
                 // Rank is the ABSOLUTE position in the value-ranked rows, so page two
                 // continues 21, 22, … instead of restarting at 1.

--- a/src/Equibles.Migrations/Migrations/20260908193945_IndexPrincipalHoldings.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260908193945_IndexPrincipalHoldings.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260908193945_IndexPrincipalHoldings")]
+    partial class IndexPrincipalHoldings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260908193945_IndexPrincipalHoldings.cs
+++ b/src/Equibles.Migrations/Migrations/20260908193945_IndexPrincipalHoldings.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <summary>Supports bounded principal-value repair without blocking holdings writes.</summary>
+    public partial class IndexPrincipalHoldings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DO $$ BEGIN "
+                    + "IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid "
+                    + "WHERE c.relname = 'IX_InstitutionalHolding_Principal' AND NOT i.indisvalid) THEN "
+                    + "EXECUTE 'DROP INDEX \"IX_InstitutionalHolding_Principal\"'; END IF; END $$;",
+                suppressTransaction: true
+            );
+            migrationBuilder.Sql(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS \"IX_InstitutionalHolding_Principal\" "
+                    + "ON \"InstitutionalHolding\" (\"ShareType\", \"Id\") WHERE \"ShareType\" = 1;",
+                suppressTransaction: true
+            );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_InstitutionalHolding_Principal\";",
+                suppressTransaction: true
+            );
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingValueFallbackRepairServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingValueFallbackRepairServiceTests.cs
@@ -104,7 +104,8 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
         ValueSource valueSource = ValueSource.Derived,
         string accession = null,
         int valueRetryCount = 0,
-        DateTime? valueLastRetryAt = null
+        DateTime? valueLastRetryAt = null,
+        ShareType shareType = ShareType.Shares
     )
     {
         var seedContext = CreateSharedContext();
@@ -135,7 +136,7 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
             ValueSource = valueSource,
             ValueRetryCount = valueRetryCount,
             ValueLastRetryAt = valueLastRetryAt,
-            ShareType = ShareType.Shares,
+            ShareType = shareType,
             InvestmentDiscretion = InvestmentDiscretion.Sole,
             AccessionNumber = accession ?? Guid.NewGuid().ToString()[..20],
             ManagerEntries =
@@ -155,6 +156,73 @@ public class HoldingValueFallbackRepairServiceTests : IDisposable
         seedContext.Set<InstitutionalHolding>().Add(holding);
         await seedContext.SaveChangesAsync();
         return holding;
+    }
+
+    [Fact]
+    public async Task Repair_PrincipalPublishesFiledValuesAndNeverRepricesThem()
+    {
+        var accession = Guid.NewGuid().ToString()[..20];
+        var rows = new List<InstitutionalHolding>();
+        for (var i = 0; i < 3; i++)
+        {
+            var holding = await SeedHolding(
+                45_000_000L,
+                45_000L,
+                900_000L,
+                valueUnavailable: i == 1,
+                valuePending: i == 2,
+                accession: accession,
+                shareType: ShareType.Principal
+            );
+            PriceAt(holding, 50m);
+            rows.Add(holding);
+        }
+        using (var stockContext = CreateSharedContext())
+        {
+            foreach (var stock in await stockContext.Set<CommonStock>().ToListAsync())
+            {
+                stock.SharesOutStanding = 100_000;
+                stock.MarketCapitalization = 5_000_000;
+            }
+            await stockContext.SaveChangesAsync();
+        }
+        var service = CreateService();
+        (await service.Repair(CancellationToken.None)).Should().Be(3);
+        var impossibleRepair = new ImpossiblePositionRepairService(
+            CreateScopeFactory(),
+            Substitute.For<ILogger<ImpossiblePositionRepairService>>()
+        );
+        (await impossibleRepair.Repair(CancellationToken.None)).Should().Be(0);
+        foreach (var row in rows)
+        {
+            var actual = await Reload(row.Id);
+            actual.Shares.Should().Be(900_000L);
+            actual.Value.Should().Be(45_000L);
+            actual.ValueSource.Should().Be(ValueSource.Filed);
+            actual.ValuePending.Should().BeFalse();
+            actual.ValueUnavailable.Should().BeFalse();
+            actual.ManagerEntries.Should().ContainSingle().Which.Value.Should().Be(45_000L);
+        }
+        (await service.Repair(CancellationToken.None)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Repair_PrincipalWithoutFiledValueBecomesUnavailable()
+    {
+        var row = await SeedHolding(
+            45_000_000L,
+            null,
+            900_000L,
+            valuePending: true,
+            shareType: ShareType.Principal
+        );
+        var service = CreateService();
+        (await service.Repair(CancellationToken.None)).Should().Be(1);
+        var actual = await Reload(row.Id);
+        actual.Value.Should().Be(0L);
+        actual.ValuePending.Should().BeFalse();
+        actual.ValueUnavailable.Should().BeTrue();
+        (await service.Repair(CancellationToken.None)).Should().Be(0);
     }
 
     private async Task<InstitutionalHolding> Reload(Guid holdingId)

--- a/tests/Equibles.IntegrationTests/Holdings/PrincipalValueRepairTransactionTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/PrincipalValueRepairTransactionTests.cs
@@ -1,0 +1,119 @@
+using System.Data.Common;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Core.Contracts;
+using Equibles.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.HostedService.Services;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+[Collection(ParadeDbCollection.Name)]
+public class PrincipalValueRepairTransactionTests(ParadeDbFixture fixture) : IAsyncLifetime
+{
+    public Task InitializeAsync() => fixture.ResetAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task FailedRollupRollsBackPositionAndCanRetry()
+    {
+        var date = new DateOnly(2026, 6, 30);
+        var stock = new CommonStock { Ticker = "PRN", Name = "Principal issuer" };
+        var holder = new InstitutionalHolder { Cik = "0001900923", Name = "Principal filer" };
+        var holding = new InstitutionalHolding
+        {
+            CommonStock = stock,
+            InstitutionalHolder = holder,
+            ReportDate = date,
+            FilingDate = date.AddDays(40),
+            AccessionNumber = "0001214659-26-010383",
+            ShareType = ShareType.Principal,
+            Shares = 900_000,
+            Value = 45_000_000,
+            FiledValue = 45_000,
+            ManagerEntries =
+            [
+                new HoldingManagerEntry
+                {
+                    ManagerNumber = 1,
+                    ManagerName = "Manager",
+                    Shares = 900_000,
+                    Value = 45_000_000,
+                },
+            ],
+        };
+        await using (var seed = fixture.CreateDbContext())
+        {
+            seed.Add(holding);
+            await seed.SaveChangesAsync();
+        }
+        var failure = new FailSnapshotRead();
+        var contexts = new List<EquiblesFinancialDbContext>();
+        var scopes = Substitute.For<IServiceScopeFactory>();
+        scopes
+            .CreateScope()
+            .Returns(_ =>
+            {
+                var context = fixture.CreateDbContext(options => options.AddInterceptors(failure));
+                contexts.Add(context);
+                var services = Substitute.For<IServiceProvider>();
+                services.GetService(typeof(EquiblesFinancialDbContext)).Returns(context);
+                var scope = Substitute.For<IServiceScope>();
+                scope.ServiceProvider.Returns(services);
+                return scope;
+            });
+        var repair = new HoldingValueFallbackRepairService(
+            scopes,
+            Substitute.For<IStockPriceProvider>(),
+            NullLogger<HoldingValueFallbackRepairService>.Instance
+        );
+        try
+        {
+            await repair.Repair(CancellationToken.None);
+            failure.Fired.Should().BeTrue();
+            await using (var read = fixture.CreateDbContext())
+            {
+                var unchanged = await read.Set<InstitutionalHolding>()
+                    .Include(h => h.ManagerEntries)
+                    .SingleAsync();
+                unchanged.Value.Should().Be(45_000_000);
+                unchanged.ManagerEntries.Single().Value.Should().Be(45_000_000);
+            }
+            (await repair.Repair(CancellationToken.None)).Should().Be(1);
+            await using var verified = fixture.CreateDbContext();
+            (await verified.Set<InstitutionalHolding>().SingleAsync()).Value.Should().Be(45_000);
+            (await verified.Set<AumQuarterlySnapshot>().SingleAsync()).DirtyAt.Should().NotBeNull();
+        }
+        finally
+        {
+            foreach (var context in contexts)
+                await context.DisposeAsync();
+        }
+    }
+
+    private sealed class FailSnapshotRead : DbCommandInterceptor
+    {
+        public bool Fired { get; private set; }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default
+        )
+        {
+            if (!Fired && command.CommandText.Contains("AumQuarterlySnapshot"))
+            {
+                Fired = true;
+                throw new InvalidOperationException("Injected rollup failure after position save");
+            }
+            return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+        }
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingValueFallbackRepairServiceReviseQueryTranslationTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingValueFallbackRepairServiceReviseQueryTranslationTests.cs
@@ -16,8 +16,10 @@ namespace Equibles.UnitTests.Holdings;
 /// </summary>
 public class HoldingValueFallbackRepairServiceReviseQueryTranslationTests
 {
-    [Fact]
-    public void BuildReviseCandidateQuery_TranslatesToSql()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CandidateQuery_TranslatesToSql(bool principal)
     {
         var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
             .UseNpgsql("Host=localhost;Database=translation-only")
@@ -33,10 +35,9 @@ public class HoldingValueFallbackRepairServiceReviseQueryTranslationTests
             }
         );
 
-        var query = HoldingValueFallbackRepairService.BuildReviseCandidateQuery(
-            ctx,
-            Guid.NewGuid()
-        );
+        var query = principal
+            ? HoldingValueFallbackRepairService.BuildPrincipalCandidateQuery(ctx)
+            : HoldingValueFallbackRepairService.BuildReviseCandidateQuery(ctx, Guid.NewGuid());
 
         // Throws InvalidOperationException ("could not be translated") when the shape stops
         // translating; the assertions pin that the frontier comparison and the row cap stay in

--- a/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowSanityGuardTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsImportServiceParseHoldingRowSanityGuardTests.cs
@@ -15,7 +15,10 @@ public class HoldingsImportServiceParseHoldingRowSanityGuardTests
     private static (InstitutionalHolding Holding, bool ValuePending) Parse(
         Guid commonStockId,
         decimal? closePrice,
-        string filedValueField
+        string filedValueField,
+        string shareType = "SH",
+        string quantity = "273201",
+        DateOnly? sourceFilingDate = null
     )
     {
         var method = typeof(HoldingsImportService).GetMethod(
@@ -25,14 +28,14 @@ public class HoldingsImportServiceParseHoldingRowSanityGuardTests
 
         var holderId = Guid.NewGuid();
         // Post-2023 filing date so VALUE is already in whole dollars.
-        var filingDate = new DateOnly(2024, 11, 15);
+        var filingDate = sourceFilingDate ?? new DateOnly(2024, 11, 15);
         var reportDate = new DateOnly(2024, 9, 30);
 
         var row = new Dictionary<string, string>
         {
-            ["SSHPRNAMTTYPE"] = "SH",
+            ["SSHPRNAMTTYPE"] = shareType,
             ["PUTCALL"] = "",
-            ["SSHPRNAMT"] = "273201",
+            ["SSHPRNAMT"] = quantity,
             ["VALUE"] = filedValueField,
             ["VOTING_AUTH_SOLE"] = "273201",
             ["VOTING_AUTH_SHARED"] = "0",
@@ -72,6 +75,53 @@ public class HoldingsImportServiceParseHoldingRowSanityGuardTests
         var holding = (InstitutionalHolding)result.GetType().GetField("Item1").GetValue(result);
         var valuePending = (bool)result.GetType().GetField("Item3").GetValue(result);
         return (holding, valuePending);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ParseHoldingRow_PrincipalUsesFiledValueWithoutSharePricing(bool hasSharePrice)
+    {
+        // ReadyState 0001214659-26-010383: PRN is a principal amount, not shares.
+        var (holding, pending) = Parse(
+            Guid.NewGuid(),
+            hasSharePrice ? 50.89m : null,
+            "45413596",
+            "PRN",
+            "899992000"
+        );
+
+        holding.Shares.Should().Be(899_992_000L);
+        holding.ShareType.Should().Be(ShareType.Principal);
+        holding.Value.Should().Be(45_413_596L);
+        holding.ValueSource.Should().Be(ValueSource.Filed);
+        holding.ValueUnavailable.Should().BeFalse();
+        pending.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseHoldingRow_OlderPrincipalFilingConvertsThousandsToDollars()
+    {
+        var (holding, pending) = Parse(
+            Guid.NewGuid(),
+            50m,
+            "45413",
+            "PRN",
+            "899992000",
+            new DateOnly(2022, 11, 15)
+        );
+        holding.Value.Should().Be(45_413_000L);
+        holding.Shares.Should().Be(899_992_000L);
+        pending.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseHoldingRow_PrincipalWithoutFiledValueIsUnavailable()
+    {
+        var (holding, pending) = Parse(Guid.NewGuid(), 50.89m, "0", "PRN", "899992000");
+        holding.Value.Should().Be(0L);
+        holding.ValueUnavailable.Should().BeTrue();
+        pending.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests.cs
@@ -101,6 +101,18 @@ public class InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests
                 accession: "sc-13g"
             )
         );
+        var principal = MakeHolding(
+            vanguardCapital,
+            apple,
+            quarterEnd,
+            FilingType.Form13F,
+            InvestmentDiscretion.Sole,
+            shares: 9_000_000_000L,
+            value: 45_000_000L,
+            accession: "principal"
+        );
+        principal.ShareType = ShareType.Principal;
+        db.Add(principal);
         await db.SaveChangesAsync();
 
         var sut = new InstitutionalHoldingsTools(
@@ -122,6 +134,7 @@ public class InstitutionalHoldingsToolsGetTopHoldersExcludes13DGTests
         output.Should().Contain("953,847,648");
         // The Schedule 13G sole-dispositive-power figure must never render as a holding row.
         output.Should().NotContain("1,099,168,953");
+        output.Should().NotContain("9,000,000,000");
         // The filer appears exactly once, not twice.
         CountOccurrences(output, "VANGUARD CAPITAL MANAGEMENT LLC").Should().Be(1);
     }

--- a/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarianceTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarianceTests.cs
@@ -9,6 +9,59 @@ namespace Equibles.UnitTests.Holdings;
 
 public class InstitutionalHoldingsToolsRenderInstitutionPortfolioCultureInvarianceTests
 {
+    [Fact]
+    public void RenderInstitutionPortfolio_DoesNotApplyEquitySplitToPrincipal()
+    {
+        var stock = new CommonStock { Ticker = "AAPL", Name = "Apple" };
+        var holder = new InstitutionalHolder { Name = "Principal holder", Cik = "123" };
+        var holding = new InstitutionalHolding
+        {
+            CommonStock = stock,
+            CommonStockId = stock.Id,
+            Shares = 123_456,
+            Value = 123_456,
+            ShareType = ShareType.Principal,
+        };
+        var splits = new Dictionary<Guid, List<StockSplit>>
+        {
+            [stock.Id] =
+            [
+                new StockSplit
+                {
+                    CommonStockId = stock.Id,
+                    PriceSeriesTicker = stock.Ticker,
+                    EffectiveDate = new DateOnly(2025, 1, 15),
+                    Numerator = 10,
+                    Denominator = 1,
+                },
+            ],
+        };
+        var method = typeof(InstitutionalHoldingsTools).GetMethod(
+            "RenderInstitutionPortfolio",
+            BindingFlags.NonPublic | BindingFlags.Static
+        );
+        var output = (string)
+            method.Invoke(
+                null,
+                [
+                    holder,
+                    new DateOnly(2024, 12, 31),
+                    new List<InstitutionalHolding> { holding },
+                    splits,
+                    0,
+                    1,
+                    1,
+                    123_456L,
+                    0,
+                    null,
+                    null,
+                ]
+            );
+        output.Should().Contain("Principal");
+        output.Should().Contain("123,456");
+        output.Should().NotContain("1,234,560");
+    }
+
     // Adversarial Lane A. RenderInstitutionPortfolio builds the per-holding
     // markdown row via:
     //   $"| {i + 1} | {ticker} | {name} | {h.Shares:N0} | {h.Value / 1_000_000m:N1} |"


### PR DESCRIPTION
Principal-denominated 13F quantities were multiplied by equity prices, inflating some filed positions by roughly 1,000 times. Preserve PRN quantities and publish the filing's converted dollar value; missing values remain unavailable.

Add a bounded, transactional historical repair that updates existing manager entries, filing totals and quarter refresh markers. Equity repricing and impossible-share-count repair exclude principal positions. Share-based top-holder results exclude principal; institution portfolios retain the filed quantity without stock-split adjustment. A restart-safe concurrent partial index supports the repair.

Validation: 4,877 unit tests passed; 94 holdings integration tests passed before review fixes, followed by 22 affected tests including PostgreSQL migration and injected-failure rollback/retry. Independent full-diff review and fixes review passed. Formatter passed.
