### PR TITLE
fix(financial-facts): retain historical fiscal calendars across year-end changes

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260908205525_TrackFinancialFactsCalendarEvidence.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260908205525_TrackFinancialFactsCalendarEvidence.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260908205525_TrackFinancialFactsCalendarEvidence")]
+    partial class TrackFinancialFactsCalendarEvidence
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260908205525_TrackFinancialFactsCalendarEvidence.cs
+++ b/src/Equibles.Migrations/Migrations/20260908205525_TrackFinancialFactsCalendarEvidence.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrackFinancialFactsCalendarEvidence : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "CalendarEvidenceFingerprint",
+                table: "FinancialFactsSyncStatus",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "XbrlCalendarEvidenceFingerprint",
+                table: "Document",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CalendarEvidenceFingerprint",
+                table: "FinancialFactsSyncStatus");
+
+            migrationBuilder.DropColumn(
+                name: "XbrlCalendarEvidenceFingerprint",
+                table: "Document");
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/Models/Document.cs
+++ b/src/Equibles.Sec.Data/Models/Document.cs
@@ -181,6 +181,10 @@ public class Document
     /// </summary>
     public int XbrlFactsVersion { get; set; }
 
+    /// <summary>Company calendar checkpoint observed when this extraction was attempted.</summary>
+    [MaxLength(64)]
+    public string XbrlCalendarEvidenceFingerprint { get; set; }
+
     /// <summary>
     /// How many times the dimensional-fact extraction has failed on this document. The
     /// sweep stops selecting a document at its retry ceiling so one unparseable envelope

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/HistoricalFiscalCalendar.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/HistoricalFiscalCalendar.cs
@@ -20,7 +20,7 @@ public sealed class HistoricalFiscalCalendar(
 
     public bool HasEvidence(DateOnly start, DateOnly end) =>
         annualPeriods.Any(period => start >= period.Start && end <= period.End)
-        || reportedYearEnds.Any(observation => observation.PeriodEnd == end);
+        || reportedYearEnds.Any(observation => Applies(observation, start, end));
 
     public bool RefusesCalendar(DateOnly start, DateOnly end)
     {
@@ -32,7 +32,7 @@ public sealed class HistoricalFiscalCalendar(
         if (annualEnds.Length > 0)
             return annualEnds.Length > 1;
         var calendars = reportedYearEnds
-            .Where(p => p.PeriodEnd == end)
+            .Where(p => Applies(p, start, end))
             .Select(p => (p.Month, p.Day))
             .Distinct()
             .Count();
@@ -62,14 +62,15 @@ public sealed class HistoricalFiscalCalendar(
                             )
                             .Concat(
                                 reportedYearEnds
-                                    .Select(p => (p.PeriodEnd, p.Month, p.Day))
+                                    .Select(p => (p.PeriodStart, p.PeriodEnd, p.Month, p.Day))
                                     .Distinct()
                                     .OrderBy(p => p.PeriodEnd)
+                                    .ThenBy(p => p.PeriodStart)
                                     .ThenBy(p => p.Month)
                                     .ThenBy(p => p.Day)
                                     .Select(p =>
                                         FormattableString.Invariant(
-                                            $"F:{p.PeriodEnd:yyyy-MM-dd}:{p.Month}:{p.Day}"
+                                            $"F:{p.PeriodStart:yyyy-MM-dd}:{p.PeriodEnd:yyyy-MM-dd}:{p.Month}:{p.Day}"
                                         )
                                     )
                             )
@@ -97,7 +98,7 @@ public sealed class HistoricalFiscalCalendar(
             );
 
         var sourceCalendars = reportedYearEnds
-            .Where(observation => observation.PeriodEnd == end)
+            .Where(observation => Applies(observation, start, end))
             .Select(observation => (observation.Month, observation.Day))
             .Distinct()
             .ToArray();
@@ -117,4 +118,8 @@ public sealed class HistoricalFiscalCalendar(
             classifyInterimInstants: true
         );
     }
+
+    private static bool Applies(ParsedFiscalYearEnd observation, DateOnly start, DateOnly end) =>
+        observation.PeriodEnd == end
+        || (start >= observation.PeriodStart && end <= observation.PeriodEnd);
 }

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/HistoricalFiscalCalendar.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/HistoricalFiscalCalendar.cs
@@ -1,0 +1,120 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Equibles.Sec.FinancialFacts.BusinessLogic.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.FiscalPeriods;
+
+namespace Equibles.Sec.FinancialFacts.BusinessLogic;
+
+/// <summary>Uses a reported annual span or exact-period filing metadata before current metadata.</summary>
+public sealed class HistoricalFiscalCalendar(
+    IReadOnlyCollection<(DateOnly Start, DateOnly End)> annualPeriods,
+    IReadOnlyCollection<ParsedFiscalYearEnd> reportedYearEnds,
+    int? currentMonth,
+    int? currentDay,
+    bool requiresHistoricalEvidence = false
+)
+{
+    public bool RequiresHistoricalEvidence { get; } = requiresHistoricalEvidence;
+
+    public bool HasEvidence(DateOnly start, DateOnly end) =>
+        annualPeriods.Any(period => start >= period.Start && end <= period.End)
+        || reportedYearEnds.Any(observation => observation.PeriodEnd == end);
+
+    public bool RefusesCalendar(DateOnly start, DateOnly end)
+    {
+        var annualEnds = annualPeriods
+            .Where(p => start >= p.Start && end <= p.End)
+            .Select(p => p.End)
+            .Distinct()
+            .ToArray();
+        if (annualEnds.Length > 0)
+            return annualEnds.Length > 1;
+        var calendars = reportedYearEnds
+            .Where(p => p.PeriodEnd == end)
+            .Select(p => (p.Month, p.Day))
+            .Distinct()
+            .Count();
+        return calendars > 1 || (RequiresHistoricalEvidence && calendars == 0);
+    }
+
+    public string Fingerprint { get; } =
+        Convert.ToHexString(
+            SHA256.HashData(
+                Encoding.UTF8.GetBytes(
+                    string.Join(
+                        "|",
+                        new[]
+                        {
+                            FormattableString.Invariant(
+                                $"{currentMonth}:{currentDay}:{requiresHistoricalEvidence}"
+                            ),
+                        }
+                            .Concat(
+                                annualPeriods
+                                    .Distinct()
+                                    .OrderBy(p => p.Start)
+                                    .ThenBy(p => p.End)
+                                    .Select(p =>
+                                        $"A:{p.Start.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}:{p.End.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)}"
+                                    )
+                            )
+                            .Concat(
+                                reportedYearEnds
+                                    .Select(p => (p.PeriodEnd, p.Month, p.Day))
+                                    .Distinct()
+                                    .OrderBy(p => p.PeriodEnd)
+                                    .ThenBy(p => p.Month)
+                                    .ThenBy(p => p.Day)
+                                    .Select(p =>
+                                        FormattableString.Invariant(
+                                            $"F:{p.PeriodEnd:yyyy-MM-dd}:{p.Month}:{p.Day}"
+                                        )
+                                    )
+                            )
+                    )
+                )
+            )
+        );
+
+    public (int Year, SecFiscalPeriod Period)? Resolve(DateOnly start, DateOnly end)
+    {
+        var annualEnds = annualPeriods
+            .Where(period => start >= period.Start && end <= period.End)
+            .Select(period => period.End)
+            .Distinct()
+            .ToArray();
+        if (annualEnds.Length > 1)
+            return null;
+        if (annualEnds.Length == 1)
+            return ReportedFiscalPeriodResolver.Resolve(
+                start,
+                end,
+                annualEnds[0].Month,
+                annualEnds[0].Day,
+                classifyInterimInstants: true
+            );
+
+        var sourceCalendars = reportedYearEnds
+            .Where(observation => observation.PeriodEnd == end)
+            .Select(observation => (observation.Month, observation.Day))
+            .Distinct()
+            .ToArray();
+        if (sourceCalendars.Length > 1)
+            return null;
+        if (sourceCalendars.Length == 0 && RequiresHistoricalEvidence)
+            return null;
+        var (month, day) =
+            sourceCalendars.Length == 1
+                ? ((int?)sourceCalendars[0].Month, (int?)sourceCalendars[0].Day)
+                : (currentMonth, currentDay);
+        return ReportedFiscalPeriodResolver.Resolve(
+            start,
+            end,
+            month,
+            day,
+            classifyInterimInstants: true
+        );
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/InlineXbrlParseResult.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/InlineXbrlParseResult.cs
@@ -7,6 +7,7 @@ namespace Equibles.Sec.FinancialFacts.BusinessLogic.Models;
 /// </summary>
 public class InlineXbrlParseResult
 {
+    public List<ParsedFiscalYearEnd> FiscalYearEnds { get; set; } = [];
     public List<ParsedXbrlFact> Facts { get; set; } = [];
     public List<ParsedSecurityListing> CoverListings { get; set; } = [];
 }

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/ParsedFiscalYearEnd.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Models/ParsedFiscalYearEnd.cs
@@ -1,0 +1,10 @@
+namespace Equibles.Sec.FinancialFacts.BusinessLogic.Models;
+
+/// <summary>A fiscal year end explicitly stated for a consolidated filing context.</summary>
+public record ParsedFiscalYearEnd(
+    string Cik,
+    DateOnly PeriodStart,
+    DateOnly PeriodEnd,
+    int Month,
+    int Day
+);

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/Parsers/InlineXbrlParser.cs
@@ -103,7 +103,73 @@ public class InlineXbrlParser
         {
             Facts = facts,
             CoverListings = ExtractCoverListings(document),
+            FiscalYearEnds = ExtractFiscalYearEnds(document, contexts, namespaces),
         };
+    }
+
+    private static List<ParsedFiscalYearEnd> ExtractFiscalYearEnds(
+        IDocument document,
+        Dictionary<string, ParsedContext> contexts,
+        Dictionary<string, string> namespaces
+    )
+    {
+        var observations = new List<ParsedFiscalYearEnd>();
+        foreach (var element in FindByLocalName(document, NonNumericLocalName))
+        {
+            if (
+                !string.IsNullOrWhiteSpace(element.GetAttribute("format"))
+                || (element.GetAttribute("xsi:nil") ?? element.GetAttribute("nil")) == "1"
+                || string.Equals(
+                    element.GetAttribute("xsi:nil") ?? element.GetAttribute("nil"),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase
+                )
+            )
+                continue;
+            var name = element.GetAttribute("name") ?? "";
+            var parts = name.Split(':');
+            if (
+                parts.Length != 2
+                || parts[1] != "CurrentFiscalYearEndDate"
+                || !namespaces.TryGetValue(parts[0], out var namespaceValue)
+                || !Uri.TryCreate(namespaceValue, UriKind.Absolute, out var namespaceUri)
+                || namespaceUri.Host != "xbrl.sec.gov"
+                || !namespaceUri.AbsolutePath.StartsWith("/dei/", StringComparison.Ordinal)
+            )
+                continue;
+            var contextRef =
+                element.GetAttribute("contextRef") ?? element.GetAttribute("contextref");
+            if (
+                contextRef == null
+                || !contexts.TryGetValue(contextRef, out var context)
+                || string.IsNullOrWhiteSpace(context.ConsolidatedCik)
+            )
+                continue;
+            // XML gMonthDay is source metadata, not a date inferred from a financial amount.
+            var value = element.TextContent.Trim();
+            if (
+                value.Length != 7
+                || !value.StartsWith("--", StringComparison.Ordinal)
+                || !DateOnly.TryParseExact(
+                    "2000-" + value[2..],
+                    "yyyy-MM-dd",
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out var date
+                )
+            )
+                continue;
+            observations.Add(
+                new ParsedFiscalYearEnd(
+                    context.ConsolidatedCik,
+                    context.Start,
+                    context.End,
+                    date.Month,
+                    date.Day
+                )
+            );
+        }
+        return observations.Distinct().ToList();
     }
 
     /// <summary>

--- a/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFactsSyncStatus.cs
+++ b/src/Equibles.Sec.FinancialFacts.Data/Models/FinancialFactsSyncStatus.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Equibles.CommonStocks.Data.Models;
 using Microsoft.EntityFrameworkCore;
@@ -30,6 +31,10 @@ public class FinancialFactsSyncStatus
     /// A lower value forces a full-history replay even when no newer filing exists.
     /// </summary>
     public int ImporterVersion { get; set; }
+
+    /// <summary>Source calendar evidence used by the last successful full-history import.</summary>
+    [MaxLength(64)]
+    public string CalendarEvidenceFingerprint { get; set; }
 
     /// <summary>
     /// When the concept-metadata sweep (labels, descriptions, balance from the

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FinancialFactsImportService.cs
@@ -35,24 +35,27 @@ public class FinancialFactsImportService
     // Bump whenever parsing, fiscal identity, or quality filtering changes existing rows. The
     // per-company checkpoint forces a full Company Facts replay without racing the old worker
     // during an additive migration rollout.
-    internal const int CurrentImporterVersion = 5;
+    internal const int CurrentImporterVersion = 6;
 
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ISecEdgarClient _secEdgarClient;
     private readonly ILogger<FinancialFactsImportService> _logger;
     private readonly ErrorReporter _errorReporter;
+    private readonly FiscalCalendarEvidenceReader _calendarReader;
 
     public FinancialFactsImportService(
         IServiceScopeFactory scopeFactory,
         ISecEdgarClient secEdgarClient,
         ILogger<FinancialFactsImportService> logger,
-        ErrorReporter errorReporter
+        ErrorReporter errorReporter,
+        FiscalCalendarEvidenceReader calendarReader = null
     )
     {
         _scopeFactory = scopeFactory;
         _secEdgarClient = secEdgarClient;
         _logger = logger;
         _errorReporter = errorReporter;
+        _calendarReader = calendarReader;
     }
 
     public async Task Import(CommonStock stock, CancellationToken cancellationToken)
@@ -68,7 +71,7 @@ public class FinancialFactsImportService
         // natural key carries the AccessionNumber, and accessions are globally
         // unique in SEC. Any CIK failing to download skips the whole cycle so the
         // checkpoint never advances past an unread source.
-        var parsed = new List<ParsedFact>();
+        var responses = new List<CompanyFactsResponse>();
         foreach (var cik in CiksFor(stock))
         {
             CompanyFactsResponse response;
@@ -88,7 +91,7 @@ public class FinancialFactsImportService
             }
 
             if (response != null && response.Facts.Count > 0)
-                parsed.AddRange(ParseFacts(response, stock));
+                responses.Add(response);
         }
 
         // Guards GH-1591: the stock can be deleted during the network calls
@@ -105,9 +108,48 @@ public class FinancialFactsImportService
             return;
         }
 
