### PR TITLE
fix(financials): reject invalid current share-count dates

### DIFF
--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/CurrentShareEvidenceDates.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/CurrentShareEvidenceDates.cs
@@ -1,0 +1,32 @@
+using System.Linq.Expressions;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.Data.Models;
+
+namespace Equibles.Sec.FinancialFacts.BusinessLogic;
+
+internal static class CurrentShareEvidenceDates
+{
+    private static readonly DocumentType[] ReportingForms =
+    [
+        DocumentType.TenK,
+        DocumentType.TenKa,
+        DocumentType.TenQ,
+        DocumentType.TenQa,
+        DocumentType.TwentyF,
+        DocumentType.TwentyFa,
+        DocumentType.FortyF,
+        DocumentType.FortyFa,
+    ];
+
+    // A current count cannot predate its own report's period or postdate its disclosure.
+    // Keep the source fact intact; an invalid context never authorizes a guessed date repair.
+    internal static readonly Expression<Func<FinancialFact, bool>> Eligible = fact =>
+        fact.PeriodEnd <= fact.FiledDate
+        && (
+            fact.Document == null
+            || !ReportingForms.Contains(fact.Document.DocumentType)
+            || fact.PeriodEnd >= fact.Document.ReportingForDate
+        );
+
+    internal static readonly Func<FinancialFact, bool> IsEligible = Eligible.Compile();
+}

--- a/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
+++ b/src/Equibles.Sec.FinancialFacts.BusinessLogic/SharesOutstandingProvider.cs
@@ -4,6 +4,7 @@ using Equibles.CorporateActions.Data;
 using Equibles.CorporateActions.Repositories;
 using Equibles.Sec.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
 using Equibles.Sec.FinancialFacts.Data.Statements;
 using Equibles.Sec.FinancialFacts.Repositories;
 using Microsoft.EntityFrameworkCore;
@@ -186,35 +187,51 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         return factor <= 0m ? fact.Shares : SplitAdjustment.AdjustShareCount(fact.Shares, factor);
     }
 
-    // True when the fact backing GetCurrentSharesOutstanding — the latest consolidated cover-page
-    // fact or the latest per-class filing, whichever wins the pick — is a foreign-private-issuer
-    // annual form (20-F/40-F, including amendments). Those cover-page counts are in the issuer's ordinary shares, which
-    // are a different unit from the US-listed ADR a price feed quotes; the Yahoo importer uses this
-    // to skip reconciling Yahoo's (correct, self-consistent) ADR market cap / shares onto that
-    // ordinary base, which would otherwise inflate market cap by the ADR ratio (e.g. Latam Airlines
-    // ~2000x), and the financial-facts importer uses it to leave the stored ADR share base alone.
-    // Keyed to the same pick so a multi-class 20-F filer (per-class facts only) is recognized, not
-    // just one with a consolidated fact. Authoritative — the SEC form, not a ticker/name heuristic.
+    // Foreign annual forms protect listed ADR counts from issuer ordinary-share counts.
+    // Preserve cover-page priority independently of whether a count's date is usable.
+    // Filing form remains identity evidence even when its numerical count has a bad date.
     public async Task<bool> IsForeignPrivateIssuer(
         CommonStock stock,
         CancellationToken cancellationToken = default
     )
     {
-        var fact = await ResolveCurrentSharesFact(stock, cancellationToken);
-        return fact != null
-            && (
-                fact.Form == DocumentType.TwentyF
-                || fact.Form == DocumentType.TwentyFa
-                || fact.Form == DocumentType.FortyF
-                || fact.Form == DocumentType.FortyFa
-            );
+        var conceptIds = await ResolveConceptIds(cancellationToken, FactTaxonomy.Dei);
+        var form = await GetLatestShareForm(stock, conceptIds, cancellationToken);
+        if (form == null)
+        {
+            conceptIds = await ResolveConceptIds(cancellationToken);
+            form = await GetLatestShareForm(stock, conceptIds, cancellationToken);
+        }
+        return form == DocumentType.TwentyF
+            || form == DocumentType.TwentyFa
+            || form == DocumentType.FortyF
+            || form == DocumentType.FortyFa;
     }
 
