### PR TITLE
fix(stocks): support metadata locks alongside reference inserts

### DIFF
--- a/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
+++ b/src/Equibles.CommonStocks.Repositories/CommonStockRepository.cs
@@ -181,9 +181,25 @@ public class CommonStockRepository : BaseRepository<CommonStock>
     /// sync cannot change ticker ownership between validation and the write. An unchanged tracked
     /// snapshot is refreshed after the lock; pending changes are rejected rather than discarded.
     /// </summary>
-    public async Task<CommonStock> GetForUpdate(
+    public Task<CommonStock> GetForUpdate(
         Guid commonStockId,
         CancellationToken cancellationToken = default
+    ) => GetWithWriteLock(commonStockId, keyUpdate: true, cancellationToken);
+
+    /// <summary>
+    /// Locks and refreshes a stock for metadata changes without blocking foreign-key inserts.
+    /// Callers must not delete the stock or change foreign-key-eligible unique keys; those
+    /// operations require GetForUpdate. Competing stock writers remain serialized.
+    /// </summary>
+    public Task<CommonStock> GetForNoKeyUpdate(
+        Guid commonStockId,
+        CancellationToken cancellationToken = default
+    ) => GetWithWriteLock(commonStockId, keyUpdate: false, cancellationToken);
+
+    private async Task<CommonStock> GetWithWriteLock(
+        Guid commonStockId,
+        bool keyUpdate,
+        CancellationToken cancellationToken
     )
     {
         if (!DbContext.Database.IsRelational())
@@ -192,28 +208,33 @@ public class CommonStockRepository : BaseRepository<CommonStock>
                 .FirstOrDefaultAsync(stock => stock.Id == commonStockId, cancellationToken);
         }
 
+        var operation = keyUpdate ? nameof(GetForUpdate) : nameof(GetForNoKeyUpdate);
         if (DbContext.Database.CurrentTransaction == null)
-            throw new InvalidOperationException("GetForUpdate requires an active transaction.");
+            throw new InvalidOperationException($"{operation} requires an active transaction.");
 
         // A tracking raw-SQL query acquires the database lock but EF identity resolution returns
         // an already-tracked instance without refreshing its values. Callers commonly preload a
         // ticker snapshot before a provider fetch, so remember that state and reload only after
-        // FOR UPDATE has serialized us with a concurrent designation writer.
+        // the write lock has serialized us with a concurrent designation writer.
         var trackedEntry = DbContext
             .ChangeTracker.Entries<CommonStock>()
             .FirstOrDefault(entry => entry.Entity.Id == commonStockId);
         if (trackedEntry != null && trackedEntry.State != EntityState.Unchanged)
         {
             throw new InvalidOperationException(
-                $"GetForUpdate cannot refresh CommonStock {commonStockId} while its tracked state "
+                $"{operation} cannot refresh CommonStock {commonStockId} while its tracked state "
                     + $"is {trackedEntry.State}; save, discard, or detach pending changes first."
             );
         }
 
+        FormattableString query;
+        if (keyUpdate)
+            query = $"""SELECT * FROM "CommonStock" WHERE "Id" = {commonStockId} FOR UPDATE""";
+        else
+            query =
+                $"""SELECT * FROM "CommonStock" WHERE "Id" = {commonStockId} FOR NO KEY UPDATE""";
         var stock = await GetDbSet()
-            .FromSqlInterpolated(
-                $"""SELECT * FROM "CommonStock" WHERE "Id" = {commonStockId} FOR UPDATE"""
-            )
+            .FromSqlInterpolated(query)
             .FirstOrDefaultAsync(cancellationToken);
         if (stock != null && trackedEntry != null)
             await DbContext.Entry(stock).ReloadAsync(cancellationToken);

--- a/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryGetForUpdateTests.cs
+++ b/tests/Equibles.IntegrationTests/CommonStocks/CommonStockRepositoryGetForUpdateTests.cs
@@ -3,6 +3,7 @@ using Equibles.CommonStocks.Data.Models;
 using Equibles.CommonStocks.Repositories;
 using Equibles.IntegrationTests.Helpers;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 
 namespace Equibles.IntegrationTests.CommonStocks;
 
@@ -20,8 +21,10 @@ public class CommonStockRepositoryGetForUpdateTests : IAsyncLifetime
 
     public Task DisposeAsync() => Task.CompletedTask;
 
-    [Fact]
-    public async Task GetForUpdate_ModifiedTrackedStock_ThrowsWithoutDiscardingChanges()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task WriteLock_ModifiedTrackedStock_ThrowsWithoutDiscardingChanges(bool keyUpdate)
     {
         var stockId = Guid.NewGuid();
         await using (var seed = _fixture.CreateDbContext())
@@ -45,11 +48,127 @@ public class CommonStockRepositoryGetForUpdateTests : IAsyncLifetime
             IsolationLevel.ReadCommitted
         );
 
-        var action = async () => await repository.GetForUpdate(stockId);
+        var action = async () => await Lock(repository, stockId, keyUpdate);
 
         await action.Should().ThrowAsync<InvalidOperationException>().WithMessage("*Modified*");
         tracked.Name.Should().Be("Pending local name");
         context.Entry(tracked).State.Should().Be(EntityState.Modified);
         await transaction.RollbackAsync();
     }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task WriteLock_ForeignKeyInsert_OnlyKeyUpdateBlocks(bool keyUpdate)