+        var incomingAnnualPeriods = responses
+            .SelectMany(response => response.Facts.Values)
+            .SelectMany(concepts => concepts.Values)
+            .SelectMany(concept => concept.Units.Values)
+            .SelectMany(values => values)
+            .Where(value =>
+                value.Start.HasValue
+                && value.Form is "10-K" or "20-F" or "40-F"
+                && value.End.DayNumber - value.Start.Value.DayNumber is >= 350 and <= 380
+            )
+            .Select(value => (Start: value.Start.Value, End: value.End))
+            .Distinct()
+            .ToArray();
+        HistoricalFiscalCalendar calendar;
+        try
+        {
+            calendar =
+                _calendarReader == null
+                    ? new HistoricalFiscalCalendar(
+                        [],
+                        [],
+                        stock.FiscalYearEndMonth,
+                        stock.FiscalYearEndDay
+                    )
+                    : await _calendarReader.Read(stock, incomingAnnualPeriods, cancellationToken);
+        }
+        catch (InvalidDataException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Fiscal calendar evidence is incomplete for {Ticker}; deferring import",
+                stock.Ticker
+            );
+            return;
+        }
+        var parsed = responses
+            .SelectMany(response => ParseFacts(response, stock, calendar))
+            .ToList();
+
         if (parsed.Count == 0)
         {
-            await UpsertSyncStatus(stock, null, cancellationToken);
+            await UpsertSyncStatus(stock, null, calendar.Fingerprint, cancellationToken);
             return;
         }
 
@@ -117,6 +159,7 @@ public class FinancialFactsImportService
         var lastSeen = syncStatus?.LastFiledDateSeen;
         if (
             syncStatus?.ImporterVersion >= CurrentImporterVersion
+            && syncStatus.CalendarEvidenceFingerprint == calendar.Fingerprint
             && lastSeen.HasValue
             && lastSeen.Value >= maxFiled
         )
@@ -125,14 +168,14 @@ public class FinancialFactsImportService
             // and skip the (expensive) re-upsert of the full history. Still re-source the share
             // count: an already-ingested cover-page fact may post-date the stale Yahoo figure
             // (and this corrects existing rows the first cycle after the change ships).
-            await UpsertSyncStatus(stock, lastSeen, cancellationToken);
+            await UpsertSyncStatus(stock, lastSeen, calendar.Fingerprint, cancellationToken);
             await UpdateSharesOutstanding(stock, cancellationToken);
             return;
         }
 
         try
         {
-            await PersistFacts(stock, parsed, maxFiled, cancellationToken);
+            await PersistFacts(stock, parsed, maxFiled, calendar.Fingerprint, cancellationToken);
             await UpdateSharesOutstanding(stock, cancellationToken);
         }
         // Per-company fault isolation (mirrors FtdImportService): one company's
@@ -229,6 +272,7 @@ public class FinancialFactsImportService
         CommonStock stock,
         List<ParsedFact> parsed,
         DateOnly maxFiled,
+        string calendarFingerprint,
         CancellationToken cancellationToken
     )
     {
@@ -271,7 +315,7 @@ public class FinancialFactsImportService
         // failure leaves the checkpoint un-advanced and the company is
         // retried in full next cycle.
         await BatchPersister.Persist(facts, InsertBatchSize, FlushFacts);
-        await UpsertSyncStatus(stock, maxFiled, cancellationToken);
+        await UpsertSyncStatus(stock, maxFiled, calendarFingerprint, cancellationToken);
 
         _logger.LogInformation(
             "Imported {Count} financial facts for {Ticker} (CIK {Cik})",
@@ -281,7 +325,11 @@ public class FinancialFactsImportService
         );
     }
 
