### PR TITLE
fix(insiders): preserve source row identity across rejected dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- Insider filing replays preserve source-row identity across rejected dates and exclude impossible dates from published trades without guessing replacement dates.
+
 - SEC document chunking now reads an indexed pending-state queue instead of scanning every stored document and probing the chunk corpus on each drained poll. Closes #3823.
 - Fails-to-deliver replays reconcile CUSIP identity only from a complete prior calendar month and no longer rewrite settled rows on every daily cycle. PRs #4461 and #4462.
 - Split adjustment of financial facts now applies only to share-denominated units, so ratio units such as USD/bbl or USD/MMBTU stay as filed. PR #4463.

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingParser.cs
@@ -22,8 +22,8 @@ public static class InsiderFilingParser
     // type (e.g., "Common Stock" vs "Stock Option (Right to Buy)"). For derivatives, Shares
     // and PricePerShare refer to the derivative instrument, not the underlying security.
     //
-    // TransactionOrder is the 0-based position of the row within its filing — assigned as
-    // we parse so the (AccessionNumber, TransactionOrder) unique index has a stable key.
+    // TransactionOrder is the source position, including rejected rows, so removing an
+    // invalid date never changes the identity of a later row.
     // The XML's document order is the only natural identity Form 4 transactions have, and
     // the same order lets the reprocess pipeline map a re-parsed row back onto its stored row.
     public static List<InsiderTransaction> ParseTransactions(
@@ -32,6 +32,24 @@ public static class InsiderFilingParser
         Guid companyId,
         FilingData filing,
         bool isAmendment
+    ) => ParseTransactionsCore(root, owner, companyId, filing, isAmendment, false);
+
+    // Replay must retain rejected dates in its source map; dropping one shifts later rows.
+    internal static List<InsiderTransaction> ParseTransactionsForReplay(
+        XElement root,
+        InsiderOwner owner,
+        Guid companyId,
+        FilingData filing,
+        bool isAmendment
+    ) => ParseTransactionsCore(root, owner, companyId, filing, isAmendment, true);
+
+    private static List<InsiderTransaction> ParseTransactionsCore(
+        XElement root,
+        InsiderOwner owner,
+        Guid companyId,
+        FilingData filing,
+        bool isAmendment,
+        bool includeInvalidDates
     )
     {
         var transactions = new List<InsiderTransaction>();
@@ -43,17 +61,22 @@ public static class InsiderFilingParser
         var rule10b5One = ParseRule10b5One(root);
         var originalFilingDate = isAmendment ? ParseDateOfOriginalSubmission(root) : null;
 
+        var sourceOrder = 0;
         void AddParsed(InsiderTransaction tx)
         {
+            var order = sourceOrder++;
             if (tx == null)
                 return;
             // A Form 3/4/5 discloses an event that has already occurred, so a transaction date after
             // the filing date — or an absurd year from a source typo (e.g. 2035 or 0022) — is
             // impossible. Newest-first trade lists would otherwise sort such a row to the very top,
             // so drop it rather than store the bad date verbatim.
-            if (tx.TransactionDate > tx.FilingDate || tx.TransactionDate.Year < 1900)
+            if (
+                !includeInvalidDates
+                && !IsPlausibleTransactionDate(tx.TransactionDate, tx.FilingDate)
+            )
                 return;
-            tx.TransactionOrder = transactions.Count;
+            tx.TransactionOrder = order;
             tx.IsRule10b5One = rule10b5One;
             tx.OriginalFilingDate = originalFilingDate;
             tx.FilingForm = ParseOwnershipForm(filing.Form);

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingReprocessManager.cs
@@ -92,6 +92,7 @@ public class InsiderFilingReprocessManager
         // can briefly nudge past Total and self-corrects.
         var staleTransactionFilingCount = await _transactionRepository
             .GetAll()
+            .IgnoreQueryFilters()
             .Where(t =>
                 t.TransactionCode != TransactionCode.IngestMarker
                 && t.ParserVersion < InsiderTransaction.CurrentParserVersion
@@ -127,6 +128,7 @@ public class InsiderFilingReprocessManager
             {
                 var pending = _transactionRepository
                     .GetAll()
+                    .IgnoreQueryFilters()
                     .Where(t =>
                         t.TransactionCode != TransactionCode.IngestMarker
                         && t.ParserVersion < InsiderTransaction.CurrentParserVersion
@@ -273,7 +275,10 @@ public class InsiderFilingReprocessManager
                 f.FilingForm == InsiderOwnershipForm.Unknown
                 && f.CaptureStatus == InsiderFilingCaptureStatus.Captured
                 && f.ContentId != null
-                && !_transactionRepository.GetAll().Any(t => t.AccessionNumber == f.AccessionNumber)
+                && !_transactionRepository
+                    .GetAll()
+                    .IgnoreQueryFilters()
+                    .Any(t => t.AccessionNumber == f.AccessionNumber)
             );
     }
 
@@ -382,6 +387,7 @@ public class InsiderFilingReprocessManager
         // without a per-filing lazy-load query.
         var rows = await _transactionRepository
             .GetByAccessionNumber(accession)
+            .IgnoreQueryFilters()
             .Include(t => t.CommonStock)
             .OrderBy(t => t.TransactionOrder)
             .ToListAsync();
@@ -425,19 +431,17 @@ public class InsiderFilingReprocessManager
         if (storedFiling != null)
             storedFiling.FilingForm = filingForm;
 
-        // Re-parse in the same document order the ingest used; map back onto the
-        // stored rows by TransactionOrder so a kind lands on the right row even if
-        // the parsed and stored counts ever differ.
-        var parsed = InsiderFilingParser.ParseTransactions(
+        // Retain rejected source rows while reconstructing the filing's original positions.
+        var parsed = InsiderFilingParser.ParseTransactionsForReplay(
             root,
             new InsiderOwner { Id = first.InsiderOwnerId },
             first.CommonStockId,
             filing,
             isAmendment
         );
-        // TransactionOrder is unique within a parse by construction, so a direct
-        // dictionary is safe; a duplicate would be a parser bug worth surfacing.
-        var parsedByOrder = parsed.ToDictionary(t => t.TransactionOrder);
+        // A legacy parse may have compacted rejected rows; require immutable evidence
+        // before copying any row-level field from the source.
+        var matchedRows = InsiderFilingRowMatches.Match(rows, parsed);
 
         // Older ingest code manufactured an Other/"No Securities Owned" row for
         // every valid zero-row parse. When the cached XML confirms there are still
@@ -456,15 +460,14 @@ public class InsiderFilingReprocessManager
             return;
         }
 
-        // The re-parse should reproduce the stored rows exactly. If the counts
-        // diverge, some stored rows won't map to a parsed row — they keep their
-        // prior data but are still advanced to the current version. Rare, but log
-        // it so the assumption is observable across a full backlog reprocess.
-        if (rows.Count != parsed.Count)
+        // Unmatched rows keep their row-level data and advance once, avoiding a retry storm.
+        // Document identity above remains grounded even when row identity is ambiguous.
+        if (matchedRows.Count != rows.Count)
         {
             _logger.LogWarning(
-                "Insider reprocess: {AccessionNumber} has {StoredCount} stored rows but re-parsed {ParsedCount}; unmatched rows keep prior data",
+                "Insider reprocess: {AccessionNumber} matched {MatchedCount} of {StoredCount} rows against {ParsedCount} source rows; unmatched rows keep prior data",
                 accession,
+                matchedRows.Count,
                 rows.Count,
                 parsed.Count
             );
@@ -472,7 +475,7 @@ public class InsiderFilingReprocessManager
 
         foreach (var row in rows)
         {
-            if (parsedByOrder.TryGetValue(row.TransactionOrder, out var reparsed))
+            if (matchedRows.TryGetValue(row.Id, out var reparsed))
             {
                 if (row.TransactionDate != reparsed.TransactionDate)
                 {
@@ -508,7 +511,15 @@ public class InsiderFilingReprocessManager
 
         // Date corrections must land before close lookup so price validation uses the
         // repaired trading day rather than the impossible source typo.
-        var bars = await FetchBars(first.CommonStockId, rows);
+        var usableRows = rows.Where(row =>
+                matchedRows.ContainsKey(row.Id)
+                && InsiderFilingParser.IsPlausibleTransactionDate(
+                    row.TransactionDate,
+                    row.FilingDate
+                )
+            )
+            .ToList();
+        var bars = await FetchBars(first.CommonStockId, usableRows);
         var splits = await _stockSplitRepository
             .GetEffectiveByStock(first.CommonStockId, DateOnly.FromDateTime(DateTime.UtcNow))
             .ToListAsync();
@@ -520,6 +531,11 @@ public class InsiderFilingReprocessManager
 
         foreach (var row in rows)
         {
+            if (!usableRows.Contains(row))
+            {
+                row.ParserVersion = InsiderTransaction.CurrentParserVersion;
+                continue;
+            }
             bars.TryGetValue(row.TransactionDate, out var barRow);
             var bar = InsiderDailyBars.Build(
                 barRow?.Close,
@@ -675,6 +691,8 @@ public class InsiderFilingReprocessManager
         List<InsiderTransaction> rows
     )
     {
+        if (rows.Count == 0)
+            return [];
         var minDate = rows.Min(r => r.TransactionDate).AddDays(-CloseLookbackDays);
         var maxDate = rows.Max(r => r.TransactionDate);
 

--- a/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingRowMatches.cs
+++ b/src/Equibles.InsiderTrading.BusinessLogic/InsiderFilingRowMatches.cs
@@ -1,0 +1,49 @@
+using Equibles.InsiderTrading.Data.Models;
+
+namespace Equibles.InsiderTrading.BusinessLogic;
+
+internal static class InsiderFilingRowMatches
+{
+    // Only fields the historical replay never rewrote can establish a legacy row's identity.
+    internal static Dictionary<Guid, InsiderTransaction> Match(
+        IReadOnlyList<InsiderTransaction> stored,
+        IReadOnlyList<InsiderTransaction> source
+    )
+    {
+        var byOrder = source.ToDictionary(t => t.TransactionOrder);
+        if (
+            stored.Count == source.Count
+            && stored.All(row =>
+                byOrder.TryGetValue(row.TransactionOrder, out var candidate)
+                && Key(row.SecurityTitle, row.Shares, row.ReportedPricePerShare)
+                    == Key(candidate.SecurityTitle, candidate.Shares, candidate.PricePerShare)
+            )
+        )
+            return stored.ToDictionary(row => row.Id, row => byOrder[row.TransactionOrder]);
+
+        var sourceGroups = source
+            .GroupBy(row => Key(row.SecurityTitle, row.Shares, row.PricePerShare))
+            .ToDictionary(g => g.Key, g => g.ToList());
+        var matches = new Dictionary<Guid, InsiderTransaction>();
+        foreach (
+            var group in stored.GroupBy(row =>
+                Key(row.SecurityTitle, row.Shares, row.ReportedPricePerShare)
+            )
+        )
+        {
+            if (
+                group.Count() == 1
+                && sourceGroups.TryGetValue(group.Key, out var candidates)
+                && candidates.Count == 1
+            )
+                matches[group.Single().Id] = candidates[0];
+        }
+        return matches;
+    }
+
+    private static (string Title, long Shares, decimal Price) Key(
+        string title,
+        long shares,
+        decimal price
+    ) => (title, shares, price);
+}

--- a/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
+++ b/src/Equibles.InsiderTrading.Data/InsiderTradingModuleConfiguration.cs
@@ -14,7 +14,13 @@ public class InsiderTradingModuleConfiguration : Equibles.Data.IFinancialModule
         // IsPriceValid is intentionally left with no SQL default: a freshly
         // inserted row is null ("not evaluated yet") until the parser (or a
         // maintenance recompute) cross-checks it against the market close.
-        builder.Entity<InsiderTransaction>();
+        // Retain rejected source dates for audit, but never expose them as usable trades.
+        // Replay explicitly opts into the raw rows to restore source identity.
+        builder
+            .Entity<InsiderTransaction>()
+            .HasQueryFilter(t =>
+                t.TransactionDate >= new DateOnly(1900, 1, 1) && t.TransactionDate <= t.FilingDate
+            );
         // Notes is a NOT NULL text[]; default existing rows to an empty array so
         // the column can be added without a backfill (the reprocess pass fills it).
         // IsRequired is explicit because nullable reference types are off, so EF

--- a/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
+++ b/src/Equibles.InsiderTrading.Data/Models/InsiderTransaction.cs
@@ -40,9 +40,9 @@ public class InsiderTransaction
     /// rows) stayed null (#7164, EquiblesCommercial); v8 stamps the authoritative
     /// Form 3/4/5 family so amendments cannot supersede a different ownership form;
     /// v9 tags the no-securities-owned sentinel as a holding so it participates only
-    /// in holding-section supersession.
+    /// in holding-section supersession; v10 restores source-row identity through rejected dates.
     /// </summary>
-    public const int CurrentParserVersion = 9;
+    public const int CurrentParserVersion = 10;
 
     public Guid Id { get; set; } = Guid.NewGuid();
 

--- a/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
+++ b/src/Equibles.Sec.HostedService/Services/InsiderTradingFilingProcessor.cs
@@ -71,6 +71,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         var candidates = accessionNumbers.ToList();
         var knownByOwnRows = await transactionRepository
             .GetAll()
+            .IgnoreQueryFilters()
             .Where(t =>
                 candidates.Contains(t.AccessionNumber)
                 && (
@@ -111,6 +112,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
         var existingRows = await transactionRepository
             .GetByAccessionNumber(filing.AccessionNumber)
+            .IgnoreQueryFilters()
             .ToListAsync();
         var staleIngestMarkers = existingRows
             .Where(row =>
@@ -259,6 +261,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             // restates holdings alone.
             var newerAmendmentRows = await transactionRepository
                 .GetAmendmentsOfOriginal(owner, companyId, originalFilingDate.Value, ownershipForm)
+                .IgnoreQueryFilters()
                 .Where(t =>
                     t.FilingDate > filing.FilingDate
                     || (
@@ -415,6 +418,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
         var claimingRows = await transactionRepository
             .GetAmendmentsClaiming(filing.AccessionNumber, ownershipForm)
+            .IgnoreQueryFilters()
             .ToListAsync();
         var windowStart = filing.FilingDate.AddDays(-OriginalDateShiftToleranceDays);
         var unresolvedRows = await transactionRepository
@@ -425,6 +429,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
                 filing.FilingDate,
                 ownershipForm
             )
+            .IgnoreQueryFilters()
             .ToListAsync();
         List<InsiderTransaction> newlyClaimedRows;
         if (claimingRows.Count > 0)
@@ -492,6 +497,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
     {
         var accessions = await transactionRepository
             .GetAll()
+            .IgnoreQueryFilters()
             .Where(t =>
                 t.SupersededAccessionNumber == supersededAccessionNumber
                 && t.FilingForm == InsiderOwnershipForm.Unknown
@@ -521,6 +527,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         var windowEnd = originalFilingDate.AddDays(OriginalDateShiftToleranceDays);
         var accessions = await transactionRepository
             .GetAll()
+            .IgnoreQueryFilters()
             .Where(t =>
                 t.InsiderOwnerId == owner.Id
                 && t.CommonStockId == companyId
@@ -558,6 +565,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         var windowStart = filingDate.AddDays(-OriginalDateShiftToleranceDays);
         var accessions = await transactionRepository
             .GetAll()
+            .IgnoreQueryFilters()
             .Where(t =>
                 t.InsiderOwnerId == owner.Id
                 && t.CommonStockId == companyId
@@ -593,6 +601,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
 
         var claimedRows = await transactionRepository
             .GetAll()
+            .IgnoreQueryFilters()
             .Where(t =>
                 amendmentAccessions.Contains(t.AccessionNumber)
                 && t.SupersededAccessionNumber != null
@@ -642,6 +651,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         {
             var unresolved = await transactionRepository
                 .GetByAccessionNumber(accessionNumber)
+                .IgnoreQueryFilters()
                 .Where(t => t.FilingForm == InsiderOwnershipForm.Unknown)
                 .ToListAsync();
             if (unresolved.Count == 0)
@@ -753,6 +763,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         var windowEnd = originalFilingDate.AddDays(OriginalDateShiftToleranceDays);
         var candidates = await transactionRepository
             .GetOriginalCandidates(owner, companyId, originalFilingDate, windowEnd, ownershipForm)
+            .IgnoreQueryFilters()
             .Select(t => new { t.AccessionNumber, t.FilingDate })
             .Distinct()
             .ToListAsync();
@@ -773,6 +784,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
             resolvedAccession = pool[0];
             var originalRows = await transactionRepository
                 .GetByAccessionNumber(resolvedAccession)
+                .IgnoreQueryFilters()
                 .ToListAsync();
             var supersededCount = DeleteSupersededSections(
                 transactionRepository,
@@ -802,6 +814,7 @@ public class InsiderTradingFilingProcessor : IFilingProcessor
         // amendment must leave an older amendment's transaction rows intact.
         var olderAmendments = await transactionRepository
             .GetAmendmentsOfOriginal(owner, companyId, originalFilingDate, ownershipForm)
+            .IgnoreQueryFilters()
             .Where(t =>
                 t.AccessionNumber != filing.AccessionNumber
                 && (

--- a/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
+++ b/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
@@ -10,6 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="../Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/oprx.xml" Link="TestAssets/oprx-invalid-dates.xml" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="../Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/snex.xml" Link="TestAssets/snex-invalid-dates.xml" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="TestAssets\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
+++ b/tests/Equibles.IntegrationTests/Equibles.IntegrationTests.csproj
@@ -10,8 +10,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="../Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/oprx.xml" Link="TestAssets/oprx-invalid-dates.xml" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="../Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/snex.xml" Link="TestAssets/snex-invalid-dates.xml" CopyToOutputDirectory="PreserveNewest" />
+    <Content
+      Include="../Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/oprx.xml"
+      Link="TestAssets/oprx-invalid-dates.xml"
+      CopyToOutputDirectory="PreserveNewest"
+    />
+    <Content
+      Include="../Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/snex.xml"
+      Link="TestAssets/snex-invalid-dates.xml"
+      CopyToOutputDirectory="PreserveNewest"
+    />
     <Content Include="TestAssets\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingRejectedDateReplayTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingRejectedDateReplayTests.cs
@@ -1,0 +1,291 @@
+using System.Text;
+using System.Xml.Linq;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CorporateActions.Repositories;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.InsiderTrading.Repositories;
+using Equibles.Integrations.Sec.Contracts;
+using Equibles.Integrations.Sec.Models;
+using Equibles.IntegrationTests.Helpers;
+using Equibles.Media.BusinessLogic;
+using Equibles.Sec.HostedService.Services;
+using Equibles.Sec.Repositories;
+using Equibles.Yahoo.Repositories;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+using Xunit;
+using File = Equibles.Media.Data.Models.File;
+using FileContent = Equibles.Media.Data.Models.FileContent;
+
+namespace Equibles.IntegrationTests.InsiderTrading;
+
+[Collection(ParadeDbCollection.Name)]
+public class InsiderFilingRejectedDateReplayTests(ParadeDbFixture fixture)
+    : ParadeDbMcpTestBase(fixture)
+{
+    [Fact]
+    public async Task Replay_RestoresSourceRowsAndQuarantinesUnusableDates()
+    {
+        const string accession = "0000913760-24-000032";
+        var xml = System.IO.File.ReadAllText(
+            Path.Combine(AppContext.BaseDirectory, "TestAssets", "snex-invalid-dates.xml")
+        );
+        var root = XElement.Parse(xml);
+        var stock = new CommonStock
+        {
+            Ticker = "SNEX",
+            Name = "StoneX",
+            Cik = "913760",
+        };
+        var owner = new InsiderOwner { Name = "Source owner", OwnerCik = "1" };
+        var filing = new FilingData
+        {
+            AccessionNumber = accession,
+            FilingDate = new(2024, 2, 14),
+            ReportDate = InsiderFilingParser.ParsePeriodOfReport(root).Value,
+            Form = "4",
+        };
+        var source = InsiderFilingParser.ParseTransactionsForReplay(
+            root,
+            owner,
+            stock.Id,
+            filing,
+            false
+        );
+        var rows = InsiderFilingParser.ParseTransactionsForReplay(
+            root,
+            owner,
+            stock.Id,
+            filing,
+            false
+        );
+        var oldCompacted = source.Where(t => t.TransactionDate.Year >= 1900).ToList();
+        for (var i = 0; i < rows.Count; i++)
+        {
+            rows[i].ReportedPricePerShare = rows[i].PricePerShare;
+            rows[i].ParserVersion = 9;
+            if (i < oldCompacted.Count)
+            {
+                rows[i].TransactionDate = oldCompacted[i].TransactionDate;
+                rows[i].TransactionCode = oldCompacted[i].TransactionCode;
+                rows[i].SecurityKind = oldCompacted[i].SecurityKind;
+            }
+        }
+        var bytes = Encoding.UTF8.GetBytes(xml);
+        DbContext.AddRange(
+            stock,
+            owner,
+            new InsiderFiling
+            {
+                AccessionNumber = accession,
+                CaptureStatus = InsiderFilingCaptureStatus.Captured,
+                UncompressedSize = bytes.Length,
+                Content = new File
+                {
+                    Name = accession,
+                    Extension = "gz",
+                    ContentType = "application/gzip",
+                    FileContent = new FileContent { Bytes = GzipCompressor.Compress(bytes) },
+                },
+            }
+        );
+        DbContext.AddRange(rows);
+        await DbContext.SaveChangesAsync();
+        DbContext.ChangeTracker.Clear();
+        var edgar = Substitute.For<ISecEdgarClient>();
+        var manager = new InsiderFilingReprocessManager(
+            new InsiderTransactionRepository(DbContext),
+            new InsiderFilingRepository(DbContext),
+            new DailyStockPriceRepository(DbContext),
+            new StockSplitRepository(DbContext),
+            new InsiderTransactionPriceValidator(),
+            edgar,
+            InsiderReprocessTestSupport.NewFileManager(),
+            DbContext,
+            NullLogger<InsiderFilingReprocessManager>()
+        );
+        var result = await manager.Run();
+        Assert.Equal(0, result.Failed);
+        DbContext.ChangeTracker.Clear();
+        var raw = await DbContext
+            .Set<InsiderTransaction>()
+            .IgnoreQueryFilters()
+            .OrderBy(t => t.TransactionOrder)
+            .ToListAsync();
+        Assert.Equal(6, raw.Count);
+        for (var i = 0; i < raw.Count; i++)
+        {
+            Assert.Equal(source[i].TransactionDate, raw[i].TransactionDate);
+            Assert.Equal(source[i].TransactionCode, raw[i].TransactionCode);
+            Assert.Equal(source[i].SecurityKind, raw[i].SecurityKind);
+            Assert.Equal(InsiderTransaction.CurrentParserVersion, raw[i].ParserVersion);
+        }
+        Assert.Equal(
+            new[] { 1, 2, 3, 5 },
+            await DbContext
+                .Set<InsiderTransaction>()
+                .OrderBy(t => t.TransactionOrder)
+                .Select(t => t.TransactionOrder)
+                .ToArrayAsync()
+        );
+        Assert.Equal(0, (await manager.Run()).Total);
+        await edgar.DidNotReceive().GetDocumentContent(Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task AllInvalidFiling_RemainsKnownAcrossRepeatedIngestion(bool alreadyStored)
+    {
+        const string accession = "0001628280-24-006020";
+        var xml = System.IO.File.ReadAllText(
+            Path.Combine(AppContext.BaseDirectory, "TestAssets", "oprx-invalid-dates.xml")
+        );
+        var root = XElement.Parse(xml);
+        var stock = new CommonStock
+        {
+            Ticker = "OPRX",
+            Name = "OptimizeRx",
+            Cik = "1448431",
+        };
+        var filing = new FilingData
+        {
+            AccessionNumber = accession,
+            FilingDate = new(2024, 2, 21),
+            ReportDate = new(23, 12, 19),
+            Form = "4",
+            Cik = stock.Cik,
+        };
+        DbContext.Add(stock);
+        if (alreadyStored)
+        {
+            var owner = new InsiderOwner
+            {
+                Name = "Source owner",
+                OwnerCik = root.Descendants("rptOwnerCik").First().Value,
+            };
+            DbContext.Add(owner);
+            DbContext.AddRange(
+                InsiderFilingParser.ParseTransactionsForReplay(root, owner, stock.Id, filing, false)
+            );
+        }
+        await DbContext.SaveChangesAsync();
+        var edgar = Substitute.For<ISecEdgarClient>();
+        edgar.GetDocumentContent(Arg.Any<FilingData>()).Returns(xml);
+        var processor = Processor(edgar);
+        Assert.Equal(!alreadyStored, await processor.Process(filing, stock));
+        Assert.False(await processor.Process(filing, stock));
+        Assert.Contains(accession, await processor.FilterKnownAccessions([accession]));
+        Assert.Equal(
+            alreadyStored ? 2 : 1,
+            await DbContext.Set<InsiderTransaction>().IgnoreQueryFilters().CountAsync()
+        );
+        Assert.Empty(await DbContext.Set<InsiderTransaction>().ToListAsync());
+    }
+
+    [Fact]
+    public async Task Amendment_SeesRejectedOriginalBeforeConvertingRemainingRowsToMarker()
+    {
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple",
+            Cik = "320193",
+        };
+        var owner = new InsiderOwner { Name = "Owner", OwnerCik = "1234567" };
+        const string original = "0000000001-24-000001";
+        const string amended = "0000000001-24-000002";
+        DbContext.AddRange(stock, owner);
+        for (var i = 0; i < 2; i++)
+            DbContext.Add(
+                new InsiderTransaction
+                {
+                    CommonStockId = stock.Id,
+                    InsiderOwnerId = owner.Id,
+                    AccessionNumber = original,
+                    TransactionOrder = i,
+                    FilingDate = new(2024, 3, 16),
+                    TransactionDate = new(i == 0 ? 24 : 2024, 3, 15),
+                    FilingForm = InsiderOwnershipForm.Form4,
+                    TransactionCode = TransactionCode.Purchase,
+                    SecurityKind = InsiderSecurityKind.NonDerivative,
+                    SecurityTitle = "Common Stock",
+                    Shares = 10 + i,
+                }
+            );
+        await DbContext.SaveChangesAsync();
+        const string xml = """
+            <ownershipDocument><documentType>4/A</documentType><periodOfReport>2024-03-15</periodOfReport>
+            <dateOfOriginalSubmission>2024-03-16</dateOfOriginalSubmission><issuer><issuerCik>320193</issuerCik></issuer>
+            <reportingOwner><reportingOwnerId><rptOwnerCik>1234567</rptOwnerCik><rptOwnerName>Owner</rptOwnerName></reportingOwnerId></reportingOwner>
+            <nonDerivativeTable><nonDerivativeTransaction><securityTitle><value>Common Stock</value></securityTitle>
+            <transactionDate><value>2024-03-15</value></transactionDate><transactionCoding><transactionCode>P</transactionCode></transactionCoding>
+            <transactionAmounts><transactionShares><value>30</value></transactionShares><transactionPricePerShare><value>0</value></transactionPricePerShare></transactionAmounts>
+            </nonDerivativeTransaction></nonDerivativeTable></ownershipDocument>
+            """;
+        var edgar = Substitute.For<ISecEdgarClient>();
+        edgar.GetDocumentContent(Arg.Any<FilingData>()).Returns(xml);
+        var processor = Processor(edgar);
+        Assert.True(
+            await processor.Process(
+                new FilingData
+                {
+                    AccessionNumber = amended,
+                    FilingDate = new(2024, 3, 18),
+                    ReportDate = new(2024, 3, 15),
+                    Form = "4/A",
+                    Cik = stock.Cik,
+                },
+                stock
+            )
+        );
+        var marker = await DbContext
+            .Set<InsiderTransaction>()
+            .IgnoreQueryFilters()
+            .SingleAsync(t => t.AccessionNumber == original);
+        Assert.Equal(TransactionCode.IngestMarker, marker.TransactionCode);
+        Assert.Equal(0, marker.TransactionOrder);
+        Assert.Single(await DbContext.Set<InsiderTransaction>().ToListAsync());
+    }
+
+    private InsiderTradingFilingProcessor Processor(ISecEdgarClient edgar)
+    {
+        var files = Substitute.For<IFileManager>();
+        files
+            .SaveInternalFile(
+                Arg.Any<byte[]>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>()
+            )
+            .Returns(call =>
+            {
+                var file = new File
+                {
+                    Name = call.ArgAt<string>(1),
+                    Extension = "gz",
+                    ContentType = "application/gzip",
+                    FileContent = new FileContent { Bytes = call.ArgAt<byte[]>(0) },
+                };
+                DbContext.Add(file);
+                return file;
+            });
+        var scopes = ServiceScopeSubstitute.Create(
+            (typeof(ISecEdgarClient), edgar),
+            (typeof(InsiderTransactionRepository), new InsiderTransactionRepository(DbContext)),
+            (typeof(InsiderOwnerRepository), new InsiderOwnerRepository(DbContext)),
+            (typeof(InsiderFilingRepository), new InsiderFilingRepository(DbContext)),
+            (typeof(FailedFilingIngestRepository), new FailedFilingIngestRepository(DbContext)),
+            (typeof(IFileManager), files),
+            (typeof(DailyStockPriceRepository), new DailyStockPriceRepository(DbContext)),
+            (typeof(StockSplitRepository), new StockSplitRepository(DbContext)),
+            (typeof(InsiderTransactionPriceValidator), new InsiderTransactionPriceValidator())
+        );
+        return new InsiderTradingFilingProcessor(
+            scopes,
+            NullLogger<InsiderTradingFilingProcessor>(),
+            null
+        );
+    }
+}

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerDivergenceTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderFilingReprocessManagerDivergenceTests.cs
@@ -20,8 +20,8 @@ namespace Equibles.IntegrationTests.InsiderTrading;
 /// <summary>
 /// Pin for the row-count divergence path in <c>ReprocessFiling</c>. When the cached XML
 /// re-parses to fewer transactions than the stored filing has rows, each stored row is
-/// matched to a parsed row by <c>TransactionOrder</c>; a stored row with no match keeps
-/// its prior <c>SecurityKind</c>/<c>Notes</c> but must still be advanced to the current
+/// matched only through unambiguous unchanged evidence; ambiguous rows keep
+/// their prior <c>SecurityKind</c>/<c>Notes</c> but must still be advanced to the current
 /// parser version, otherwise it would be re-selected on every future run.
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
@@ -58,8 +58,8 @@ public class InsiderFilingReprocessManagerDivergenceTests : ParadeDbMcpTestBase
             IsDirector = true,
         };
 
-        // Two stale rows. The cached XML below has a single transaction (order 0), so
-        // order 0 re-parses and reclassifies while order 1 has no parsed counterpart.
+        // Two identical stored rows against one source row cannot establish which row
+        // survived a legacy compacting parse; neither may be reclassified by position.
         InsiderTransaction MakeStale(int order) =>
             new()
             {
@@ -152,8 +152,8 @@ public class InsiderFilingReprocessManagerDivergenceTests : ParadeDbMcpTestBase
 
         result.Failed.Should().Be(0);
         result.Processed.Should().Be(1);
-        // Only the matched row flipped Derivative -> NonDerivative.
-        result.Reclassified.Should().Be(1);
+        // Document identity is grounded, but neither duplicate has a proven row match.
+        result.Reclassified.Should().Be(0);
         // Served from the cache, no EDGAR round-trip.
         await edgar.DidNotReceive().GetDocumentContent(Arg.Any<string>(), Arg.Any<string>());
 
@@ -161,7 +161,7 @@ public class InsiderFilingReprocessManagerDivergenceTests : ParadeDbMcpTestBase
         var matchedAfter = await verify.Set<InsiderTransaction>().FindAsync(matched.Id);
         var unmatchedAfter = await verify.Set<InsiderTransaction>().FindAsync(unmatched.Id);
 
-        matchedAfter!.SecurityKind.Should().Be(InsiderSecurityKind.NonDerivative);
+        matchedAfter!.SecurityKind.Should().Be(InsiderSecurityKind.Derivative);
         matchedAfter.FilingForm.Should().Be(InsiderOwnershipForm.Form5);
         matchedAfter.IsAmendment.Should().Be(isAmendment);
         matchedAfter.OriginalFilingDate.Should().Be(isAmendment ? originalFilingDate : null);

--- a/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTradingRepositoryTests.cs
+++ b/tests/Equibles.IntegrationTests/InsiderTrading/InsiderTradingRepositoryTests.cs
@@ -229,7 +229,7 @@ public class InsiderTransactionRepositoryTests : IDisposable
             CommonStock = stock,
             InsiderOwnerId = owner.Id,
             InsiderOwner = owner,
-            FilingDate = filingDate ?? new DateOnly(2024, 6, 15),
+            FilingDate = filingDate ?? (transactionDate ?? new DateOnly(2024, 6, 14)).AddDays(1),
             TransactionDate = transactionDate ?? new DateOnly(2024, 6, 14),
             TransactionCode = code,
             Shares = shares,

--- a/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InsiderTradingToolsTests.cs
@@ -87,7 +87,7 @@ public class InsiderTradingToolsTests : ParadeDbMcpTestBase
             InsiderOwnerId = owner.Id,
             InsiderOwner = owner,
             TransactionDate = transactionDate ?? new DateOnly(2024, 6, 14),
-            FilingDate = filingDate ?? new DateOnly(2024, 6, 15),
+            FilingDate = filingDate ?? (transactionDate ?? new DateOnly(2024, 6, 14)).AddDays(1),
             TransactionCode = code,
             Shares = shares,
             PricePerShare = pricePerShare,

--- a/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingRejectedRowIdentityTests.cs
+++ b/tests/Equibles.UnitTests/InsiderTrading/BusinessLogic/InsiderFilingRejectedRowIdentityTests.cs
@@ -1,0 +1,98 @@
+using System.Xml.Linq;
+using Equibles.InsiderTrading.BusinessLogic;
+using Equibles.InsiderTrading.Data.Models;
+using Equibles.Integrations.Sec.Models;
+
+namespace Equibles.UnitTests.InsiderTrading.BusinessLogic;
+
+public class InsiderFilingRejectedRowIdentityTests
+{
+    [Theory]
+    [InlineData("snex", "2024-02-14", 6, new int[] { 1, 2, 3, 5 })]
+    [InlineData("spgi", "2024-02-05", 5, new int[] { 0 })]
+    [InlineData("oprx", "2024-02-21", 2, new int[] { })]
+    [InlineData("gic", "2024-01-09", 2, new int[] { 0 })]
+    [InlineData("gwrs", "2024-05-23", 4, new int[] { 0, 1 })]
+    public void RealSource_InvalidDatesCannotShiftLaterTrades(
+        string name,
+        string filed,
+        int sourceCount,
+        int[] visibleOrders
+    )
+    {
+        var root = XElement.Load(
+            Path.Combine(
+                AppContext.BaseDirectory,
+                "TestAssets",
+                "InsiderTrading",
+                "InvalidDates",
+                name + ".xml"
+            )
+        );
+        var filing = new FilingData
+        {
+            FilingDate = DateOnly.Parse(filed),
+            ReportDate = InsiderFilingParser.ParsePeriodOfReport(root).Value,
+        };
+        var owner = new InsiderOwner();
+        var stock = Guid.NewGuid();
+        var visible = InsiderFilingParser.ParseTransactions(root, owner, stock, filing, false);
+        var replay = InsiderFilingParser.ParseTransactionsForReplay(
+            root,
+            owner,
+            stock,
+            filing,
+            false
+        );
+        Assert.Equal(visibleOrders, visible.Select(t => t.TransactionOrder));
+        Assert.Equal(sourceCount, replay.Count);
+        Assert.All(
+            replay.Where(t => !visibleOrders.Contains(t.TransactionOrder)),
+            t => Assert.True(t.TransactionDate.Year < 1900)
+        );
+        var stored = replay
+            .Select(t => new InsiderTransaction
+            {
+                TransactionOrder = t.TransactionOrder,
+                Shares = t.Shares,
+                ReportedPricePerShare = t.PricePerShare,
+                SecurityTitle = t.SecurityTitle,
+                TransactionDate = new(2024, 2, 13),
+                TransactionCode = TransactionCode.Sale,
+                SecurityKind = InsiderSecurityKind.Unknown,
+            })
+            .ToList();
+        var matches = InsiderFilingRowMatches.Match(stored, replay);
+        Assert.Equal(sourceCount, matches.Count);
+        Assert.All(stored, t => Assert.Equal(t.TransactionOrder, matches[t.Id].TransactionOrder));
+    }
+
+    [Fact]
+    public void CompactedLegacyRows_MatchOnlyUniqueUnchangedEvidence()
+    {
+        var stored = new InsiderTransaction
+        {
+            TransactionOrder = 0,
+            SecurityTitle = "Common Stock",
+            Shares = 20,
+            ReportedPricePerShare = 5,
+        };
+        var rejected = new InsiderTransaction
+        {
+            TransactionOrder = 0,
+            SecurityTitle = "Common Stock",
+            Shares = 10,
+            PricePerShare = 5,
+        };
+        var valid = new InsiderTransaction
+        {
+            TransactionOrder = 1,
+            SecurityTitle = "Common Stock",
+            Shares = 20,
+            PricePerShare = 5,
+        };
+        Assert.Same(valid, InsiderFilingRowMatches.Match([stored], [rejected, valid])[stored.Id]);
+        rejected.Shares = 20;
+        Assert.Empty(InsiderFilingRowMatches.Match([stored], [rejected, valid]));
+    }
+}

--- a/tests/Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/README.md
+++ b/tests/Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/README.md
@@ -1,0 +1,7 @@
+Original ownership XML extracted without field edits from SEC accession submissions on 2026-09-08. Invalid source years are intentional.
+
+- snex: https://www.sec.gov/Archives/edgar/data/913760/000091376024000032/0000913760-24-000032.txt
+- spgi: https://www.sec.gov/Archives/edgar/data/64040/000006404024000054/0000064040-24-000054.txt
+- oprx: https://www.sec.gov/Archives/edgar/data/1448431/000162828024006020/0001628280-24-006020.txt
+- gic: https://www.sec.gov/Archives/edgar/data/945114/000171375424000004/0001713754-24-000004.txt
+- gwrs: https://www.sec.gov/Archives/edgar/data/1434728/000143472824000180/0001434728-24-000180.txt

--- a/tests/Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/gic.xml
+++ b/tests/Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/gic.xml
@@ -1,0 +1,125 @@
+<ownershipDocument>
+
+    <schemaVersion>X0508</schemaVersion>
+
+    <documentType>4</documentType>
+
+    <periodOfReport>0024-01-07</periodOfReport>
+
+    <notSubjectToSection16>0</notSubjectToSection16>
+
+    <issuer>
+        <issuerCik>0000945114</issuerCik>
+        <issuerName>GLOBAL INDUSTRIAL Co</issuerName>
+        <issuerTradingSymbol>GIC</issuerTradingSymbol>
+    </issuer>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0001713754</rptOwnerCik>
+            <rptOwnerName>Litwin Barry</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerStreet1>C/O GLOBAL INDUSTRIAL COMPANY</rptOwnerStreet1>
+            <rptOwnerStreet2>11 HARBOR PARK DRIVE</rptOwnerStreet2>
+            <rptOwnerCity>PORT WASHINGTON</rptOwnerCity>
+            <rptOwnerState>NY</rptOwnerState>
+            <rptOwnerZipCode>11050</rptOwnerZipCode>
+            <rptOwnerStateDescription></rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>1</isDirector>
+            <isOfficer>1</isOfficer>
+            <isTenPercentOwner>0</isTenPercentOwner>
+            <isOther>0</isOther>
+            <officerTitle>Chief Executive Officer</officerTitle>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <aff10b5One>0</aff10b5One>
+
+    <nonDerivativeTable>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2024-01-07</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>A</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>19027</value>
+                    <footnoteId id="F1"/>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>0</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>168365</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>0024-01-07</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>F</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>17538</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>36.79</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>150827</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+    </nonDerivativeTable>
+
+    <derivativeTable></derivativeTable>
+
+    <footnotes>
+        <footnote id="F1">On January 7, 2024, the reporting person was granted 19,027 restricted stock units pursuant to the Issuer's 2020 Omnibus Long-Term Incentive Plan with 25% of the restricted stock units vesting on the first, second, third, and fourth anniversary of the grant date.</footnote>
+    </footnotes>
+
+    <remarks></remarks>
+
+    <ownerSignature>
+        <signatureName>/s/ Barry Litwin by April Gruder as Attorney-In-Fact</signatureName>
+        <signatureDate>2024-01-09</signatureDate>
+    </ownerSignature>
+</ownershipDocument>

--- a/tests/Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/gwrs.xml
+++ b/tests/Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/gwrs.xml
@@ -1,0 +1,180 @@
+<ownershipDocument>
+
+    <schemaVersion>X0508</schemaVersion>
+
+    <documentType>4</documentType>
+
+    <periodOfReport>0024-05-23</periodOfReport>
+
+    <notSubjectToSection16>0</notSubjectToSection16>
+
+    <issuer>
+        <issuerCik>0001434728</issuerCik>
+        <issuerName>Global Water Resources, Inc.</issuerName>
+        <issuerTradingSymbol>GWRS</issuerTradingSymbol>
+    </issuer>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0001814062</rptOwnerCik>
+            <rptOwnerName>Krygier Christopher D</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerStreet1>C/O GLOBAL WATER RESOURCES, INC.</rptOwnerStreet1>
+            <rptOwnerStreet2>21410 N. 19TH AVENUE, SUITE 205</rptOwnerStreet2>
+            <rptOwnerCity>PHOENIX</rptOwnerCity>
+            <rptOwnerState>AZ</rptOwnerState>
+            <rptOwnerZipCode>85027</rptOwnerZipCode>
+            <rptOwnerStateDescription></rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>0</isDirector>
+            <isOfficer>1</isOfficer>
+            <isTenPercentOwner>0</isTenPercentOwner>
+            <isOther>0</isOther>
+            <officerTitle>Chief Operating Officer</officerTitle>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <aff10b5One>0</aff10b5One>
+
+    <nonDerivativeTable>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2024-05-23</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>P</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>9</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>13.16</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>3096.455</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By self as Trustee for The CKTJ Living Trust</value>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2024-05-23</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>P</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>546</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>13.17</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>3642.455</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By self as Trustee for The CKTJ Living Trust</value>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>0024-05-23</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>P</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>195</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>13.20</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>3837.455</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>I</value>
+                </directOrIndirectOwnership>
+                <natureOfOwnership>
+                    <value>By self as Trustee for The CKTJ Living Trust</value>
+                </natureOfOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeHolding>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>31494</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeHolding>
+    </nonDerivativeTable>
+
+    <derivativeTable></derivativeTable>
+
+    <footnotes></footnotes>
+
+    <remarks></remarks>
+
+    <ownerSignature>
+        <signatureName>/s/ Suzette Prante, attorney-in-fact</signatureName>
+        <signatureDate>2024-05-23</signatureDate>
+    </ownerSignature>
+</ownershipDocument>

--- a/tests/Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/oprx.xml
+++ b/tests/Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/oprx.xml
@@ -1,0 +1,161 @@
+<ownershipDocument>
+
+    <schemaVersion>X0508</schemaVersion>
+
+    <documentType>4</documentType>
+
+    <periodOfReport>0023-12-19</periodOfReport>
+
+    <notSubjectToSection16>0</notSubjectToSection16>
+
+    <issuer>
+        <issuerCik>0001448431</issuerCik>
+        <issuerName>OptimizeRx Corp</issuerName>
+        <issuerTradingSymbol>OPRX</issuerTradingSymbol>
+    </issuer>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0001887046</rptOwnerCik>
+            <rptOwnerName>Stelmakh Edward</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerStreet1>C/O OPTIMIZERX CORPORATION</rptOwnerStreet1>
+            <rptOwnerStreet2>260 CHARLES STREET, SUITE 302</rptOwnerStreet2>
+            <rptOwnerCity>WALTHAM</rptOwnerCity>
+            <rptOwnerState>MA</rptOwnerState>
+            <rptOwnerZipCode>02453</rptOwnerZipCode>
+            <rptOwnerStateDescription></rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>0</isDirector>
+            <isOfficer>1</isOfficer>
+            <isTenPercentOwner>0</isTenPercentOwner>
+            <isOther>0</isOther>
+            <officerTitle>CFO/COO</officerTitle>
+            <otherText></otherText>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <aff10b5One>0</aff10b5One>
+
+    <nonDerivativeTable></nonDerivativeTable>
+
+    <derivativeTable>
+        <derivativeTransaction>
+            <securityTitle>
+                <value>Stock Option</value>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>12.73</value>
+            </conversionOrExercisePrice>
+            <transactionDate>
+                <value>0023-12-19</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>A</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>15711</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>0</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <exerciseDate>
+                <footnoteId id="F1"/>
+            </exerciseDate>
+            <expirationDate>
+                <value>2026-12-19</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>15711</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>15711</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeTransaction>
+        <derivativeTransaction>
+            <securityTitle>
+                <value>Restricted Stock Units</value>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <footnoteId id="F2"/>
+            </conversionOrExercisePrice>
+            <transactionDate>
+                <value>0023-12-19</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>A</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>15711</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>0</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <exerciseDate>
+                <footnoteId id="F3"/>
+            </exerciseDate>
+            <expirationDate>
+                <value>2026-12-19</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>15711</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>15711</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeTransaction>
+    </derivativeTable>
+
+    <footnotes>
+        <footnote id="F1">The stock option vests in three equal annual installments beginning December 19, 2024, the first anniversary of the grant date.</footnote>
+        <footnote id="F2">Restricted stock units convert into common stock on a one-for-one basis.</footnote>
+        <footnote id="F3">The restricted stock units vest in three equal annual installments beginning December 19, 2024, the first anniversary of the grant date.</footnote>
+    </footnotes>
+
+    <remarks>The filing of this Statement shall not be construed as an admission (a) that the person filing this Statement is, for the purposes of Section 16 of the Securities Exchange Act of 1934, as amended, the beneficial owner of any equity securities covered by this Statement, or (b) that this Statement is legally required to be filed by such person.</remarks>
+
+    <ownerSignature>
+        <signatureName>/s/ Marion Odence-Ford, by Power of Attorney</signatureName>
+        <signatureDate>2024-02-21</signatureDate>
+    </ownerSignature>
+</ownershipDocument>

--- a/tests/Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/snex.xml
+++ b/tests/Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/snex.xml
@@ -1,0 +1,298 @@
+<ownershipDocument>
+
+    <schemaVersion>X0508</schemaVersion>
+
+    <documentType>4</documentType>
+
+    <periodOfReport>0024-02-12</periodOfReport>
+
+    <notSubjectToSection16>0</notSubjectToSection16>
+
+    <issuer>
+        <issuerCik>0000913760</issuerCik>
+        <issuerName>StoneX Group Inc.</issuerName>
+        <issuerTradingSymbol>SNEX</issuerTradingSymbol>
+    </issuer>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0001620576</rptOwnerCik>
+            <rptOwnerName>Lyon Charles M</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerStreet1>329 PARK AVENUE NORTH</rptOwnerStreet1>
+            <rptOwnerStreet2>SUITE 350</rptOwnerStreet2>
+            <rptOwnerCity>WINTER PARK</rptOwnerCity>
+            <rptOwnerState>FL</rptOwnerState>
+            <rptOwnerZipCode>32789</rptOwnerZipCode>
+            <rptOwnerStateDescription></rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>0</isDirector>
+            <isOfficer>0</isOfficer>
+            <isTenPercentOwner>0</isTenPercentOwner>
+            <isOther>1</isOther>
+            <officerTitle></officerTitle>
+            <otherText>President and CEO - subsidiary</otherText>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <aff10b5One>0</aff10b5One>
+
+    <nonDerivativeTable>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>0024-02-12</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>M</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>3659</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>30</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>65216</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2024-02-12</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>3659</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>67.2869</value>
+                    <footnoteId id="F1"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>61557</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2024-02-13</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>M</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>15552</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>30</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>77109</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2024-02-13</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>S</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>15552</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>65.1061</value>
+                    <footnoteId id="F1"/>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>61557</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+    </nonDerivativeTable>
+
+    <derivativeTable>
+        <derivativeTransaction>
+            <securityTitle>
+                <value>Stock Options</value>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>30</value>
+            </conversionOrExercisePrice>
+            <transactionDate>
+                <value>0024-02-12</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>M</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>3659</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>0</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <exerciseDate>
+                <value>2021-12-05</value>
+            </exerciseDate>
+            <expirationDate>
+                <value>2026-12-05</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>3659</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>371341</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeTransaction>
+        <derivativeTransaction>
+            <securityTitle>
+                <value>Stock Options</value>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>30</value>
+            </conversionOrExercisePrice>
+            <transactionDate>
+                <value>2024-02-13</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>M</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>15552</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>0</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <exerciseDate>
+                <value>2021-12-05</value>
+            </exerciseDate>
+            <expirationDate>
+                <value>2026-12-05</value>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>15552</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>355789</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeTransaction>
+    </derivativeTable>
+
+    <footnotes>
+        <footnote id="F1">The price reported represents an average price.  The Reporting Person will provide to the Commission, the issuer and any stockholder, upon request, full information regarding the number of shares sold at each separate price.</footnote>
+    </footnotes>
+
+    <remarks></remarks>
+
+    <ownerSignature>
+        <signatureName>Charles M. Lyon</signatureName>
+        <signatureDate>2024-02-14</signatureDate>
+    </ownerSignature>
+</ownershipDocument>

--- a/tests/Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/spgi.xml
+++ b/tests/Equibles.UnitTests/TestAssets/InsiderTrading/InvalidDates/spgi.xml
@@ -1,0 +1,248 @@
+<ownershipDocument>
+
+    <schemaVersion>X0508</schemaVersion>
+
+    <documentType>4</documentType>
+
+    <periodOfReport>0024-02-01</periodOfReport>
+
+    <notSubjectToSection16>0</notSubjectToSection16>
+
+    <issuer>
+        <issuerCik>0000064040</issuerCik>
+        <issuerName>S&amp;P Global Inc.</issuerName>
+        <issuerTradingSymbol>SPGI</issuerTradingSymbol>
+    </issuer>
+
+    <reportingOwner>
+        <reportingOwnerId>
+            <rptOwnerCik>0001839729</rptOwnerCik>
+            <rptOwnerName>Saha Saugata</rptOwnerName>
+        </reportingOwnerId>
+        <reportingOwnerAddress>
+            <rptOwnerStreet1>55 WATER STREET</rptOwnerStreet1>
+            <rptOwnerStreet2></rptOwnerStreet2>
+            <rptOwnerCity>NEW YORK</rptOwnerCity>
+            <rptOwnerState>NY</rptOwnerState>
+            <rptOwnerZipCode>10041</rptOwnerZipCode>
+            <rptOwnerStateDescription></rptOwnerStateDescription>
+        </reportingOwnerAddress>
+        <reportingOwnerRelationship>
+            <isDirector>0</isDirector>
+            <isOfficer>1</isOfficer>
+            <isTenPercentOwner>0</isTenPercentOwner>
+            <isOther>0</isOther>
+            <officerTitle>President, Commodity Insights</officerTitle>
+        </reportingOwnerRelationship>
+    </reportingOwner>
+
+    <aff10b5One>0</aff10b5One>
+
+    <nonDerivativeTable>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>2024-02-01</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>M</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>4661</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>457.22</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>A</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>6407</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+        <nonDerivativeTransaction>
+            <securityTitle>
+                <value>Common Stock</value>
+            </securityTitle>
+            <transactionDate>
+                <value>0024-02-01</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>F</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>2265</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>457.22</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>4142</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </nonDerivativeTransaction>
+    </nonDerivativeTable>
+
+    <derivativeTable>
+        <derivativeTransaction>
+            <securityTitle>
+                <value>Restricted Stock Units</value>
+                <footnoteId id="F1"/>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>0</value>
+            </conversionOrExercisePrice>
+            <transactionDate>
+                <value>0024-02-01</value>
+            </transactionDate>
+            <transactionCoding>
+                <transactionFormType>4</transactionFormType>
+                <transactionCode>M</transactionCode>
+                <equitySwapInvolved>0</equitySwapInvolved>
+            </transactionCoding>
+            <transactionAmounts>
+                <transactionShares>
+                    <value>4661</value>
+                </transactionShares>
+                <transactionPricePerShare>
+                    <value>0</value>
+                </transactionPricePerShare>
+                <transactionAcquiredDisposedCode>
+                    <value>D</value>
+                </transactionAcquiredDisposedCode>
+            </transactionAmounts>
+            <exerciseDate>
+                <value>2024-02-01</value>
+                <footnoteId id="F2"/>
+            </exerciseDate>
+            <expirationDate>
+                <value>2024-02-01</value>
+                <footnoteId id="F2"/>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>4661</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>0</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeTransaction>
+        <derivativeHolding>
+            <securityTitle>
+                <value>Restricted Stock Units</value>
+                <footnoteId id="F1"/>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>0</value>
+            </conversionOrExercisePrice>
+            <exerciseDate>
+                <footnoteId id="F3"/>
+            </exerciseDate>
+            <expirationDate>
+                <footnoteId id="F3"/>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>524</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>524</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeHolding>
+        <derivativeHolding>
+            <securityTitle>
+                <value>Restricted Stock Units</value>
+                <footnoteId id="F1"/>
+            </securityTitle>
+            <conversionOrExercisePrice>
+                <value>0</value>
+            </conversionOrExercisePrice>
+            <exerciseDate>
+                <footnoteId id="F4"/>
+            </exerciseDate>
+            <expirationDate>
+                <footnoteId id="F4"/>
+            </expirationDate>
+            <underlyingSecurity>
+                <underlyingSecurityTitle>
+                    <value>Common Stock</value>
+                </underlyingSecurityTitle>
+                <underlyingSecurityShares>
+                    <value>1190</value>
+                </underlyingSecurityShares>
+            </underlyingSecurity>
+            <postTransactionAmounts>
+                <sharesOwnedFollowingTransaction>
+                    <value>1190</value>
+                </sharesOwnedFollowingTransaction>
+            </postTransactionAmounts>
+            <ownershipNature>
+                <directOrIndirectOwnership>
+                    <value>D</value>
+                </directOrIndirectOwnership>
+            </ownershipNature>
+        </derivativeHolding>
+    </derivativeTable>
+
+    <footnotes>
+        <footnote id="F1">Each restricted stock unit represents a contingent right to receive one share of SPGI common stock.</footnote>
+        <footnote id="F2">As previously reported, the reporting person was granted 4,661 restricted stock units on 02/01/2021, subject to 3-year cliff vesting. The restricted stock units vested 100% on 02/01/2024.</footnote>
+        <footnote id="F3">As previously reported, the reporting person was granted 1,536 restricted stock units on 03/01/2022, subject to 3-year vesting. The restricted stock units vested 33% on 12/31/2022 and 33% on 12/31/2023 and the remaining 34% will vest on 12/31/2024. Vested shares will be delivered to the reporting person no later than January 31 following the respective vesting date.</footnote>
+        <footnote id="F4">As previously reported, the reporting person was granted 1,776 restricted stock units on 03/01/2023, subject to 3-year vesting. The restricted stock units vested 33% on 12/31/2023 and will vest 33% on 12/31/2024 and 34% on 12/31/2025. Vested shares will be delivered to the reporting person no later than January 31 following the respective vesting date.</footnote>
+    </footnotes>
+
+    <remarks></remarks>
+
+    <ownerSignature>
+        <signatureName>/s/ Alma Montanez, Attorney-in-Fact</signatureName>
+        <signatureDate>2024-02-05</signatureDate>
+    </ownerSignature>
+</ownershipDocument>


### PR DESCRIPTION
## Summary

Rejected ownership rows could shift later transaction positions during replay and overwrite a different trade. Preserve original source positions, match legacy rows only with unchanged source evidence, and keep impossible dates out of published trades without inventing replacements.

## Code changes

- Retain source positions before date rejection and match replay rows by unchanged title, quantity, and reported price; ambiguous matches remain untouched.
- Keep rejected rows available to replay, ingestion deduplication, and amendment replacement while excluding pre-1900 and post-filing dates from normal reads.
- Advance parser version to 10 and add original SEC fixtures from five affected filings with database coverage for replay, repeated ingestion, and amendment replacement.

## Verification

- Release solution build passed.
- All 4,923 unit tests and all 2,859 integration tests passed (including 235 insider cases).
- Changed C# files pass formatting checks; independent review is clear.
- Changelog and fixture provenance updated.

Related: daniel3303/EquiblesCommercial#7411.