-    // The single source of truth for "the issuer's current share count and the filing that stated
-    // it", shared by GetCurrentSharesOutstanding and IsForeignPrivateIssuer so the two can never
-    // disagree about which fact is authoritative. Callers pair the two accessors on the same
-    // stock and the resolution costs several queries, so the result (including an abstention) is
-    // memoized per stock for this scoped instance's lifetime — one import scope, single consumer.
+    private async Task<DocumentType> GetLatestShareForm(
+        CommonStock stock,
+        IReadOnlyCollection<Guid> conceptIds,
+        CancellationToken cancellationToken
+    )
+    {
+        return await _financialFactRepository
+            .GetByStock(stock)
+            .Where(f => conceptIds.Contains(f.FinancialConceptId) && f.Unit == SharesUnit)
+            .Where(f =>
+                f.Dimensions.Count == 0
+                || (
+                    f.Dimensions.Count == 1
+                    && f.Dimensions.Any(d => ClassOfStockAxes.Contains(d.Axis))
+                )
+            )
+            .OrderByDescending(f => f.FiledDate)
+            .ThenBy(f => f.Dimensions.Count)
+            .ThenByDescending(f => f.PeriodEnd)
+            .Select(f => f.Form)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    // Memoize the selected numerical evidence for this scoped instance's lifetime.
     private readonly Dictionary<Guid, SharesFact> _currentFactByStock = [];
 
     private async Task<SharesFact> ResolveCurrentSharesFact(
@@ -427,14 +444,14 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
                 )
             )
             .Include(f => f.Dimensions)
+            .Include(f => f.Document)
             .ToListAsync(cancellationToken);
         if (perClassFacts.Count == 0)
             return null;
 
-        var latest = perClassFacts
-            .OrderByDescending(f => f.PeriodEnd)
-            .ThenBy(f => Array.IndexOf(ClassOfStockAxes, f.Dimensions[0].Axis))
-            .First();
+        var latest = LatestDatedClassFact(perClassFacts);
+        if (latest == null)
+            return null;
 
         var total = perClassFacts
             .Where(f =>
@@ -463,6 +480,7 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         // statics, so reference equality holds after materialization.
         var match = await _financialFactRepository
             .GetConsolidatedByStock(stock)
+            .Where(CurrentShareEvidenceDates.Eligible)
             .Where(f => conceptIds.Contains(f.FinancialConceptId) && f.Unit == SharesUnit)
             .OrderByDescending(f => f.FiledDate)
             .ThenByDescending(f => f.PeriodEnd)
@@ -516,6 +534,7 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
                 && f.Dimensions.Any(d => ClassOfStockAxes.Contains(d.Axis))
             )
             .Include(f => f.Dimensions)
+            .Include(f => f.Document)
             .ToListAsync(cancellationToken);
         if (perClassFacts.Count == 0)
             return null;
@@ -524,13 +543,9 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
         // as-of date and axis (a filer double-tagging the same classes on two axes must not be
         // double-counted), and grouped by class member so a restated row never double-counts a
         // class.
-        var latest = perClassFacts
-            .OrderByDescending(f => f.FiledDate)
-            .ThenByDescending(f => f.PeriodEnd)
-            // Deterministic axis pick when a filer double-tags the same filing's classes on two
-            // class axes — without it the pinned axis depends on list order among equal keys.
-            .ThenBy(f => Array.IndexOf(ClassOfStockAxes, f.Dimensions[0].Axis))
-            .First();
+        var latest = LatestDatedClassFact(perClassFacts);
+        if (latest == null)
+            return null;
 
         var total = perClassFacts
             .Where(f =>
@@ -552,6 +567,34 @@ public class SharesOutstandingProvider : ISharesOutstandingProvider
                 latest.AccessionNumber
             )
             : null;
+    }
+
+    // Comparative classes may repeat, but a class stated only at another date cannot
+    // silently disappear from the purported entity total.
+    private static FinancialFact LatestDatedClassFact(IEnumerable<FinancialFact> facts)
+    {
+        foreach (
+            var filing in facts
+                .GroupBy(f => f.AccessionNumber)
+                .OrderByDescending(g => g.Max(f => f.FiledDate))
+        )
+        {
+            var latest = filing
+                .OrderByDescending(f => f.PeriodEnd)
+                .ThenBy(f => Array.IndexOf(ClassOfStockAxes, f.Dimensions[0].Axis))
+                .First();
+            if (!CurrentShareEvidenceDates.IsEligible(latest))
+                continue;
+            var axisFacts = filing.Where(f => f.Dimensions[0].Axis == latest.Dimensions[0].Axis);
+            var currentMembers = axisFacts
+                .Where(f => f.PeriodEnd == latest.PeriodEnd)
+                .Select(f => f.Dimensions[0].Member)
+                .ToHashSet(StringComparer.Ordinal);
+            if (axisFacts.Any(f => !currentMembers.Contains(f.Dimensions[0].Member)))
+                continue;
+            return latest;
+        }
+        return null;
     }
 
     // The financial-concept ids the "shares-outstanding" alias resolves to, or an empty list when