-    private IEnumerable<ParsedFact> ParseFacts(CompanyFactsResponse response, CommonStock stock)
+    private IEnumerable<ParsedFact> ParseFacts(
+        CompanyFactsResponse response,
+        CommonStock stock,
+        HistoricalFiscalCalendar calendar
+    )
     {
         foreach (var (taxonomyKey, concepts) in response.Facts)
         {
@@ -294,14 +342,15 @@ public class FinancialFactsImportService
                 {
                     foreach (var value in values)
                     {
-                        var fact = TryBuildParsedFact(
+                        var fact = TryBuildParsedFactWithCalendar(
                             taxonomy,
                             tag,
                             concept.Label,
                             concept.Description,
                             unit,
                             value,
-                            stock
+                            stock,
+                            calendar
                         );
                         if (fact != null)
                             yield return fact;
@@ -319,6 +368,18 @@ public class FinancialFactsImportService
         string unit,
         CompanyFactValue value,
         CommonStock stock
+    ) =>
+        TryBuildParsedFactWithCalendar(taxonomy, tag, label, description, unit, value, stock, null);
+
+    private static ParsedFact TryBuildParsedFactWithCalendar(
+        FactTaxonomy taxonomy,
+        string tag,
+        string label,
+        string description,
+        string unit,
+        CompanyFactValue value,
+        CommonStock stock,
+        HistoricalFiscalCalendar calendar
     )
     {
         if (string.IsNullOrWhiteSpace(value.Accn))
@@ -326,6 +387,8 @@ public class FinancialFactsImportService
 
         var isInstant = value.Start == null;
         var periodStart = value.Start ?? value.End;
+        if (calendar?.RefusesCalendar(periodStart, value.End) == true)
+            return null;
         // SEC serves foreign private issuers' 6-K interim values with fp = null, so an
         // unmappable fp must not drop the value outright — dropping them left every
         // FPI's interim facts missing platform-wide. The date-derived identity below is
@@ -338,13 +401,16 @@ public class FinancialFactsImportService
         // original SEC-supplied identity is the fallback. Instants and durations
         // must use the same date-derived year; SEC fy names the filing and can
         // differ from the calendar year in which the measured fiscal year ends.
-        var resolved = FiscalPeriodResolver.Resolve(
-            periodStart,
-            value.End,
-            stock.FiscalYearEndMonth,
-            stock.FiscalYearEndDay,
-            classifyInterimInstants: true
-        );
+        var resolved =
+            calendar != null
+                ? calendar.Resolve(periodStart, value.End)
+                : FiscalPeriodResolver.Resolve(
+                    periodStart,
+                    value.End,
+                    stock.FiscalYearEndMonth,
+                    stock.FiscalYearEndDay,
+                    classifyInterimInstants: true
+                );
         // With neither a mappable fp nor a date-derived identity the period cannot be
         // placed — defaulting would route the fact into the annual bucket (the
         // zero-valued enum member) and corrupt the dashboards, so it is dropped.
@@ -637,6 +703,7 @@ public class FinancialFactsImportService
     private async Task UpsertSyncStatus(
         CommonStock stock,
         DateOnly? lastFiledSeen,
+        string calendarFingerprint,
         CancellationToken cancellationToken
     )
     {
@@ -649,6 +716,7 @@ public class FinancialFactsImportService
             LastCheckedAt = DateTime.UtcNow,
             LastFiledDateSeen = lastFiledSeen,
             ImporterVersion = CurrentImporterVersion,
+            CalendarEvidenceFingerprint = calendarFingerprint,
         };
 
         await dbContext
@@ -663,6 +731,7 @@ public class FinancialFactsImportService
                         LastFiledDateSeen =
                             incoming.LastFiledDateSeen ?? existing.LastFiledDateSeen,
                         ImporterVersion = incoming.ImporterVersion,
+                        CalendarEvidenceFingerprint = incoming.CalendarEvidenceFingerprint,
                     }
             )
             .RunAsync(cancellationToken);

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalCalendarEvidencePendingException.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalCalendarEvidencePendingException.cs
@@ -1,0 +1,11 @@
+namespace Equibles.Sec.FinancialFacts.HostedService.Services;
+
+/// <summary>Resolved facts were saved, but other measured dates still lack a historical calendar.</summary>
+public sealed class FiscalCalendarEvidencePendingException(int persistedCount, int deferredCount)
+    : Exception(
+        $"Historical calendar evidence is pending for {deferredCount} facts; {persistedCount} resolved facts were persisted"
+    )
+{
+    public int PersistedCount { get; } = persistedCount;
+    public int DeferredCount { get; } = deferredCount;
+}

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalCalendarEvidenceReader.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/FiscalCalendarEvidenceReader.cs
@@ -1,0 +1,194 @@
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Core.AutoWiring;
+using Equibles.Data;
+using Equibles.Media.BusinessLogic;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using Equibles.Sec.FinancialFacts.BusinessLogic.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Equibles.Sec.FinancialFacts.HostedService.Services;
+
+/// <summary>Reads historical calendars from reported annual spans and captured filing metadata.</summary>
+[Service]
+public class FiscalCalendarEvidenceReader(
+    IServiceScopeFactory scopeFactory,
+    IFileManager fileManager,
+    InlineXbrlParser inlineParser
+)
+{
+    private const int MaxOpenYearDocuments = 16;
+    private const long MaxCalendarEnvelopeBytes = 50 * 1024 * 1024;
+
+    public async Task<HistoricalFiscalCalendar> Read(
+        CommonStock stock,
+        IReadOnlyCollection<(DateOnly Start, DateOnly End)> incomingAnnualPeriods,
+        CancellationToken cancellationToken
+    )
+    {
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+        var annualDates = await db.Set<Document>()
+            .Where(d =>
+                d.CommonStockId == stock.Id
+                && (
+                    d.DocumentType == DocumentType.TenK
+                    || d.DocumentType == DocumentType.TwentyF
+                    || d.DocumentType == DocumentType.FortyF
+                )
+            )
+            .Select(d => d.ReportingForDate)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+        var stored = await db.Set<FinancialFact>()
+            .Where(f =>
+                f.CommonStockId == stock.Id
+                && f.DimensionsKey == ""
+                && f.PeriodType == FactPeriodType.Duration
+                && (
+                    f.Form == DocumentType.TenK
+                    || f.Form == DocumentType.TwentyF
+                    || f.Form == DocumentType.FortyF
+                )
+                && f.PeriodEnd >= f.PeriodStart.AddDays(350)
+                && f.PeriodEnd <= f.PeriodStart.AddDays(380)
+                && annualDates.Contains(f.PeriodEnd)
+            )
+            .Select(f => new { f.PeriodStart, f.PeriodEnd })
+            .Distinct()
+            .ToListAsync(cancellationToken);
+        var annualPeriods = stored
+            .Select(f => (Start: f.PeriodStart, End: f.PeriodEnd))
+            .Concat(
+                incomingAnnualPeriods.Where(p =>
+                    annualDates.Contains(p.End)
+                    && p.End.DayNumber - p.Start.DayNumber is >= 350 and <= 380
+                )
+            )
+            .Distinct()
+            .ToArray();
+        var observations = new List<ParsedFiscalYearEnd>();
+        var calendarChanged =
+            stock.FiscalYearEndMonth is >= 1 and <= 12
+            && stock.FiscalYearEndDay is >= 1 and <= 31
+            && annualPeriods.Any(p => !MatchesCurrentCalendar(p.End, stock));
+        if (calendarChanged)
+        {
+            // Retain metadata for gaps between ordinary annual spans, including transition
+            // years, even after a later annual report adopts the current calendar.
+            var candidates = await db.Set<Document>()
+                .Where(d =>
+                    d.CommonStockId == stock.Id
+                    && (
+                        d.DocumentType == DocumentType.TenQ
+                        || d.DocumentType == DocumentType.TenK
+                        || d.DocumentType == DocumentType.TwentyF
+                        || d.DocumentType == DocumentType.FortyF
+                    )
+                )
+                .Select(d => new { d.Id, d.ReportingForDate })
+                .ToListAsync(cancellationToken);
+            var evidenceIds = candidates
+                .Where(d =>
+                    !annualPeriods.Any(p =>
+                        d.ReportingForDate >= p.Start && d.ReportingForDate <= p.End
+                    )
+                )
+                .OrderBy(d => d.ReportingForDate)
+                .ThenBy(d => d.Id)
+                .Take(MaxOpenYearDocuments + 1)
+                .Select(d => d.Id)
+                .ToArray();
+            if (evidenceIds.Length > MaxOpenYearDocuments)
+                throw new InvalidDataException(
+                    "Fiscal calendar evidence exceeds the bounded document budget"
+                );
+            var documents = await db.Set<Document>()
+                .Where(d => evidenceIds.Contains(d.Id))
+                .Include(d => d.XbrlContent)
+                .ToListAsync(cancellationToken);
+            var ciks = stock.SecondaryCiks.Append(stock.Cik).ToArray();
+            foreach (var document in documents)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (
+                    document.XbrlStatus != XbrlCaptureStatus.Captured
+                    || document.XbrlType != XbrlType.InlineIxbrl
+                    || document.XbrlContent == null
+                    || document.XbrlUncompressedSize is null
+                    || document.XbrlUncompressedSize > MaxCalendarEnvelopeBytes
+                )
+                    throw new InvalidDataException(
+                        "Fiscal calendar evidence has no bounded captured envelope"
+                    );
+                var bytes = GzipCompressor.Decompress(
+                    await fileManager.GetContent(document.XbrlContent)
+                );
+                if (bytes.LongLength > MaxCalendarEnvelopeBytes)
+                    throw new InvalidDataException(
+                        "Fiscal calendar evidence exceeds the envelope budget"
+                    );
+                var parsed = inlineParser.ParseEnvelope(Encoding.UTF8.GetString(bytes));
+                var evidence = parsed
+                    .FiscalYearEnds.Where(o =>
+                        o.PeriodEnd == document.ReportingForDate
+                        && ciks.Any(cik => SameCik(o.Cik, cik))
+                    )
+                    .ToArray();
+                if (evidence.Length == 0)
+                    throw new InvalidDataException(
+                        "Captured filing has no consolidated fiscal calendar for its issuer and period"
+                    );
+                observations.AddRange(evidence);
+            }
+        }
+        if (
+            observations
+                .GroupBy(o => o.PeriodEnd)
+                .Any(g => g.Select(o => (o.Month, o.Day)).Distinct().Count() > 1)
+        )
+            throw new InvalidDataException("Conflicting fiscal calendars for one reported period");
+        return new HistoricalFiscalCalendar(
+            annualPeriods,
+            observations,
+            stock.FiscalYearEndMonth,
+            stock.FiscalYearEndDay,
+            calendarChanged
+        );
+    }
+
+    private static bool SameCik(string left, string right) =>
+        !string.IsNullOrWhiteSpace(left)
+        && !string.IsNullOrWhiteSpace(right)
+        && left.Trim().TrimStart('0') == right.Trim().TrimStart('0');
+
+    private static bool MatchesCurrentCalendar(DateOnly annualEnd, CommonStock stock)
+    {
+        if (
+            stock.FiscalYearEndMonth is not (>= 1 and <= 12)
+            || stock.FiscalYearEndDay is not (>= 1 and <= 31)
+        )
+            return false;
+        var month = stock.FiscalYearEndMonth.Value;
+        var day = Math.Min(
+            stock.FiscalYearEndDay.Value,
+            DateTime.DaysInMonth(annualEnd.Year, month)
+        );
+        return new[] { annualEnd.Year - 1, annualEnd.Year, annualEnd.Year + 1 }
+            .Where(year => year is >= 1 and <= 9999)
+            .Any(year =>
+                Math.Abs(
+                    new DateOnly(
+                        year,
+                        month,
+                        Math.Min(day, DateTime.DaysInMonth(year, month))
+                    ).DayNumber - annualEnd.DayNumber
+                ) <= 14
+            );
+    }
+}

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
@@ -65,7 +65,7 @@ public class XbrlFactExtractionService
     // Version 5: preserve every cover-page symbol observation as dated issuer evidence.
     // Version 6: fill absent standard consolidated facts in foreign financial reports.
     // Version 7 replays derived fiscal identities for interim instants and existing rows.
-    public const int CurrentVersion = 7;
+    public const int CurrentVersion = 8;
 
     private const int InsertBatchSize = 1000;
 
@@ -100,6 +100,7 @@ public class XbrlFactExtractionService
     private readonly InlineXbrlParser _inlineParser;
     private readonly StandaloneXbrlParser _standaloneParser;
     private readonly IFileManager _fileManager;
+    private readonly FiscalCalendarEvidenceReader _calendarReader;
     private readonly ILogger<XbrlFactExtractionService> _logger;
 
     public XbrlFactExtractionService(
@@ -107,13 +108,15 @@ public class XbrlFactExtractionService
         InlineXbrlParser inlineParser,
         StandaloneXbrlParser standaloneParser,
         IFileManager fileManager,
-        ILogger<XbrlFactExtractionService> logger
+        ILogger<XbrlFactExtractionService> logger,
+        FiscalCalendarEvidenceReader calendarReader = null
     )
     {
         _scopeFactory = scopeFactory;
         _inlineParser = inlineParser;
         _standaloneParser = standaloneParser;
         _fileManager = fileManager;
+        _calendarReader = calendarReader;
         _logger = logger;
     }
 
@@ -192,6 +195,24 @@ public class XbrlFactExtractionService
         var conceptIds = await ResolveConcepts(persistable, cancellationToken);
 
         var stock = document.CommonStock;
+        var incomingAnnualPeriods = parsed
+            .Where(f =>
+                !f.IsInstant
+                && f.Dimensions.Count == 0
+                && f.PeriodEnd.DayNumber - f.PeriodStart.DayNumber is >= 350 and <= 380
+            )
+            .Select(f => (Start: f.PeriodStart, End: f.PeriodEnd))
+            .Distinct()
+            .ToArray();
+        var calendar =
+            _calendarReader == null
+                ? new HistoricalFiscalCalendar(
+                    [],
+                    [],
+                    stock.FiscalYearEndMonth,
+                    stock.FiscalYearEndDay
+                )
+                : await _calendarReader.Read(stock, incomingAnnualPeriods, cancellationToken);
         var facts = new List<FinancialFact>();
         var consolidatedFills = new List<FinancialFact>();
         var dimensionsByKey = new Dictionary<string, List<ParsedXbrlDimension>>(
@@ -199,9 +220,13 @@ public class XbrlFactExtractionService
         );
         foreach (var candidate in persistable)
         {
+            if (calendar.RefusesCalendar(candidate.Fact.PeriodStart, candidate.Fact.PeriodEnd))
+                throw new InvalidDataException(
+                    "Fiscal calendar evidence is incomplete for a captured fact"
+                );
             if (!conceptIds.TryGetValue((candidate.Taxonomy, candidate.Tag), out var conceptId))
                 continue;
-            var fact = BuildFact(document, stock, candidate, conceptId);
+            var fact = BuildFact(document, stock, candidate, conceptId, calendar);
             if (candidate.Taxonomy != FactTaxonomy.Custom && candidate.DimensionsKey == "")
                 consolidatedFills.Add(fact);
             else
@@ -212,13 +237,7 @@ public class XbrlFactExtractionService
         await BatchPersister.Persist(facts, InsertBatchSize, items => FlushFacts(items, false));
         foreach (
             var group in consolidatedFills.GroupBy(fact =>
-                FiscalPeriodResolver.Resolve(
-                    fact.PeriodStart,
-                    fact.PeriodEnd,
-                    stock.FiscalYearEndMonth,
-                    stock.FiscalYearEndDay,
-                    classifyInterimInstants: true
-                ) != null
+                calendar.Resolve(fact.PeriodStart, fact.PeriodEnd) != null
             )
         )
         {
@@ -443,16 +462,20 @@ public class XbrlFactExtractionService
         DateOnly periodStart,
         DateOnly periodEnd,
         int? fiscalYearEndMonth,
-        int? fiscalYearEndDay
+        int? fiscalYearEndDay,
+        HistoricalFiscalCalendar calendar = null
     )
     {
-        var resolved = FiscalPeriodResolver.Resolve(
-            periodStart,
-            periodEnd,
-            fiscalYearEndMonth,
-            fiscalYearEndDay,
-            classifyInterimInstants: true
-        );
+        var resolved =
+            calendar != null
+                ? calendar.Resolve(periodStart, periodEnd)
+                : FiscalPeriodResolver.Resolve(
+                    periodStart,
+                    periodEnd,
+                    fiscalYearEndMonth,
+                    fiscalYearEndDay,
+                    classifyInterimInstants: true
+                );
         if (resolved != null)
             return resolved.Value;
 
@@ -475,7 +498,8 @@ public class XbrlFactExtractionService
         Document document,
         CommonStock stock,
         PersistableXbrlFact candidate,
-        Guid conceptId
+        Guid conceptId,
+        HistoricalFiscalCalendar calendar
     )
     {
         var fact = candidate.Fact;
@@ -483,7 +507,8 @@ public class XbrlFactExtractionService
             fact.PeriodStart,
             fact.PeriodEnd,
             stock.FiscalYearEndMonth,
-            stock.FiscalYearEndDay
+            stock.FiscalYearEndDay,
+            calendar
         );
 
         return new FinancialFact

--- a/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/Services/XbrlFactExtractionService.cs
@@ -218,12 +218,14 @@ public class XbrlFactExtractionService
         var dimensionsByKey = new Dictionary<string, List<ParsedXbrlDimension>>(
             StringComparer.Ordinal
         );
+        var deferredCalendarFacts = 0;
         foreach (var candidate in persistable)
         {
             if (calendar.RefusesCalendar(candidate.Fact.PeriodStart, candidate.Fact.PeriodEnd))
-                throw new InvalidDataException(
-                    "Fiscal calendar evidence is incomplete for a captured fact"
-                );
+            {
+                deferredCalendarFacts++;
+                continue;
+            }
             if (!conceptIds.TryGetValue((candidate.Taxonomy, candidate.Tag), out var conceptId))
                 continue;
             var fact = BuildFact(document, stock, candidate, conceptId, calendar);
@@ -249,7 +251,10 @@ public class XbrlFactExtractionService
         }
         await PersistDimensions(document, dimensionsByKey, cancellationToken);
 
-        return facts.Count + consolidatedFills.Count;
+        var persistedCount = facts.Count + consolidatedFills.Count;
+        if (deferredCalendarFacts > 0)
+            throw new FiscalCalendarEvidencePendingException(persistedCount, deferredCalendarFacts);
+        return persistedCount;
     }
 
     /// <summary>

--- a/src/Equibles.Sec.FinancialFacts.HostedService/XbrlFactsExtractionWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/XbrlFactsExtractionWorker.cs
@@ -1,6 +1,8 @@
+using Equibles.Data;
 using Equibles.Errors.BusinessLogic;
 using Equibles.Errors.Data.Models;
 using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.HostedService.Configuration;
 using Equibles.Sec.FinancialFacts.HostedService.Services;
 using Equibles.Sec.Repositories;
@@ -62,30 +64,11 @@ public class XbrlFactsExtractionWorker : BaseScraperWorker
 
             // Newest filings first so fresh quarters get their dimensional
             // rows soonest while the historical drain catches up behind them.
-            var batch = await documentRepository
-                .GetByXbrlStatus(XbrlCaptureStatus.Captured)
-                .Where(d =>
-                    (
-                        d.XbrlFactsVersion
-                            < Equibles
-                                .CommonStocks
-                                .Data
-                                .Models
-                                .CommonStockTickerEvidence
-                                .SourceXbrlFactsVersion
-                        || (
-                            d.XbrlFactsVersion < XbrlFactExtractionService.CurrentVersion
-                            && (
-                                d.DocumentType == DocumentType.TwentyF
-                                || d.DocumentType == DocumentType.TwentyFa
-                                || d.DocumentType == DocumentType.FortyF
-                                || d.DocumentType == DocumentType.FortyFa
-                                || d.DocumentType == DocumentType.SixK
-                                || d.DocumentType == DocumentType.SixKa
-                            )
-                        )
-                    )
-                    && d.XbrlFactsAttempts < Document.MaxXbrlFactsAttempts
+            var db = scope.ServiceProvider.GetRequiredService<EquiblesFinancialDbContext>();
+            var checkpoints = db.Set<FinancialFactsSyncStatus>();
+            var batch = await SelectDueDocuments(
+                    documentRepository.GetByXbrlStatus(XbrlCaptureStatus.Captured),
+                    checkpoints
                 )
                 .OrderByDescending(d => d.ReportingDate)
                 .Take(batchSize)
@@ -94,10 +77,26 @@ public class XbrlFactsExtractionWorker : BaseScraperWorker
             if (batch.Count == 0)
                 return;
 
+            var stockIds = batch.Select(d => d.CommonStockId).Distinct().ToArray();
+            var fingerprints = await checkpoints
+                .Where(s => stockIds.Contains(s.CommonStockId))
+                .ToDictionaryAsync(
+                    s => s.CommonStockId,
+                    s => s.CalendarEvidenceFingerprint,
+                    stoppingToken
+                );
+
             var extracted = 0;
             foreach (var document in batch)
             {
                 stoppingToken.ThrowIfCancellationRequested();
+                fingerprints.TryGetValue(document.CommonStockId, out var fingerprint);
+                if (document.XbrlCalendarEvidenceFingerprint != fingerprint)
+                {
+                    document.XbrlFactsAttempts = 0;
+                    document.XbrlFactsVersion = 0;
+                }
+                document.XbrlCalendarEvidenceFingerprint = fingerprint;
                 try
                 {
                     extracted += await extractionService.Extract(document, stoppingToken);
@@ -150,4 +149,20 @@ public class XbrlFactsExtractionWorker : BaseScraperWorker
                 return;
         }
     }
+
+    internal static IQueryable<Document> SelectDueDocuments(
+        IQueryable<Document> documents,
+        IQueryable<FinancialFactsSyncStatus> checkpoints
+    ) =>
+        documents.Where(d =>
+            (
+                d.XbrlFactsVersion < XbrlFactExtractionService.CurrentVersion
+                && d.XbrlFactsAttempts < Document.MaxXbrlFactsAttempts
+            )
+            || checkpoints.Any(s =>
+                s.CommonStockId == d.CommonStockId
+                && s.CalendarEvidenceFingerprint != null
+                && s.CalendarEvidenceFingerprint != d.XbrlCalendarEvidenceFingerprint
+            )
+        );
 }

--- a/src/Equibles.Sec.FinancialFacts.HostedService/XbrlFactsExtractionWorker.cs
+++ b/src/Equibles.Sec.FinancialFacts.HostedService/XbrlFactsExtractionWorker.cs
@@ -104,6 +104,16 @@ public class XbrlFactsExtractionWorker : BaseScraperWorker
                     // the envelope simply carries none worth re-reading.
                     document.XbrlFactsVersion = XbrlFactExtractionService.CurrentVersion;
                 }
+                catch (FiscalCalendarEvidencePendingException ex)
+                {
+                    document.XbrlFactsAttempts++;
+                    extracted += ex.PersistedCount;
+                    Logger.LogWarning(
+                        "Historical calendar evidence is pending for {Count} facts in {DocumentId}; resolved facts were saved",
+                        ex.DeferredCount,
+                        document.Id
+                    );
+                }
                 // Shutdown mid-batch is not a document failure: let it surface
                 // so the base loop winds down quietly instead of burning one of
                 // the document's attempts and landing a phantom row in Errors.

--- a/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportPeriodIdentityTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FinancialFactsImportPeriodIdentityTests.cs
@@ -76,6 +76,198 @@ public class FinancialFactsImportPeriodIdentityTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Import_HistoricalCalendarChange_UsesCapturedQuarterMetadataAndKeepsCurrentYearEnd()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "JHG",
+            Name = "Janus Henderson Group",
+            Cik = "0001274173",
+            FiscalYearEndMonth = 6,
+            FiscalYearEndDay = 30,
+        };
+        var annualEnd = new DateOnly(2025, 12, 31);
+        var quarterEnd = new DateOnly(2026, 3, 31);
+        const string envelope = """
+            <html xmlns:dei="http://xbrl.sec.gov/dei/2026"><body>
+            <xbrli:context id="quarter"><xbrli:entity>
+            <xbrli:identifier scheme="http://www.sec.gov/CIK">0001274173</xbrli:identifier>
+            </xbrli:entity><xbrli:period><xbrli:startDate>2026-01-01</xbrli:startDate>
+            <xbrli:endDate>2026-03-31</xbrli:endDate></xbrli:period></xbrli:context>
+            <ix:nonNumeric name="dei:CurrentFiscalYearEndDate" contextRef="quarter">--12-31</ix:nonNumeric>
+            </body></html>
+            """;
+        var bytes = System.Text.Encoding.UTF8.GetBytes(envelope);
+        Equibles.Media.Data.Models.File File() =>
+            new()
+            {
+                Name = "filing",
+                Extension = "txt",
+                ContentType = "text/plain",
+            };
+        await using (var seed = _fixture.CreateDbContext())
+        {
+            seed.Add(stock);
+            seed.Add(
+                new Document
+                {
+                    CommonStock = stock,
+                    Content = File(),
+                    DocumentType = DocumentType.TenK,
+                    ReportingForDate = annualEnd,
+                    ReportingDate = new DateOnly(2026, 2, 1),
+                    AccessionNumber = "0001437749-26-005628",
+                }
+            );
+            seed.Add(
+                new Document
+                {
+                    CommonStock = stock,
+                    Content = File(),
+                    DocumentType = DocumentType.TenQ,
+                    ReportingForDate = quarterEnd,
+                    ReportingDate = new DateOnly(2026, 5, 1),
+                    AccessionNumber = "0001437749-26-015926",
+                    XbrlContent = File(),
+                    XbrlStatus = XbrlCaptureStatus.Captured,
+                    XbrlType = XbrlType.InlineIxbrl,
+                    XbrlUncompressedSize = bytes.Length,
+                }
+            );
+            await seed.SaveChangesAsync(CancellationToken.None);
+        }
+        CompanyFactValue Value(DateOnly? start, DateOnly end, string form) =>
+            new()
+            {
+                Start = start,
+                End = end,
+                Val = 123m,
+                Form = form,
+                Fy = 2026,
+                Fp = "Q3",
+                Filed = new DateOnly(2026, 5, 1),
+                Accn = "0001437749-26-015926",
+            };
+        var response = new CompanyFactsResponse
+        {
+            Cik = 1274173,
+            EntityName = stock.Name,
+            Facts = new()
+            {
+                ["us-gaap"] = new()
+                {
+                    ["Revenues"] = new()
+                    {
+                        Label = "Revenue",
+                        Units = new()
+                        {
+                            ["USD"] =
+                            [
+                                Value(new(2025, 1, 1), annualEnd, "10-K"),
+                                Value(new(2025, 1, 1), new(2025, 3, 31), "10-Q"),
+                                Value(new(2026, 1, 1), quarterEnd, "10-Q"),
+                            ],
+                        },
+                    },
+                    ["Assets"] = new()
+                    {
+                        Label = "Assets",
+                        Units = new() { ["USD"] = [Value(null, quarterEnd, "10-Q")] },
+                    },
+                },
+            },
+        };
+        var client = Substitute.For<ISecEdgarClient>();
+        client.GetCompanyFacts(stock.Cik).Returns(response);
+        var files = Substitute.For<Equibles.Media.BusinessLogic.IFileManager>();
+        files
+            .GetContent(Arg.Any<Equibles.Media.Data.Models.File>())
+            .Returns(Equibles.Media.BusinessLogic.GzipCompressor.Compress(bytes));
+        var scopes = CreateScopeFactory();
+        var reader = new FiscalCalendarEvidenceReader(
+            scopes,
+            files,
+            new Equibles.Sec.FinancialFacts.BusinessLogic.Parsers.InlineXbrlParser()
+        );
+        var sut = new FinancialFactsImportService(
+            scopes,
+            client,
+            Substitute.For<ILogger<FinancialFactsImportService>>(),
+            Substitute.For<ErrorReporter>(
+                Substitute.For<IServiceScopeFactory>(),
+                Substitute.For<ILogger<ErrorReporter>>()
+            ),
+            reader
+        );
+        await sut.Import(stock, CancellationToken.None);
+        await using var verify = _fixture.CreateDbContext();
+        var facts = await verify
+            .Set<FinancialFact>()
+            .Where(f => f.CommonStockId == stock.Id)
+            .ToListAsync();
+        facts.Should().HaveCount(4);
+        facts
+            .Where(f => f.PeriodEnd == quarterEnd)
+            .Should()
+            .OnlyContain(f =>
+                f.FiscalYear == 2026 && f.FiscalPeriod == SecFiscalPeriod.Q1 && f.Value == 123m
+            );
+        facts
+            .Single(f => f.PeriodEnd == new DateOnly(2025, 3, 31))
+            .FiscalPeriod.Should()
+            .Be(SecFiscalPeriod.Q1);
+        var storedStock = await verify.Set<CommonStock>().SingleAsync(s => s.Id == stock.Id);
+        storedStock.FiscalYearEndMonth.Should().Be(6);
+        var checkpoint = await verify
+            .Set<FinancialFactsSyncStatus>()
+            .SingleAsync(s => s.CommonStockId == stock.Id);
+        checkpoint.CalendarEvidenceFingerprint.Should().HaveLength(64);
+
+        // A corrected source calendar must replay even when SEC's newest filed date is unchanged.
+        var originalFingerprint = checkpoint.CalendarEvidenceFingerprint;
+        var originalIds = facts.Select(f => f.Id).Order().ToArray();
+        files
+            .GetContent(Arg.Any<Equibles.Media.Data.Models.File>())
+            .Returns(
+                Equibles.Media.BusinessLogic.GzipCompressor.Compress(
+                    System.Text.Encoding.UTF8.GetBytes(envelope.Replace("--12-31", "--06-30"))
+                )
+            );
+        await sut.Import(stock, CancellationToken.None);
+        verify.ChangeTracker.Clear();
+        var replayed = await verify
+            .Set<FinancialFact>()
+            .Where(f => f.CommonStockId == stock.Id)
+            .ToListAsync();
+        replayed.Select(f => f.Id).Order().Should().Equal(originalIds);
+        replayed
+            .Where(f => f.PeriodEnd == quarterEnd)
+            .Should()
+            .OnlyContain(f =>
+                f.FiscalYear == 2026 && f.FiscalPeriod == SecFiscalPeriod.Q3 && f.Value == 123m
+            );
+        var replayCheckpoint = await verify
+            .Set<FinancialFactsSyncStatus>()
+            .SingleAsync(s => s.CommonStockId == stock.Id);
+        replayCheckpoint.CalendarEvidenceFingerprint.Should().NotBe(originalFingerprint);
+
+        // Unusable source evidence must leave the last successful checkpoint and facts intact.
+        files
+            .GetContent(Arg.Any<Equibles.Media.Data.Models.File>())
+            .Returns(
+                Equibles.Media.BusinessLogic.GzipCompressor.Compress(
+                    System.Text.Encoding.UTF8.GetBytes(envelope.Replace("0001274173", "0000000001"))
+                )
+            );
+        await sut.Import(stock, CancellationToken.None);
+        await verify.Entry(replayCheckpoint).ReloadAsync();
+        replayCheckpoint.CalendarEvidenceFingerprint.Should().NotBe(originalFingerprint);
+        (await verify.Set<FinancialFact>().CountAsync(f => f.CommonStockId == stock.Id))
+            .Should()
+            .Be(4);
+    }
+
+    [Fact]
     public async Task Import_TenKWithThreeComparableYears_DerivesFiscalYearFromPeriodEndPerCompanyFYE()
     {
         // Apple's FYE is Sept 28 (52/53-week filer, so actual end dates

--- a/tests/Equibles.IntegrationTests/Sec/FiscalCalendarEvidenceReaderTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/FiscalCalendarEvidenceReaderTests.cs
@@ -1,0 +1,163 @@
+using System.Text;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Data;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.HostedService;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.Sec;
+
+[Collection(ParadeDbCollection.Name)]
+public class FiscalCalendarEvidenceReaderTests(ParadeDbFixture fixture)
+    : ParadeDbMcpTestBase(fixture)
+{
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task HistoricalGapRetainsItsCalendarAfterNewCalendarAnnualArrives(
+        bool secondaryCik,
+        bool unknownCurrent
+    )
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "JHG",
+            Name = "Calendar transition",
+            Cik = "0001274173",
+            FiscalYearEndMonth = unknownCurrent ? null : 6,
+            FiscalYearEndDay = unknownCurrent ? null : 30,
+        };
+        if (secondaryCik)
+            stock.SecondaryCiks = ["0000001234"];
+        File NewFile() =>
+            new()
+            {
+                Name = "source",
+                Extension = "txt",
+                ContentType = "text/plain",
+            };
+        var oldEnd = new DateOnly(2025, 12, 31);
+        var newEnd = new DateOnly(2027, 6, 30);
+        var quarterEnd = new DateOnly(2026, 3, 31);
+        Document Annual(DateOnly end) =>
+            new()
+            {
+                CommonStock = stock,
+                Content = NewFile(),
+                DocumentType = DocumentType.TenK,
+                ReportingForDate = end,
+                ReportingDate = end.AddDays(30),
+                AccessionNumber = end.ToString("yyyyMMdd"),
+            };
+        DbContext.AddRange(Annual(oldEnd), Annual(newEnd));
+        var cik = secondaryCik ? "0000001234" : stock.Cik;
+        var envelope = $$"""
+            <html xmlns:dei="http://xbrl.sec.gov/dei/2026"><body>
+            <xbrli:context id="q"><xbrli:entity><xbrli:identifier scheme="http://www.sec.gov/CIK">{{cik}}</xbrli:identifier></xbrli:entity>
+            <xbrli:period><xbrli:startDate>2026-01-01</xbrli:startDate><xbrli:endDate>2026-03-31</xbrli:endDate></xbrli:period></xbrli:context>
+            <ix:nonNumeric name="dei:CurrentFiscalYearEndDate" contextRef="q">--12-31</ix:nonNumeric>
+            </body></html>
+            """;
+        var bytes = Encoding.UTF8.GetBytes(envelope);
+        DbContext.Add(
+            new Document
+            {
+                CommonStock = stock,
+                Content = NewFile(),
+                DocumentType = DocumentType.TenQ,
+                ReportingForDate = quarterEnd,
+                ReportingDate = quarterEnd.AddDays(30),
+                AccessionNumber = "quarter",
+                XbrlStatus = unknownCurrent
+                    ? XbrlCaptureStatus.NotChecked
+                    : XbrlCaptureStatus.Captured,
+                XbrlType = XbrlType.InlineIxbrl,
+                XbrlContent = NewFile(),
+                XbrlUncompressedSize = bytes.Length,
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        var files = Substitute.For<IFileManager>();
+        files.GetContent(Arg.Any<File>()).Returns(GzipCompressor.Compress(bytes));
+        var scopes = ServiceScopeSubstitute.Create((typeof(EquiblesFinancialDbContext), DbContext));
+        var sut = new FiscalCalendarEvidenceReader(scopes, files, new InlineXbrlParser());
+        var calendar = await sut.Read(
+            stock,
+            [(new(2025, 1, 1), oldEnd), (new(2026, 7, 1), newEnd)],
+            CancellationToken.None
+        );
+        if (unknownCurrent)
+        {
+            calendar.RequiresHistoricalEvidence.Should().BeFalse();
+            calendar.RefusesCalendar(new(2026, 1, 1), quarterEnd).Should().BeFalse();
+            await files.DidNotReceive().GetContent(Arg.Any<File>());
+        }
+        else
+        {
+            calendar.Resolve(new(2026, 1, 1), quarterEnd).Should().Be((2026, SecFiscalPeriod.Q1));
+            calendar.Resolve(quarterEnd, quarterEnd).Should().Be((2026, SecFiscalPeriod.Q1));
+        }
+    }
+
+    [Fact]
+    public async Task EvidenceCheckpointRearmsCompletedAndExhaustedXbrlDocuments()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "REPLAY",
+            Name = "Replay",
+            Cik = "0000000011",
+        };
+        var checkpoint = new FinancialFactsSyncStatus
+        {
+            CommonStock = stock,
+            CalendarEvidenceFingerprint = new string('a', 64),
+            LastCheckedAt = DateTime.UtcNow,
+        };
+        var document = new Document
+        {
+            CommonStock = stock,
+            Content = new File
+            {
+                Name = "filing",
+                Extension = "txt",
+                ContentType = "text/plain",
+            },
+            DocumentType = DocumentType.TenQ,
+            AccessionNumber = "replay",
+            XbrlStatus = XbrlCaptureStatus.Captured,
+            XbrlFactsVersion = XbrlFactExtractionService.CurrentVersion,
+            XbrlCalendarEvidenceFingerprint = checkpoint.CalendarEvidenceFingerprint,
+            XbrlFactsAttempts = Document.MaxXbrlFactsAttempts,
+        };
+        DbContext.AddRange(checkpoint, document);
+        await DbContext.SaveChangesAsync();
+        IQueryable<Document> Due() =>
+            XbrlFactsExtractionWorker.SelectDueDocuments(
+                DbContext.Set<Document>(),
+                DbContext.Set<FinancialFactsSyncStatus>()
+            );
+        (await Due().CountAsync()).Should().Be(0);
+        checkpoint.CalendarEvidenceFingerprint = new string('b', 64);
+        await DbContext.SaveChangesAsync();
+        (await Due().SingleAsync()).Id.Should().Be(document.Id);
+        document.XbrlCalendarEvidenceFingerprint = checkpoint.CalendarEvidenceFingerprint;
+        document.XbrlFactsVersion = 0;
+        document.XbrlFactsAttempts = 1;
+        await DbContext.SaveChangesAsync();
+        (await Due().CountAsync()).Should().Be(1);
+        document.XbrlFactsAttempts = Document.MaxXbrlFactsAttempts;
+        await DbContext.SaveChangesAsync();
+        (await Due().CountAsync()).Should().Be(0);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Sec/XbrlFactExtractionServiceExtractTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlFactExtractionServiceExtractTests.cs
@@ -92,8 +92,12 @@ public class XbrlFactExtractionServiceExtractTests : ParadeDbMcpTestBase
             .Be(1);
     }
 
