### PR TITLE
fix(tests): isolate website refill memo identities

### DIFF
--- a/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingWebsiteRefillTests.cs
+++ b/tests/Equibles.UnitTests/Sec/CompanySyncServiceUpdateExistingWebsiteRefillTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Reflection;
 using Equibles.CommonStocks.BusinessLogic;
 using Equibles.CommonStocks.Data;
@@ -28,12 +29,13 @@ namespace Equibles.UnitTests.Sec;
 /// </summary>
 public class CompanySyncServiceUpdateExistingWebsiteRefillTests
 {
-    public CompanySyncServiceUpdateExistingWebsiteRefillTests()
-    {
-        // The blank-website memo is static process state; earlier tests sharing a
-        // CIK would otherwise suppress the refill fetch these tests pin.
-        CompanySyncService.ClearBlankWebsiteMemoForTests();
-    }
+    private static long _nextCik = 9_000_000_000;
+
+    // A process-wide memo makes a shared CIK unsafe across parallel test classes. Give each
+    // case its own key instead of clearing memo entries another test may still be using.
+    private readonly string _cik = Interlocked
+        .Increment(ref _nextCik)
+        .ToString(CultureInfo.InvariantCulture);
 
     private static EquiblesFinancialDbContext NewDb()
     {
@@ -96,16 +98,14 @@ public class CompanySyncServiceUpdateExistingWebsiteRefillTests
         return (Task)m.Invoke(sut, [secCompany, primaryTicker, new List<string>(), state]);
     }
 
-    private static async Task<(EquiblesFinancialDbContext Db, CommonStock Stock)> SeedStock(
-        string website
-    )
+    private async Task<(EquiblesFinancialDbContext Db, CommonStock Stock)> SeedStock(string website)
     {
         var db = NewDb();
         db.Set<CommonStock>()
             .Add(
                 new CommonStock
                 {
-                    Cik = "0000000002",
+                    Cik = _cik,
                     Ticker = "EXM",
                     Name = "Example Corp",
                     Website = website,
@@ -113,14 +113,14 @@ public class CompanySyncServiceUpdateExistingWebsiteRefillTests
             );
         await db.SaveChangesAsync();
         db.ChangeTracker.Clear();
-        var stock = await db.Set<CommonStock>().FirstAsync(s => s.Cik == "0000000002");
+        var stock = await db.Set<CommonStock>().FirstAsync(s => s.Cik == _cik);
         return (db, stock);
     }
 
-    private static CompanyInfo UnchangedCompanyInfo() =>
+    private CompanyInfo UnchangedCompanyInfo() =>
         new()
         {
-            Cik = "0000000002",
+            Cik = _cik,
             Name = "Example Corp",
             Tickers = ["EXM"],
         };
@@ -132,12 +132,12 @@ public class CompanySyncServiceUpdateExistingWebsiteRefillTests
         using var _ = db;
         var edgar = Substitute.For<ISecEdgarClient>();
         edgar
-            .GetCompanyMetadata("0000000002")
+            .GetCompanyMetadata(_cik)
             .Returns(new CompanyMetadata { Website = "https://www.example.com" });
 
         await Invoke(BuildSut(edgar), UnchangedCompanyInfo(), "EXM", BuildState(db, stock));
 
-        var updated = await db.Set<CommonStock>().FirstAsync(s => s.Cik == "0000000002");
+        var updated = await db.Set<CommonStock>().FirstAsync(s => s.Cik == _cik);
         updated.Website.Should().Be("https://www.example.com");
     }
 
@@ -147,11 +147,11 @@ public class CompanySyncServiceUpdateExistingWebsiteRefillTests
         var (db, stock) = await SeedStock("");
         using var _ = db;
         var edgar = Substitute.For<ISecEdgarClient>();
-        edgar.GetCompanyMetadata("0000000002").Returns(new CompanyMetadata { Website = "" });
+        edgar.GetCompanyMetadata(_cik).Returns(new CompanyMetadata { Website = "" });
 
         await Invoke(BuildSut(edgar), UnchangedCompanyInfo(), "EXM", BuildState(db, stock));
 
-        var updated = await db.Set<CommonStock>().FirstAsync(s => s.Cik == "0000000002");
+        var updated = await db.Set<CommonStock>().FirstAsync(s => s.Cik == _cik);
         updated.Website.Should().BeNull();
     }
 
@@ -165,7 +165,7 @@ public class CompanySyncServiceUpdateExistingWebsiteRefillTests
         await Invoke(BuildSut(edgar), UnchangedCompanyInfo(), "EXM", BuildState(db, stock));
 
         await edgar.DidNotReceive().GetCompanyMetadata(Arg.Any<string>());
-        var updated = await db.Set<CommonStock>().FirstAsync(s => s.Cik == "0000000002");
+        var updated = await db.Set<CommonStock>().FirstAsync(s => s.Cik == _cik);
         updated.Website.Should().Be("https://www.already-set.com");
     }
 }


### PR DESCRIPTION
## Summary
The website-refill tests intermittently fail when a parallel company-sync test records a blank website for the same CIK. Clearing the static memo in the constructor cannot prevent another class from writing that key immediately afterward, and clears state other tests may still need.

## Code changes
Give each website-refill case its own numeric CIK and use that identity consistently in the seeded stock, provider response, and assertions. Remove the process-wide memo reset; production behavior is unchanged.

## Validation
- Observed the original blank-versus-null failure during a full suite run.
- All 5 related tests and all 4,923 unit tests pass after isolation.
- CSharpier and independent full-diff review pass.