--- a/tests/Equibles.IntegrationTests/Sec/CurrentShareEvidenceTests.cs
+++ b/tests/Equibles.IntegrationTests/Sec/CurrentShareEvidenceTests.cs
@@ -1,0 +1,91 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+
+namespace Equibles.IntegrationTests.Sec;
+
+[Collection(ParadeDbCollection.Name)]
+public class CurrentShareEvidenceTests(ParadeDbFixture fixture) : ParadeDbMcpTestBase(fixture)
+{
+    [Theory]
+    [InlineData(2025)]
+    [InlineData(2027)]
+    public async Task InvalidCurrentContextFallsBackWithoutLosingForeignForm(int invalidYear)
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "DATE",
+            Name = "Date evidence",
+            Cik = "0000001234",
+        };
+        var concept = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.Dei,
+            Tag = "EntityCommonStockSharesOutstanding",
+            Label = "Shares",
+        };
+        FinancialFact Fact(
+            decimal value,
+            DateOnly asOf,
+            DateOnly filed,
+            DateOnly report,
+            DocumentType form
+        ) =>
+            new()
+            {
+                CommonStock = stock,
+                FinancialConcept = concept,
+                Document = new Document
+                {
+                    CommonStock = stock,
+                    DocumentType = form,
+                    ReportingDate = filed,
+                    ReportingForDate = report,
+                    AccessionNumber = filed.ToString("yyyyMMdd"),
+                    Content = new File
+                    {
+                        Name = "filing",
+                        Extension = "htm",
+                        ContentType = "text/html",
+                    },
+                },
+                Value = value,
+                Unit = "shares",
+                PeriodType = FactPeriodType.Instant,
+                PeriodStart = asOf,
+                PeriodEnd = asOf,
+                FiledDate = filed,
+                Form = form,
+                AccessionNumber = filed.ToString("yyyyMMdd"),
+                DimensionsKey = "",
+            };
+        var rejected = Fact(
+            200,
+            new(invalidYear, 4, 1),
+            new(2026, 5, 1),
+            new(2026, 3, 31),
+            DocumentType.TwentyF
+        );
+        DbContext.AddRange(
+            Fact(100, new(2026, 1, 1), new(2026, 2, 1), new(2026, 1, 1), DocumentType.SixK),
+            rejected
+        );
+        await DbContext.SaveChangesAsync();
+        var provider = new SharesOutstandingProvider(
+            new FinancialFactRepository(DbContext),
+            new FinancialConceptRepository(DbContext),
+            new StockSplitRepository(DbContext)
+        );
+        Assert.Equal(100, await provider.GetReportedSharesOutstanding(stock));
+        Assert.True(await provider.IsForeignPrivateIssuer(stock));
+        Assert.Equal(new DateOnly(invalidYear, 4, 1), rejected.PeriodEnd);
+        Assert.Equal(200, rejected.Value);
+    }
+}

--- a/tests/Equibles.UnitTests/Sec/FinancialFactsTestModuleConfiguration.cs
+++ b/tests/Equibles.UnitTests/Sec/FinancialFactsTestModuleConfiguration.cs
@@ -7,10 +7,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Equibles.UnitTests.Sec;
 
 /// <summary>
-/// Registers the financial-fact entities for in-memory tests, ignoring the
-/// <see cref="FinancialFact.Document"/> navigation — it pulls in <c>Chunk</c> whose
-/// <c>Pgvector.Vector</c> property the in-memory EF Core provider can't bind (mirrors
-/// <see cref="DocumentOnlyModuleConfiguration"/>).
+/// Registers financial facts and their source documents without the vector-bearing chunks.
 /// </summary>
 internal sealed class FinancialFactsTestModuleConfiguration : IModuleConfiguration
 {
@@ -21,11 +18,12 @@ internal sealed class FinancialFactsTestModuleConfiguration : IModuleConfigurati
             v => DocumentType.FromValue(v) ?? new DocumentType(v)
         );
 