-    [Fact]
-    public async Task Extract_CalendarChange_RepairsLabelsUsingTheCapturedHistoricalCalendar()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task Extract_CalendarChange_RepairsLabelsUsingTheCapturedHistoricalCalendar(
+        bool offPeriodFact
+    )
     {
         var envelope = InlineEnvelope()
             .Replace("<html ", "<html xmlns:dei=\"http://xbrl.sec.gov/dei/2025\" ")
@@ -102,13 +106,35 @@ public class XbrlFactExtractionServiceExtractTests : ParadeDbMcpTestBase
                 "</body>",
                 "<ix:nonNumeric name=\"dei:CurrentFiscalYearEndDate\" contextRef=\"Consolidated\">--12-31</ix:nonNumeric></body>"
             );
+        if (offPeriodFact)
+            envelope = envelope.Replace(
+                "</body>",
+                """
+                <xbrli:context id="Future"><xbrli:entity><xbrli:identifier scheme="http://www.sec.gov/CIK">0000320193</xbrli:identifier>
+                <xbrli:segment><xbrldi:explicitMember dimension="srt:ProductOrServiceAxis">aapl:IPhoneMember</xbrldi:explicitMember></xbrli:segment>
+                </xbrli:entity><xbrli:period><xbrli:instant>2025-04-01</xbrli:instant></xbrli:period></xbrli:context>
+                <ix:nonFraction name="us-gaap:RevenueFromContractWithCustomerExcludingAssessedTax" contextRef="Future" unitRef="usd">123</ix:nonFraction>
+                </body>
+                """
+            );
         var document = await SeedDocument(envelope);
         await BuildSut().Extract(document, CancellationToken.None);
         var fact = await DbContext
             .Set<FinancialFact>()