+    {
+        var stockId = await SeedStock();
+        await using var context = _fixture.CreateDbContext();
+        await using var transaction = await context.Database.BeginTransactionAsync();
+        await Lock(new CommonStockRepository(context), stockId, keyUpdate);
+
+        await using var writer = new NpgsqlConnection(_fixture.ConnectionString);
+        await writer.OpenAsync();
+        await using var setup = new NpgsqlCommand("SET lock_timeout = '500ms'", writer);
+        await setup.ExecuteNonQueryAsync();
+        await using var insert = new NpgsqlCommand(
+            """
+            INSERT INTO "OffExchangeVolume"
+                ("Id", "CommonStockId", "ListedTicker", "WeekStartDate", "AtsVolume",
+                 "AtsTradeCount", "NonAtsOtcVolume", "NonAtsOtcTradeCount", "CreationTime")
+            VALUES (@id, @stock, 'AAPL', '2026-09-07', 1, 1, 0, 0, CURRENT_TIMESTAMP)
+            """,
+            writer
+        );
+        insert.Parameters.AddWithValue("stock", stockId);
+        insert.Parameters.AddWithValue("id", Guid.NewGuid());
+        if (keyUpdate)
+        {
+            var error = await Assert.ThrowsAsync<PostgresException>(() =>
+                insert.ExecuteNonQueryAsync()
+            );
+            error.SqlState.Should().Be(PostgresErrorCodes.LockNotAvailable);
+        }
+        else
+        {
+            (await insert.ExecuteNonQueryAsync()).Should().Be(1);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task NoKeyUpdate_ConcurrentStockWriter_StillBlocks(bool delete)
+    {
+        var stockId = await SeedStock();
+        await using var context = _fixture.CreateDbContext();
+        await using var transaction = await context.Database.BeginTransactionAsync();
+        await new CommonStockRepository(context).GetForNoKeyUpdate(stockId);
+        await using var writer = new NpgsqlConnection(_fixture.ConnectionString);
+        await writer.OpenAsync();
+        await using var timeout = new NpgsqlCommand("SET lock_timeout = '500ms'", writer);
+        await timeout.ExecuteNonQueryAsync();
+        await using var command = new NpgsqlCommand(
+            delete
+                ? """DELETE FROM "CommonStock" WHERE "Id" = @stock"""
+                : """UPDATE "CommonStock" SET "Name" = 'Competing writer' WHERE "Id" = @stock""",
+            writer
+        );
+        command.Parameters.AddWithValue("stock", stockId);
+        var error = await Assert.ThrowsAsync<PostgresException>(() =>
+            command.ExecuteNonQueryAsync()
+        );
+        error.SqlState.Should().Be(PostgresErrorCodes.LockNotAvailable);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task WriteLock_PreloadedSnapshot_RefreshesAfterLock(bool keyUpdate)
+    {
+        var stockId = await SeedStock();
+        await using var context = _fixture.CreateDbContext();
+        var repository = new CommonStockRepository(context);
+        var tracked = await repository.GetByPrimaryTicker("AAPL");
+        await using (var writer = _fixture.CreateDbContext())
+        {
+            await writer
+                .Set<CommonStock>()
+                .Where(stock => stock.Id == stockId)
+                .ExecuteUpdateAsync(update =>
+                    update.SetProperty(stock => stock.Name, "Updated issuer")
+                );
+        }
+        await using var transaction = await context.Database.BeginTransactionAsync();
+        var locked = await Lock(repository, stockId, keyUpdate);
+        locked.Should().BeSameAs(tracked);
+        locked.Name.Should().Be("Updated issuer");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task WriteLock_WithoutTransaction_RefusesUnprotectedRead(bool keyUpdate)
+    {
+        await using var context = _fixture.CreateDbContext();
+        var action = () => Lock(new CommonStockRepository(context), Guid.NewGuid(), keyUpdate);
+        await action
+            .Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*active transaction*");
+    }
+
+    private async Task<Guid> SeedStock()
+    {
+        await using var context = _fixture.CreateDbContext();
+        var stock = new CommonStock { Ticker = "AAPL", Name = "Apple" };
+        context.Add(stock);
+        await context.SaveChangesAsync();
+        return stock.Id;
+    }
+
+    private static Task<CommonStock> Lock(
+        CommonStockRepository repository,
+        Guid stockId,
+        bool keyUpdate
+    ) => keyUpdate ? repository.GetForUpdate(stockId) : repository.GetForNoKeyUpdate(stockId);
 }


### PR DESCRIPTION
## Summary
A listing metadata batch can deadlock with volume or holdings inserts when it takes FOR UPDATE locks across several stocks: foreign-key checks need incompatible KEY SHARE locks on those same parent rows.

## Code changes
Add CommonStockRepository.GetForNoKeyUpdate for callers that update metadata without deleting rows or changing referenced unique keys. Keep GetForUpdate unchanged for stronger locking. Both methods require a transaction, refresh unchanged tracked snapshots after locking, and refuse to discard pending changes.

## Validation
- 10 PostgreSQL integration cases passed, including a real OffExchangeVolume insert under each lock mode and competing stock update/delete refusals.
- Snapshot refresh and pending-change protection tested for both methods.
- Full Release build and CSharpier passed. Full unit suite: 4,923 passed. Full integration suite passed.
- The first full unit run hit a website-refill test failure; its isolated class and a complete unit rerun passed without changes.
- Independent full-diff review found no blocking issues.