+        new Equibles.Media.Data.MediaModuleConfiguration().ConfigureEntities(builder);
+        new DocumentOnlyModuleConfiguration().ConfigureEntities(builder);
         builder.Entity<FinancialConcept>();
         builder.Entity<FinancialFact>(b =>
         {
             b.Property(e => e.Form).HasConversion(conv);
-            b.Ignore(e => e.Document);
         });
         builder.Entity<FinancialFactDimension>();
     }

--- a/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderDateEvidenceTests.cs
+++ b/tests/Equibles.UnitTests/Sec/SharesOutstandingProviderDateEvidenceTests.cs
@@ -1,0 +1,365 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Equibles.Sec.Data.Models;
+using Equibles.Sec.FinancialFacts.BusinessLogic;
+using Equibles.Sec.FinancialFacts.Data.Enums;
+using Equibles.Sec.FinancialFacts.Data.Models;
+using Equibles.Sec.FinancialFacts.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Sec;
+
+public class SharesOutstandingProviderDateEvidenceTests
+{
+    [Fact]
+    public async Task PriorYearContextInCurrentCover_DoesNotApplyOldSplitAgain()
+    {
+        await using var db = NewDb();
+        var (stock, concept) = SeedIdentity(db);
+        var prior = Fact(
+            stock,
+            concept,
+            12_176_027,
+            new(2026, 5, 1),
+            new(2026, 5, 8),
+            new(2026, 3, 31)
+        );
+        var invalid = Fact(
+            stock,
+            concept,
+            12_337_297,
+            new(2025, 8, 3),
+            new(2026, 8, 7),
+            new(2026, 6, 30)
+        );
+        db.AddRange(
+            prior,
+            invalid,
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                PriceSeriesTicker = stock.Ticker,
+                EffectiveDate = new(2025, 10, 13),
+                Numerator = 1,
+                Denominator = 15,
+            }
+        );
+        await db.SaveChangesAsync();
+
+        var result = await Provider(db).GetCurrentSharesOutstanding(stock);
+
+        Assert.Equal(12_176_027, result);
+        Assert.Equal(new DateOnly(2025, 8, 3), invalid.PeriodEnd);
+        Assert.Equal(12_337_297m, invalid.Value);
+        Assert.Equal(EntityState.Unchanged, db.Entry(invalid).State);
+    }
+
+    [Theory]
+    [InlineData("TenK")]
+    [InlineData("TenKa")]
+    [InlineData("TenQ")]
+    [InlineData("TenQa")]
+    [InlineData("TwentyF")]
+    [InlineData("TwentyFa")]
+    [InlineData("FortyF")]
+    [InlineData("FortyFa")]
+    public async Task ReportingForms_RejectPrePeriodCount(string form)
+    {
+        await using var db = NewDb();
+        var (stock, concept) = SeedIdentity(db);
+        db.Add(
+            Fact(
+                stock,
+                concept,
+                100,
+                new(2025, 12, 30),
+                new(2026, 3, 1),
+                new(2025, 12, 31),
+                DocumentType.FromValue(form)
+            )
+        );
+        await db.SaveChangesAsync();
+        Assert.Null(await Provider(db).GetReportedSharesOutstanding(stock));
+    }
+
+    [Theory]
+    [InlineData(30)]
+    [InlineData(31)]
+    public async Task ReportAndFilingDateBoundaries_AreEligible(int day)
+    {
+        await using var db = NewDb();
+        var (stock, concept) = SeedIdentity(db);
+        db.Add(Fact(stock, concept, 100, new(2026, 3, day), new(2026, 3, 31), new(2026, 3, 30)));
+        await db.SaveChangesAsync();
+        Assert.Equal(100, await Provider(db).GetReportedSharesOutstanding(stock));
+    }
+
+    [Fact]
+    public async Task FutureCount_IsNotCurrentEvidence()
+    {
+        await using var db = NewDb();
+        var (stock, concept) = SeedIdentity(db);
+        db.Add(Fact(stock, concept, 100, new(2027, 3, 31), new(2026, 5, 1), new(2026, 3, 31)));
+        await db.SaveChangesAsync();
+        Assert.Null(await Provider(db).GetReportedSharesOutstanding(stock));
+    }
+
+    [Fact]
+    public async Task UnlinkedLegacyFact_RetainsItsSourceDate()
+    {
+        await using var db = NewDb();
+        var (stock, concept) = SeedIdentity(db);
+        var fact = Fact(stock, concept, 100, new(2025, 3, 31), new(2026, 5, 1), new(2026, 3, 31));
+        fact.Document = null;
+        fact.DocumentId = null;
+        db.Add(fact);
+        await db.SaveChangesAsync();
+        Assert.Equal(100, await Provider(db).GetReportedSharesOutstanding(stock));
+    }
+
+    [Fact]
+    public async Task NonPeriodicFiling_DoesNotImposeAnInventedReportPeriod()
+    {
+        await using var db = NewDb();
+        var (stock, concept) = SeedIdentity(db);
+        db.Add(
+            Fact(
+                stock,
+                concept,
+                100,
+                new(2026, 3, 1),
+                new(2026, 5, 1),
+                new(2026, 5, 1),
+                DocumentType.EightK
+            )
+        );
+        await db.SaveChangesAsync();
+        Assert.Equal(100, await Provider(db).GetReportedSharesOutstanding(stock));
+    }
+
+    [Theory]
+    [InlineData(2025)]
+    [InlineData(2027)]
+    public async Task InvalidLatestClassDate_RejectsFilingRatherThanPublishingRemainingClass(
+        int invalidYear
+    )
+    {
+        await using var db = NewDb();
+        var (stock, concept) = SeedIdentity(db);
+        var priorA = ClassFact(
+            stock,
+            concept,
+            100,
+            new(2025, 12, 31),
+            new(2026, 2, 1),
+            new(2025, 12, 31),
+            "A"
+        );
+        var priorB = ClassFact(
+            stock,
+            concept,
+            200,
+            new(2025, 12, 31),
+            new(2026, 2, 1),
+            new(2025, 12, 31),
+            "B"
+        );
+        var currentA = ClassFact(
+            stock,
+            concept,
+            110,
+            new(2026, 4, 1),
+            new(2026, 5, 1),
+            new(2026, 3, 31),
+            "A"
+        );
+        var invalidB = ClassFact(
+            stock,
+            concept,
+            210,
+            new(invalidYear, 4, 1),
+            new(2026, 5, 1),
+            new(2026, 3, 31),
+            "B"
+        );
+        db.AddRange(priorA, priorB, currentA, invalidB);
+        await db.SaveChangesAsync();
+        Assert.Equal(300, await Provider(db).GetSummedPerClassSharesOutstanding(stock));
+    }
+
+    [Theory]
+    [InlineData("TwentyF")]
+    [InlineData("FortyF")]
+    public async Task RejectedCount_PreservesForeignFilingProtection(string form)
+    {
+        await using var db = NewDb();
+        var (stock, concept) = SeedIdentity(db);
+        db.AddRange(
+            Fact(
+                stock,
+                concept,
+                100,
+                new(2026, 1, 1),
+                new(2026, 2, 1),
+                new(2026, 1, 1),
+                DocumentType.SixK
+            ),
+            Fact(
+                stock,
+                concept,
+                200,
+                new(2025, 4, 1),
+                new(2026, 5, 1),
+                new(2026, 3, 31),
+                DocumentType.FromValue(form)
+            )
+        );
+        await db.SaveChangesAsync();
+        var provider = Provider(db);
+        Assert.Equal(100, await provider.GetReportedSharesOutstanding(stock));
+        Assert.True(await provider.IsForeignPrivateIssuer(stock));
+    }
+
+    [Fact]
+    public async Task ForeignProtection_PreservesCoverPagePriorityOverLaterBalanceSheet()
+    {
+        await using var db = NewDb();
+        var (stock, cover) = SeedIdentity(db);
+        var balance = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.UsGaap,
+            Tag = "CommonStockSharesOutstanding",
+        };
+        db.Add(balance);
+        db.AddRange(
+            Fact(
+                stock,
+                cover,
+                100,
+                new(2026, 1, 1),
+                new(2026, 2, 1),
+                new(2025, 12, 31),
+                DocumentType.TwentyF
+            ),
+            Fact(
+                stock,
+                balance,
+                200,
+                new(2026, 4, 1),
+                new(2026, 5, 1),
+                new(2026, 3, 31),
+                DocumentType.SixK
+            )
+        );
+        await db.SaveChangesAsync();
+        var provider = Provider(db);
+        Assert.Equal(100, await provider.GetCurrentSharesOutstanding(stock));
+        Assert.True(await provider.IsForeignPrivateIssuer(stock));
+    }
+
+    [Fact]
+    public void DateFilter_TranslatesToPostgresWithSourceReportJoin()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseNpgsql("Host=localhost;Database=date_evidence;Username=test")
+            .Options;
+        using var db = new EquiblesFinancialDbContext(options, Modules());
+        var sql = db.Set<FinancialFact>().Where(CurrentShareEvidenceDates.Eligible).ToQueryString();
+        Assert.Contains("ReportingForDate", sql);
+        Assert.Contains("FiledDate", sql);
+    }
+
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .EnableServiceProviderCaching(false)
+            .Options;
+        var db = new EquiblesFinancialDbContext(options, Modules());
+        db.Database.EnsureCreated();
+        return db;
+    }
+
+    private static IModuleConfiguration[] Modules() =>
+        [
+            new CommonStocksModuleConfiguration(),
+            new FinancialFactsTestModuleConfiguration(),
+            new CorporateActionsModuleConfiguration(),
+        ];
+
+    private static (CommonStock, FinancialConcept) SeedIdentity(EquiblesFinancialDbContext db)
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "LPSN",
+            Cik = "1102993",
+            Name = "LivePerson",
+        };
+        var concept = new FinancialConcept
+        {
+            Taxonomy = FactTaxonomy.Dei,
+            Tag = "EntityCommonStockSharesOutstanding",
+        };
+        db.AddRange(stock, concept);
+        return (stock, concept);
+    }
+
+    private static SharesOutstandingProvider Provider(EquiblesFinancialDbContext db) =>
+        new(
+            new FinancialFactRepository(db),
+            new FinancialConceptRepository(db),
+            new StockSplitRepository(db)
+        );
+
+    private static FinancialFact Fact(
+        CommonStock stock,
+        FinancialConcept concept,
+        decimal value,
+        DateOnly asOf,
+        DateOnly filed,
+        DateOnly report,
+        DocumentType form = null
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            FinancialConceptId = concept.Id,
+            Document = new Document
+            {
+                CommonStockId = stock.Id,
+                DocumentType = form ?? DocumentType.TenQ,
+                ReportingForDate = report,
+                ReportingDate = filed,
+            },
+            Unit = "shares",
+            PeriodType = FactPeriodType.Instant,
+            PeriodStart = asOf,
+            PeriodEnd = asOf,
+            FiledDate = filed,
+            Form = form ?? DocumentType.TenQ,
+            AccessionNumber = filed.ToString("yyyyMMdd"),
+            DimensionsKey = "",
+            Value = value,
+        };
+
+    private static FinancialFact ClassFact(
+        CommonStock stock,
+        FinancialConcept concept,
+        decimal value,
+        DateOnly asOf,
+        DateOnly filed,
+        DateOnly report,
+        string member
+    )
+    {
+        var fact = Fact(stock, concept, value, asOf, filed, report);
+        const string axis = "us-gaap:StatementClassOfStockAxis";
+        fact.DimensionsKey = $"{axis}={member}";
+        fact.Dimensions.Add(new FinancialFactDimension { Axis = axis, Member = member });
+        return fact;
+    }
+}


### PR DESCRIPTION
## Summary

A current filing can contain a share-count context with a wrong year. Treating that historical date as current evidence applies intervening splits again and corrupts current shares and market capitalization. Reject counts dated after disclosure or before their linked annual/quarterly reporting period, retaining source facts and selecting eligible older evidence.

## Code changes

- Apply source-date eligibility before consolidated selection and require complete class membership before accepting a per-class total.
- Preserve foreign-issuer form protection independently of rejected numerical evidence, including cover-page priority.
- Add date, split, comparative-class, foreign-form, and PostgreSQL execution regressions.

Validation: Release solution build; 4,917 unit tests; two PostgreSQL integration cases; changed-file CSharpier; independent review.