-            .SingleAsync(f => f.DocumentId == document.Id);
+            .SingleAsync(f =>
+                f.DocumentId == document.Id && f.PeriodEnd == document.ReportingForDate
+            );
         var originalId = fact.Id;
         var originalValue = fact.Value;
+        var originalUnresolvedPeriod = offPeriodFact
+            ? (
+                await DbContext
+                    .Set<FinancialFact>()
+                    .SingleAsync(f =>
+                        f.DocumentId == document.Id && f.PeriodEnd == new DateOnly(2025, 4, 1)
+                    )
+            ).FiscalPeriod
+            : default;
         fact.FiscalPeriod = SecFiscalPeriod.Q3;
         document.CommonStock.FiscalYearEndMonth = 6;
         document.CommonStock.FiscalYearEndDay = 30;
@@ -142,7 +168,37 @@ public class XbrlFactExtractionServiceExtractTests : ParadeDbMcpTestBase
             }
         );
         await DbContext.SaveChangesAsync();
-        (await BuildSut(true).Extract(document, CancellationToken.None)).Should().Be(1);
+        if (offPeriodFact)
+        {
+            for (var attempt = 0; attempt < 2; attempt++)
+            {
+                var pending = await Assert.ThrowsAsync<FiscalCalendarEvidencePendingException>(() =>
+                    BuildSut(true).Extract(document, CancellationToken.None)
+                );
+                pending.PersistedCount.Should().Be(1);
+                pending.DeferredCount.Should().Be(1);
+            }
+            (await DbContext.Set<FinancialFact>().CountAsync(f => f.DocumentId == document.Id))
+                .Should()
+                .Be(2);
+            (
+                await DbContext
+                    .Set<FinancialFactDimension>()
+                    .CountAsync(d => d.FinancialFact.DocumentId == document.Id)
+            )
+                .Should()
+                .Be(2);
+            var unresolved = await DbContext
+                .Set<FinancialFact>()
+                .AsNoTracking()
+                .SingleAsync(f =>
+                    f.DocumentId == document.Id && f.PeriodEnd == new DateOnly(2025, 4, 1)
+                );
+            unresolved.Value.Should().Be(123m);
+            unresolved.FiscalPeriod.Should().Be(originalUnresolvedPeriod);
+        }
+        else
+            (await BuildSut(true).Extract(document, CancellationToken.None)).Should().Be(1);
         await DbContext.Entry(fact).ReloadAsync();
         fact.Id.Should().Be(originalId);
         fact.Value.Should().Be(originalValue);

--- a/tests/Equibles.IntegrationTests/Sec/XbrlFactExtractionServiceExtractTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/XbrlFactExtractionServiceExtractTests.cs
@@ -92,7 +92,66 @@ public class XbrlFactExtractionServiceExtractTests : ParadeDbMcpTestBase
             .Be(1);
     }
 
-    private XbrlFactExtractionService BuildSut()
+    [Fact]
+    public async Task Extract_CalendarChange_RepairsLabelsUsingTheCapturedHistoricalCalendar()
+    {
+        var envelope = InlineEnvelope()
+            .Replace("<html ", "<html xmlns:dei=\"http://xbrl.sec.gov/dei/2025\" ")
+            .Replace("scheme=\"cik\"", "scheme=\"http://www.sec.gov/CIK\"")
+            .Replace(
+                "</body>",
+                "<ix:nonNumeric name=\"dei:CurrentFiscalYearEndDate\" contextRef=\"Consolidated\">--12-31</ix:nonNumeric></body>"
+            );
+        var document = await SeedDocument(envelope);
+        await BuildSut().Extract(document, CancellationToken.None);
+        var fact = await DbContext
+            .Set<FinancialFact>()
+            .SingleAsync(f => f.DocumentId == document.Id);
+        var originalId = fact.Id;
+        var originalValue = fact.Value;
+        fact.FiscalPeriod = SecFiscalPeriod.Q3;
+        document.CommonStock.FiscalYearEndMonth = 6;
+        document.CommonStock.FiscalYearEndDay = 30;
+        var annual = new Document
+        {
+            CommonStock = document.CommonStock,
+            Content = document.Content,
+            DocumentType = DocumentType.TenK,
+            ReportingForDate = new(2024, 12, 31),
+            ReportingDate = new(2025, 2, 1),
+            AccessionNumber = "0000320193-25-000000",
+        };
+        DbContext.Add(annual);
+        DbContext.Add(
+            new FinancialFact
+            {
+                CommonStockId = document.CommonStockId,
+                FinancialConceptId = fact.FinancialConceptId,
+                Document = annual,
+                Unit = "USD",
+                PeriodType = FactPeriodType.Duration,
+                PeriodStart = new(2024, 1, 1),
+                PeriodEnd = new(2024, 12, 31),
+                FiscalYear = 2024,
+                FiscalPeriod = SecFiscalPeriod.FullYear,
+                Value = 100m,
+                Form = DocumentType.TenK,
+                FiledDate = annual.ReportingDate,
+                AccessionNumber = annual.AccessionNumber,
+                DimensionsKey = "",
+            }
+        );
+        await DbContext.SaveChangesAsync();
+        (await BuildSut(true).Extract(document, CancellationToken.None)).Should().Be(1);
+        await DbContext.Entry(fact).ReloadAsync();
+        fact.Id.Should().Be(originalId);
+        fact.Value.Should().Be(originalValue);
+        fact.FiscalYear.Should().Be(2025);
+        fact.FiscalPeriod.Should().Be(SecFiscalPeriod.Q1);
+        document.CommonStock.FiscalYearEndMonth.Should().Be(6);
+    }
+
+    private XbrlFactExtractionService BuildSut(bool historicalCalendar = false)
     {
         var scopeFactory = ServiceScopeSubstitute.Create(
             (typeof(EquiblesFinancialDbContext), DbContext),
@@ -105,7 +164,14 @@ public class XbrlFactExtractionServiceExtractTests : ParadeDbMcpTestBase
             new InlineXbrlParser(),
             new StandaloneXbrlParser(),
             fileManager,
-            NullLogger<XbrlFactExtractionService>()
+            NullLogger<XbrlFactExtractionService>(),
+            historicalCalendar
+                ? new FiscalCalendarEvidenceReader(
+                    scopeFactory,
+                    fileManager,
+                    new InlineXbrlParser()
+                )
+                : null
         );
     }
 

--- a/tests/Equibles.UnitTests/Sec/HistoricalCalendarImportTests.cs
+++ b/tests/Equibles.UnitTests/Sec/HistoricalCalendarImportTests.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Integrations.Sec.Models.Responses;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.HostedService.Services;
+
+namespace Equibles.UnitTests.Sec;
+
+public class HistoricalCalendarImportTests
+{
+    [Theory]
+    [InlineData("Q1", SecFiscalPeriod.Q1)]
+    [InlineData("FY", SecFiscalPeriod.FullYear)]
+    public void ShortReportedPeriodRetainsSourceIdentity(
+        string sourcePeriod,
+        SecFiscalPeriod expected
+    )
+    {
+        var value = new CompanyFactValue
+        {
+            Start = new DateOnly(2025, 2, 1),
+            End = new DateOnly(2025, 3, 31),
+            Fy = 2025,
+            Fp = sourcePeriod,
+            Val = 123m,
+            Form = "10-Q",
+            Accn = "0001274173-25-000001",
+            Filed = new DateOnly(2025, 5, 1),
+        };
+        var calendar = new HistoricalFiscalCalendar(
+            [(new(2025, 1, 1), new(2025, 12, 31))],
+            [],
+            6,
+            30,
+            true
+        );
+        var method = typeof(FinancialFactsImportService).GetMethod(
+            "TryBuildParsedFactWithCalendar",
+            BindingFlags.Static | BindingFlags.NonPublic
+        )!;
+        var parsed = method.Invoke(
+            null,
+            [
+                FactTaxonomy.UsGaap,
+                "Revenues",
+                "Revenue",
+                "",
+                "USD",
+                value,
+                new CommonStock { FiscalYearEndMonth = 6, FiscalYearEndDay = 30 },
+                calendar,
+            ]
+        );
+        parsed.Should().NotBeNull();
+        parsed!.GetType().GetProperty("FiscalYear")!.GetValue(parsed).Should().Be(2025);
+        parsed.GetType().GetProperty("FiscalPeriod")!.GetValue(parsed).Should().Be(expected);
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/HistoricalFiscalCalendarTests.cs
+++ b/tests/Equibles.UnitTests/Sec/HistoricalFiscalCalendarTests.cs
@@ -71,8 +71,8 @@ public class HistoricalFiscalCalendarTests
     public void FingerprintTracksCalendarEvidenceButIgnoresOrderingAndDuplicateContexts()
     {
         var end = new DateOnly(2026, 3, 31);
-        var first = new ParsedFiscalYearEnd("1274173", end, end, 12, 31);
-        var duplicateContext = first with { PeriodStart = new DateOnly(2026, 1, 1) };
+        var first = new ParsedFiscalYearEnd("1274173", new DateOnly(2026, 1, 1), end, 12, 31);
+        var duplicateContext = first with { Cik = "0001274173" };
         var annual = (new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31));
         var a = new HistoricalFiscalCalendar([annual], [first], 6, 30, true);
         var b = new HistoricalFiscalCalendar(
@@ -116,5 +116,24 @@ public class HistoricalFiscalCalendarTests
         );
         calendar.Resolve(start, end).Should().BeNull();
         calendar.RefusesCalendar(start, end).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContextCalendarAppliesWithinItsStatedWindowAndRefusesLaterDates()
+    {
+        var end = new DateOnly(2026, 3, 31);
+        var calendar = new HistoricalFiscalCalendar(
+            [],
+            [new("1274173", new(2026, 1, 1), end, 12, 31)],
+            6,
+            30,
+            true
+        );
+        calendar
+            .Resolve(new(2026, 3, 24), new(2026, 3, 24))
+            .Should()
+            .Be((2026, SecFiscalPeriod.Q1));
+        calendar.RefusesCalendar(new(2026, 4, 1), new(2026, 4, 1)).Should().BeTrue();
+        calendar.RefusesCalendar(new(2025, 12, 31), new(2026, 3, 24)).Should().BeTrue();
     }
 }

--- a/tests/Equibles.UnitTests/Sec/HistoricalFiscalCalendarTests.cs
+++ b/tests/Equibles.UnitTests/Sec/HistoricalFiscalCalendarTests.cs
@@ -1,0 +1,120 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using Equibles.Sec.FinancialFacts.BusinessLogic.Models;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+
+namespace Equibles.UnitTests.Sec;
+
+public class HistoricalFiscalCalendarTests
+{
+    [Theory]
+    [InlineData(3, 31, SecFiscalPeriod.Q1)]
+    [InlineData(6, 30, SecFiscalPeriod.Q2)]
+    [InlineData(9, 30, SecFiscalPeriod.Q3)]
+    public void HistoricalQuarterAndInstantUseReportedAnnualCalendar(
+        int month,
+        int day,
+        SecFiscalPeriod expected
+    )
+    {
+        var calendar = new HistoricalFiscalCalendar(
+            [(new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31))],
+            [],
+            6,
+            30
+        );
+        var end = new DateOnly(2025, month, day);
+        calendar.Resolve(end, end).Should().Be((2025, expected));
+        calendar.Resolve(new DateOnly(2025, 1, 1), end).Should().Be((2025, expected));
+    }
+
+    [Fact]
+    public void OpenYearUsesItsOwnFilingCalendarWithoutReplacingCurrentCalendar()
+    {
+        var end = new DateOnly(2026, 3, 31);
+        var calendar = new HistoricalFiscalCalendar(
+            [],
+            [new ParsedFiscalYearEnd("1274173", new DateOnly(2026, 1, 1), end, 12, 31)],
+            6,
+            30
+        );
+        calendar.Resolve(end, end).Should().Be((2026, SecFiscalPeriod.Q1));
+        calendar.Resolve(new DateOnly(2026, 1, 1), end).Should().Be((2026, SecFiscalPeriod.Q1));
+        calendar
+            .Resolve(new DateOnly(2026, 9, 30), new DateOnly(2026, 9, 30))
+            .Should()
+            .Be((2027, SecFiscalPeriod.Q1));
+    }
+
+    [Fact]
+    public void ConflictingSourceCalendarsDoNotChooseOne()
+    {
+        var end = new DateOnly(2026, 3, 31);
+        var calendar = new HistoricalFiscalCalendar(
+            [],
+            [new("1274173", end, end, 12, 31), new("1274173", end, end, 6, 30)],
+            6,
+            30
+        );
+        calendar.Resolve(end, end).Should().BeNull();
+    }
+
+    [Fact]
+    public void ChangedCalendarAbstainsUntilTheMeasuredPeriodHasEvidence()
+    {
+        var end = new DateOnly(2026, 3, 31);
+        var calendar = new HistoricalFiscalCalendar([], [], 6, 30, true);
+        calendar.Resolve(end, end).Should().BeNull();
+        calendar.HasEvidence(end, end).Should().BeFalse();
+    }
+
+    [Fact]
+    public void FingerprintTracksCalendarEvidenceButIgnoresOrderingAndDuplicateContexts()
+    {
+        var end = new DateOnly(2026, 3, 31);
+        var first = new ParsedFiscalYearEnd("1274173", end, end, 12, 31);
+        var duplicateContext = first with { PeriodStart = new DateOnly(2026, 1, 1) };
+        var annual = (new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31));
+        var a = new HistoricalFiscalCalendar([annual], [first], 6, 30, true);
+        var b = new HistoricalFiscalCalendar(
+            [annual, annual],
+            [duplicateContext, first],
+            6,
+            30,
+            true
+        );
+        a.Fingerprint.Should().Be(b.Fingerprint);
+        a.Fingerprint.Should()
+            .NotBe(new HistoricalFiscalCalendar([annual], [], 6, 30, true).Fingerprint);
+        a.Fingerprint.Should()
+            .NotBe(new HistoricalFiscalCalendar([annual], [first], 12, 31, true).Fingerprint);
+    }
+
+    [Fact]
+    public void OverlappingReportedAnnualCalendarsAbstain()
+    {
+        var end = new DateOnly(2025, 6, 30);
+        var calendar = new HistoricalFiscalCalendar(
+            [(new(2025, 1, 1), new(2025, 12, 31)), (new(2024, 7, 1), end)],
+            [],
+            6,
+            30
+        );
+        calendar.Resolve(end, end).Should().BeNull();
+    }
+
+    [Fact]
+    public void ShortSourceStampedPeriodIsNotAConflictingCalendar()
+    {
+        var start = new DateOnly(2025, 2, 1);
+        var end = new DateOnly(2025, 3, 31);
+        var calendar = new HistoricalFiscalCalendar(
+            [(new(2025, 1, 1), new(2025, 12, 31))],
+            [],
+            6,
+            30,
+            true
+        );
+        calendar.Resolve(start, end).Should().BeNull();
+        calendar.RefusesCalendar(start, end).Should().BeFalse();
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/InlineXbrlFiscalYearEndTests.cs
+++ b/tests/Equibles.UnitTests/Sec/InlineXbrlFiscalYearEndTests.cs
@@ -1,0 +1,57 @@
+using Equibles.Sec.FinancialFacts.BusinessLogic.Parsers;
+
+namespace Equibles.UnitTests.Sec;
+
+public class InlineXbrlFiscalYearEndTests
+{
+    private static string Envelope(
+        string value = "--12-31",
+        string ns = "http://xbrl.sec.gov/dei/2026",
+        string segment = ""
+    ) =>
+        $$"""
+            <html xmlns:dei="{{ns}}"><body><ix:header>
+            <xbrli:context id="d_2026-01-01_2026-03-31">
+              <xbrli:entity><xbrli:identifier scheme="http://www.sec.gov/CIK">0001274173</xbrli:identifier>{{segment}}</xbrli:entity>
+              <xbrli:period><xbrli:startDate>2026-01-01</xbrli:startDate><xbrli:endDate>2026-03-31</xbrli:endDate></xbrli:period>
+            </xbrli:context></ix:header>
+            <ix:nonNumeric contextRef="d_2026-01-01_2026-03-31" name="dei:CurrentFiscalYearEndDate">{{value}}</ix:nonNumeric>
+            </body></html>
+            """;
+
+    [Fact]
+    public void ReadsJhgHistoricalCalendarFromItsOwnConsolidatedContext()
+    {
+        var actual = new InlineXbrlParser()
+            .ParseEnvelope(Envelope())
+            .FiscalYearEnds.Should()
+            .ContainSingle()
+            .Which;
+        actual.Cik.Should().Be("0001274173");
+        actual.PeriodEnd.Should().Be(new DateOnly(2026, 3, 31));
+        actual.Month.Should().Be(12);
+        actual.Day.Should().Be(31);
+    }
+
+    [Theory]
+    [InlineData("--02-30", "http://xbrl.sec.gov/dei/2026", "")]
+    [InlineData("--12-31", "https://example.com/dei/2026", "")]
+    [InlineData("--12-31", "http://xbrl.sec.gov/dei/2026", "<xbrli:segment></xbrli:segment>")]
+    public void RefusesUnusableOrUnqualifiedEvidence(string value, string ns, string segment)
+    {
+        new InlineXbrlParser()
+            .ParseEnvelope(Envelope(value, ns, segment))
+            .FiscalYearEnds.Should()
+            .BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("xsi:nil=\"true\"")]
+    [InlineData("xsi:nil=\"1\"")]
+    [InlineData("format=\"ixt:date-month-day\"")]
+    public void RefusesNilOrTransformedMetadata(string attribute)
+    {
+        var html = Envelope().Replace("<ix:nonNumeric ", $"<ix:nonNumeric {attribute} ");
+        new InlineXbrlParser().ParseEnvelope(html).FiscalYearEnds.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
A company can legitimately change its fiscal year end while its older filings still use the previous calendar. Using only current metadata relabels those older quarters—for example, a March Q1 becomes Q3 after a December-to-June change.

Resolve historical facts from reported annual spans and, for gaps after a calendar change, consolidated DEI fiscal-year-end metadata from captured filings. Company Facts and XBRL share the resolver, preserve source identity for short reporting periods, and refuse conflicting calendar evidence. Calendar fingerprints trigger Company Facts replay without requiring a newer filing and rearm completed or exhausted XBRL documents. The additive migration stores both checkpoints. Captured filings with off-period facts save independently resolved facts before bounded deferral, so unsupported dates cannot block valid quarter repairs.

Validation: 4,896 unit tests and 16 affected PostgreSQL integration tests passed; solution build and CSharpier checks passed. Independent full-diff review and follow-up review passed. Regression cases cover a subsequent annual adopting the new calendar, secondary CIKs, missing current calendars, source-stamped short periods, stable fact IDs/values, and bounded XBRL retries after evidence changes.
