### PR TITLE
fix(holdings): require filer evidence on both comparison sides

### DIFF
--- a/src/Equibles.Holdings.BusinessLogic/HoldingsComparisonCoverage.cs
+++ b/src/Equibles.Holdings.BusinessLogic/HoldingsComparisonCoverage.cs
@@ -1,0 +1,163 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.BusinessLogic.Models;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.Holdings.Repositories.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.Holdings.BusinessLogic;
+
+public static class HoldingsComparisonCoverage
+{
+    public static async Task<Dictionary<DateOnly, HoldingsComparisonStatus>> History(
+        InstitutionalHoldingRepository repository,
+        CommonStock stock,
+        IReadOnlyList<DateOnly> dates,
+        string listedTicker = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var ordered = dates.Distinct().Order().ToArray();
+        if (ordered.Length < 2)
+            return [];
+        var holdings =
+            listedTicker == null
+                ? repository.Get13FHistoryByStock(stock)
+                : repository.Get13FHistoryByListing(stock, listedTicker);
+        var positions = await holdings
+            .Where(h => ordered.Contains(h.ReportDate))
+            .Select(h => new HoldingsFilingPresence
+            {
+                ReportDate = h.ReportDate,
+                InstitutionalHolderId = h.InstitutionalHolderId,
+            })
+            .Distinct()
+            .ToListAsync(cancellationToken);
+        var byDate = positions
+            .GroupBy(p => p.ReportDate)
+            .ToDictionary(g => g.Key, g => g.Select(p => p.InstitutionalHolderId).ToHashSet());
+        var pending = new List<HoldingsComparisonStatus>();
+        for (var index = 1; index < ordered.Length; index++)
+        {
+            var current = ordered[index];
+            var previous = ordered[index - 1];
+            pending.Add(
+                Compare(
+                    current,
+                    previous,
+                    byDate.GetValueOrDefault(current) ?? [],
+                    byDate.GetValueOrDefault(previous) ?? []
+                )
+            );
+        }
+        return await Resolve(repository, pending, cancellationToken);
+    }
+
+    public static async Task<HoldingsComparisonStatus> Activity(
+        InstitutionalHoldingRepository repository,
+        IReadOnlyCollection<HolderStockActivity> activity,
+        DateOnly current,
+        DateOnly previous,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var pending = Compare(
+            current,
+            previous,
+            activity
+                .Where(row => row.CurrentPositionCount > 0)
+                .Select(row => row.InstitutionalHolderId)
+                .ToHashSet(),
+            activity
+                .Where(row => row.PreviousPositionCount > 0)
+                .Select(row => row.InstitutionalHolderId)
+                .ToHashSet()
+        );
+        return (await Resolve(repository, [pending], cancellationToken))[current];
+    }
+
+    private static HoldingsComparisonStatus Compare(
+        DateOnly current,
+        DateOnly previous,
+        HashSet<Guid> currentHolders,
+        HashSet<Guid> previousHolders
+    ) =>
+        new(
+            current,
+            previous,
+            currentHolders.Except(previousHolders).ToHashSet(),
+            previousHolders.Except(currentHolders).ToHashSet()
+        );
+
+    private static async Task<Dictionary<DateOnly, HoldingsComparisonStatus>> Resolve(
+        InstitutionalHoldingRepository repository,
+        IReadOnlyList<HoldingsComparisonStatus> pending,
+        CancellationToken cancellationToken
+    )
+    {
+        // Read evidence for every missing side in one command; per-quarter reads amplify
+        // the cost of long ownership histories. Same-stock rows already prove filing presence.
+        var requested = pending
+            .Where(p => p.ConsecutiveQuarters)
+            .SelectMany(p =>
+                p.MissingPreviousFilers.Select(id => new HoldingsFilingPresence
+                    {
+                        ReportDate = p.PreviousReportDate,
+                        InstitutionalHolderId = id,
+                    })
+                    .Concat(
+                        p.MissingCurrentFilers.Select(id => new HoldingsFilingPresence
+                        {
+                            ReportDate = p.ReportDate,
+                            InstitutionalHolderId = id,
+                        })
+                    )
+            )
+            .Distinct()
+            .ToList();
+        var query = EvidenceQuery(repository, requested);
+        var observed = query == null ? [] : await query.ToListAsync(cancellationToken);
+        var byDate = observed.ToLookup(p => p.ReportDate, p => p.InstitutionalHolderId);
+        return pending.ToDictionary(
+            p => p.ReportDate,
+            p =>
+                p with
+                {
+                    MissingPreviousFilers = p
+                        .MissingPreviousFilers.Except(byDate[p.PreviousReportDate])
+                        .ToHashSet(),
+                    MissingCurrentFilers = p
+                        .MissingCurrentFilers.Except(byDate[p.ReportDate])
+                        .ToHashSet(),
+                }
+        );
+    }
+
+    internal static IQueryable<HoldingsFilingPresence> EvidenceQuery(
+        InstitutionalHoldingRepository repository,
+        IReadOnlyList<HoldingsFilingPresence> requested
+    )
+    {
+        IQueryable<HoldingsFilingPresence> query = null;
+        foreach (var group in requested.GroupBy(p => p.ReportDate))
+        {
+            var date = group.Key;
+            var holders = group.Select(p => p.InstitutionalHolderId).Distinct().ToArray();
+            var branch = repository
+                .GetAll()
+                .Where(h =>
+                    h.FilingType == FilingType.Form13F
+                    && h.ReportDate == date
+                    && holders.Contains(h.InstitutionalHolderId)
+                )
+                .Select(h => new HoldingsFilingPresence
+                {
+                    ReportDate = h.ReportDate,
+                    InstitutionalHolderId = h.InstitutionalHolderId,
+                })
+                .Distinct();
+            query = query == null ? branch : query.Concat(branch);
+        }
+        return query;
+    }
+}

--- a/src/Equibles.Holdings.BusinessLogic/Models/HoldingsComparisonStatus.cs
+++ b/src/Equibles.Holdings.BusinessLogic/Models/HoldingsComparisonStatus.cs
@@ -1,0 +1,25 @@
+namespace Equibles.Holdings.BusinessLogic.Models;
+
+public sealed record HoldingsComparisonStatus(
+    DateOnly ReportDate,
+    DateOnly PreviousReportDate,
+    IReadOnlySet<Guid> MissingPreviousFilers,
+    IReadOnlySet<Guid> MissingCurrentFilers
+)
+{
+    public bool ConsecutiveQuarters =>
+        PreviousReportDate == HoldingsCorpusCoverage.PreviousQuarterEnd(ReportDate);
+    public bool ComparisonAvailable =>
+        ConsecutiveQuarters && MissingPreviousFilers.Count == 0 && MissingCurrentFilers.Count == 0;
+
+    public bool CanCompareHolder(Guid holderId) =>
+        ConsecutiveQuarters
+        && !MissingPreviousFilers.Contains(holderId)
+        && !MissingCurrentFilers.Contains(holderId);
+
+    public string Note =>
+        !ConsecutiveQuarters
+            ? "Comparison unavailable: the stored report dates are not consecutive quarters."
+        : ComparisonAvailable ? null
+        : $"Comparison unavailable: {MissingPreviousFilers.Count} current holders have no observed prior-quarter 13F and {MissingCurrentFilers.Count} prior holders have no observed current-quarter 13F. Missing filings or filer identity changes are not treated as buying or selling.";
+}

--- a/src/Equibles.Holdings.BusinessLogic/Models/HoldingsFilingPresence.cs
+++ b/src/Equibles.Holdings.BusinessLogic/Models/HoldingsFilingPresence.cs
@@ -1,0 +1,7 @@
+namespace Equibles.Holdings.BusinessLogic.Models;
+
+public sealed record HoldingsFilingPresence
+{
+    public DateOnly ReportDate { get; init; }
+    public Guid InstitutionalHolderId { get; init; }
+}

--- a/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
+++ b/src/Equibles.Holdings.Mcp/Tools/InstitutionalHoldingsTools.cs
@@ -405,7 +405,7 @@ public class InstitutionalHoldingsTools
         ReadOnly = true
     )]
     [Description(
-        "Get the historical trend of aggregate reported 13F exposure for an exact stock or ETF listing across multiple quarters. The legacy Total Shares field sums reported quantities across common-share rows, put/call notional-underlying rows, and any tracked principal-denominated rows, so it is not a pure share-ownership measure. Shows how total reported quantity, published position value, and filer count changed. Values normally use report-date closing prices, may fall back to filer values, and can include zero when unavailable. While the newest quarter's filing window is open, non-ETF primary stocks use a provisional combined view; ETF listings remain exact and as-filed because carry-forward is filer-wide."
+        "Get the historical trend of aggregate reported 13F exposure for an exact stock or ETF listing across multiple quarters. The legacy Total Shares field sums reported quantities across common-share rows, put/call notional-underlying rows, and any tracked principal-denominated rows, so it is not a pure share-ownership measure. Shows total reported quantity, published position value, and filer count. Changes are withheld when a relevant filer has no observed 13F in either compared quarter; missing filings and filer identity changes are not trades. Values normally use report-date closing prices, may fall back to filer values, and can include zero when unavailable. While the newest quarter's filing window is open, non-ETF primary stocks use a provisional combined view; ETF listings remain exact and as-filed because carry-forward is filer-wide."
     )]
     public Task<string> GetInstitutionalOwnershipHistory(
         [Description("Listed security ticker (e.g., AAPL, VOO)")] string ticker,
@@ -473,7 +473,13 @@ public class InstitutionalHoldingsTools
                     .OrderBy(row => row.ReportDate)
                     .ToList();
                 await _marketActivityShareRestater.RestateStockActivity(stock, selected);
-                return RenderOwnershipHistory(stock, ticker, selected, anchor);
+                var coverage = await HoldingsComparisonCoverage.History(
+                    _holdingRepository,
+                    stock,
+                    selected.Select(row => row.ReportDate).ToList(),
+                    exactListingScope ? listedTicker : null
+                );
+                return RenderOwnershipHistory(stock, ticker, selected, anchor, coverage);
             },
             "GetInstitutionalOwnershipHistory",
             $"ticker: {ticker}"
@@ -484,7 +490,11 @@ public class InstitutionalHoldingsTools
         CommonStock stock,
         string ticker,
         IReadOnlyList<StockQuarterlyActivity> activity,
-        StockQuarterAnchor anchor
+        StockQuarterAnchor anchor,
+        IReadOnlyDictionary<
+            DateOnly,
+            Equibles.Holdings.BusinessLogic.Models.HoldingsComparisonStatus
+        > coverage
     )
     {
         var result = MarkdownTable.Start(
@@ -500,7 +510,10 @@ public class InstitutionalHoldingsTools
             var isCombinedRow =
                 anchor is { IsCombined: true } && row.ReportDate == anchor.ReportDate;
             combinedRowShown |= isCombinedRow;
-            var change = FormatShareChange(row.CurrentShares, previousShares);
+            var comparison = coverage.GetValueOrDefault(row.ReportDate);
+            var change = comparison is { ComparisonAvailable: false }
+                ? "unavailable (coverage)"
+                : FormatShareChange(row.CurrentShares, previousShares);
 
             result.AppendLine(
                 $"| {FormatDate(row.ReportDate)}{(isCombinedRow ? " \\*" : "")} | {McpFormat.WholeNumber(row.CurrentFilerCount)} | {McpFormat.WholeNumber(row.CurrentShares)} | {FormatMillions(row.CurrentValue)} | {change} |"
@@ -508,6 +521,9 @@ public class InstitutionalHoldingsTools
 
             previousShares = row.CurrentShares;
         }
+
+        foreach (var comparison in coverage.Values.Where(c => !c.ComparisonAvailable))
+            result.AppendLine($"{FormatDate(comparison.ReportDate)}: {comparison.Note}");
 
         if (combinedRowShown)
         {
@@ -883,7 +899,7 @@ public class InstitutionalHoldingsTools
         ReadOnly = true
     )]
     [Description(
-        "Get the institutions that moved the needle the most on a stock this quarter — biggest absolute share additions (Top Buyers) and biggest absolute share reductions (Top Sellers) versus the previous 13F report date. Includes new positions (Δ = full position) and sold-out positions (Δ = −prior position); a previous holder counts as a seller only if it filed a 13F for the target quarter, so a fund that stopped filing (CIK migration, deregistration) is not shown as a mass seller. While the newest quarter's filing window is open, results cover only the funds that have already filed (noted in the output). Returns a markdown table with two sections. Use this to surface the most actionable quarterly signal from 13F filings."
+        "Get the institutions that moved the needle the most on a stock this quarter — biggest absolute share additions (Top Buyers) and biggest absolute share reductions (Top Sellers) versus the previous 13F report date. Includes new positions (Δ = full position) and sold-out positions (Δ = −prior position); entries and exits require observed 13F filings in both compared quarters, so missing filings or a CIK migration cannot become a full-position buy or sale. While the newest quarter's filing window is open, results cover only the funds that have already filed (noted in the output). Returns a markdown table with two sections. Use this to surface the most actionable quarterly signal from 13F filings."
     )]
     public Task<string> GetTopInstitutionalBuyersSellers(
         [Description("Listed security ticker (e.g., AAPL, VOO)")] string ticker,
@@ -955,20 +971,14 @@ public class InstitutionalHoldingsTools
                     previousDate.HasValue
                     && targetDate == reportDates[0]
                     && CombinedQuarterHelper.IsFilingWindowOpen(targetDate);
-                HashSet<Guid> filedPreviousHolders = null;
-                if (previousDate.HasValue)
-                {
-                    var priorHolderIds = activity
-                        .Where(row => row.PreviousPositionCount > 0)
-                        .Select(row => row.InstitutionalHolderId)
-                        .Distinct()
-                        .ToList();
-                    filedPreviousHolders = (
-                        await _holdingRepository
-                            .GetFiledHolderIdsAmong(targetDate, priorHolderIds)
-                            .ToListAsync()
-                    ).ToHashSet();
-                }
+                var comparison = previousDate.HasValue
+                    ? await HoldingsComparisonCoverage.Activity(
+                        _holdingRepository,
+                        activity,
+                        targetDate,
+                        previousDate.Value
+                    )
+                    : null;
 
                 // Restate each quarter's share counts onto today's split basis (the two
                 // quarters sit on different bases if a split fell between them) so Δ Shares
@@ -990,11 +1000,7 @@ public class InstitutionalHoldingsTools
 
                 var movers = activity
                     .GroupBy(row => row.InstitutionalHolderId)
-                    .Where(g =>
-                        filedPreviousHolders == null
-                        || g.Any(row => row.CurrentPositionCount > 0)
-                        || filedPreviousHolders.Contains(g.Key)
-                    )
+                    .Where(g => comparison != null && comparison.CanCompareHolder(g.Key))
                     .Select(g =>
                     {
                         var currentShares = g.Sum(row =>
@@ -1029,7 +1035,7 @@ public class InstitutionalHoldingsTools
                     .ToList();
 
                 if (topBuyers.Count == 0 && topSellers.Count == 0)
-                    return $"No quarter-over-quarter movement found for {StockListingLabel(stock, ticker)} as of {FormatDate(targetDate)}.";
+                    return $"No comparable quarter-over-quarter movement found for {StockListingLabel(stock, ticker)} as of {FormatDate(targetDate)}. {(comparison == null ? "No prior quarter is available." : comparison.Note)}";
 
                 var topHolderIds = topBuyers
                     .Select(m => m.Id)
@@ -1092,9 +1098,9 @@ public class InstitutionalHoldingsTools
                 var comparisonNote =
                     windowOpen
                         ? $"Note: the {FormatDate(targetDate)} filing window is still open — "
-                            + "movement is computed only across funds that have already filed."
+                            + "movement requires observed filings in both compared quarters."
                     : previousDate.HasValue
-                        ? $"Note: sellers are counted only among funds that filed a 13F for {FormatDate(targetDate)} — "
+                        ? $"Note: buyers and sellers require observed 13F filings in both compared quarters — "
                             + "funds that stopped filing under this CIK (migrations, deregistrations) are excluded."
                     : null;
 
@@ -1105,7 +1111,7 @@ public class InstitutionalHoldingsTools
                     previousDate,
                     buyerRows,
                     sellerRows,
-                    JoinNotes(dateNote, comparisonNote)
+                    JoinNotes(JoinNotes(dateNote, comparisonNote), comparison?.Note)
                 );
             },
             "GetTopInstitutionalBuyersSellers",

--- a/tests/Equibles.IntegrationTests/Helpers/HoldingsReadCounter.cs
+++ b/tests/Equibles.IntegrationTests/Helpers/HoldingsReadCounter.cs
@@ -1,0 +1,21 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Equibles.IntegrationTests.Helpers;
+
+internal sealed class HoldingsReadCounter : DbCommandInterceptor
+{
+    public int Reads { get; private set; }
+
+    public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+        DbCommand command,
+        CommandEventData eventData,
+        InterceptionResult<DbDataReader> result,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (command.CommandText.Contains("InstitutionalHolding"))
+            Reads++;
+        return base.ReaderExecutingAsync(command, eventData, result, cancellationToken);
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsComparisonCoveragePostgresTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsComparisonCoveragePostgresTests.cs
@@ -1,0 +1,71 @@
+using Equibles.CommonStocks.Data.Models;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Repositories;
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsComparisonCoveragePostgresTests(ParadeDbFixture fixture) : IAsyncLifetime
+{
+    public Task InitializeAsync() => fixture.ResetAsync();
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Theory]
+    [InlineData(4)]
+    [InlineData(20)]
+    public async Task History_BatchesEvidenceRegardlessOfQuarterCount(int quarterCount)
+    {
+        var stock = new CommonStock { Ticker = "COVER", Name = "Coverage subject" };
+        var other = new CommonStock { Ticker = "OTHER", Name = "Other issuer" };
+        var stable = new InstitutionalHolder { Cik = "1", Name = "Stable filer" };
+        var rotating = new InstitutionalHolder { Cik = "2", Name = "Rotating filer" };
+        var dates = Enumerable
+            .Range(0, quarterCount)
+            .Select(i => new DateOnly(2020, 1, 1).AddMonths((i + 1) * 3).AddDays(-1))
+            .ToArray();
+        await using (var seed = fixture.CreateDbContext())
+        {
+            seed.AddRange(stock, other, stable, rotating);
+            for (var i = 0; i < dates.Length; i++)
+            {
+                seed.Add(Holding(stock, stable, dates[i]));
+                seed.Add(Holding(i % 2 == 0 ? stock : other, rotating, dates[i]));
+            }
+            await seed.SaveChangesAsync();
+        }
+        var counter = new HoldingsReadCounter();
+        await using var db = fixture.CreateDbContext(options => options.AddInterceptors(counter));
+        var result = await HoldingsComparisonCoverage.History(
+            new InstitutionalHoldingRepository(db),
+            stock,
+            dates
+        );
+        result.Should().HaveCount(quarterCount - 1);
+        result.Values.Should().OnlyContain(status => status.ComparisonAvailable);
+        counter
+            .Reads.Should()
+            .Be(2, "position presence and missing-side evidence each use one batched read");
+    }
+
+    private static InstitutionalHolding Holding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly date
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            ReportDate = date,
+            FilingDate = date.AddDays(40),
+            FilingType = FilingType.Form13F,
+            Shares = 100,
+            Value = 10000,
+            AccessionNumber = Guid.NewGuid().ToString("N"),
+            ShareType = ShareType.Shares,
+        };
+}

--- a/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
+++ b/tests/Equibles.IntegrationTests/Mcp/InstitutionalHoldingsToolsGetTopBuyersSellersTests.cs
@@ -19,8 +19,7 @@ namespace Equibles.IntegrationTests.Mcp;
 /// (Δ &lt; 0) ascending — and handles four boundary cases that the implementation has to
 /// get right: a fresh new position (no prior row), a sold-out position (no current row),
 /// an unchanged position (Δ = 0 → must be excluded from both lists), and the
-/// no-prior-quarter case (every holder is a "new" buyer because the prior quarter is
-/// empty).
+/// no-prior-quarter case (movement is unavailable without a comparison).
 /// </summary>
 [Collection(ParadeDbCollection.Name)]
 public class InstitutionalHoldingsToolsGetTopInstitutionalBuyersSellersTests : ParadeDbMcpTestBase
@@ -72,6 +71,8 @@ public class InstitutionalHoldingsToolsGetTopInstitutionalBuyersSellersTests : P
         };
         DbContext.Add(otherStock);
         DbContext.Add(MakeHolding(otherStock, soldOut, latest, shares: 10));
+        // A prior 13F establishes that the newcomer's missing stock position was an absence.
+        DbContext.Add(MakeHolding(otherStock, newcomer, prior, shares: 10));
         await DbContext.SaveChangesAsync();
         DbContext.ChangeTracker.Clear();
 
@@ -125,7 +126,7 @@ public class InstitutionalHoldingsToolsGetTopInstitutionalBuyersSellersTests : P
     }
 
     [Fact]
-    public async Task GetTopInstitutionalBuyersSellers_NoPriorQuarter_TreatsAllHoldersAsBuyers()
+    public async Task GetTopInstitutionalBuyersSellers_NoPriorQuarter_ReportsUnavailableComparison()
     {
         var stock = new CommonStock
         {
@@ -160,20 +161,10 @@ public class InstitutionalHoldingsToolsGetTopInstitutionalBuyersSellersTests : P
 
         var output = await sut.GetTopInstitutionalBuyersSellers("MSFT");
 
-        // No prior quarter → both holders surface as buyers with their full positions.
-        var buyersSection = output.Substring(
-            output.IndexOf("## Top Buyers"),
-            output.IndexOf("## Top Sellers") - output.IndexOf("## Top Buyers")
-        );
-        buyersSection
-            .IndexOf("Alpha Capital")
-            .Should()
-            .BeLessThan(buyersSection.IndexOf("Beta Capital"));
-        buyersSection.Should().Contain("+5,000");
-        buyersSection.Should().Contain("+3,000");
-
-        // No sellers when there is no prior quarter.
-        output.Should().Contain("_No sellers this quarter._");
+        output.Should().Contain("No prior quarter");
+        output.Should().NotContain("## Top Buyers");
+        output.Should().NotContain("+5,000");
+        output.Should().NotContain("+3,000");
     }
 
     [Fact]
@@ -268,7 +259,7 @@ public class InstitutionalHoldingsToolsGetTopInstitutionalBuyersSellersTests : P
         var output = await sut.GetTopInstitutionalBuyersSellers("NVDA");
 
         // No buyers and no sellers — early-return message, not the per-section tables.
-        output.Should().Contain("No quarter-over-quarter movement found");
+        output.Should().Contain("No comparable quarter-over-quarter movement found");
         output.Should().NotContain("## Top Buyers");
         output.Should().NotContain("## Top Sellers");
     }
@@ -399,7 +390,7 @@ public class InstitutionalHoldingsToolsGetTopInstitutionalBuyersSellersTests : P
 
         var output = await sut.GetTopInstitutionalBuyersSellers("GOOGL");
 
-        output.Should().Contain("No quarter-over-quarter movement found");
+        output.Should().Contain("No comparable quarter-over-quarter movement found");
     }
 
     private static InstitutionalHolding MakeHolding(

--- a/tests/Equibles.UnitTests/Holdings/HoldingsComparisonCoverageTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsComparisonCoverageTests.cs
@@ -1,0 +1,209 @@
+using Equibles.CommonStocks.Data;
+using Equibles.CommonStocks.Data.Models;
+using Equibles.CommonStocks.Repositories;
+using Equibles.CorporateActions.Data;
+using Equibles.CorporateActions.Repositories;
+using Equibles.Data;
+using Equibles.Errors.BusinessLogic;
+using Equibles.Errors.Data;
+using Equibles.Errors.Repositories;
+using Equibles.Holdings.BusinessLogic;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Equibles.Holdings.Mcp.Tools;
+using Equibles.Holdings.Repositories;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsComparisonCoverageTests
+{
+    private static readonly DateOnly Prior = new(2025, 9, 30);
+    private static readonly DateOnly Current = new(2025, 12, 31);
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task History_MissingFilersOnEitherSide_WithholdsDelta(bool missingPrior)
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple",
+            Cik = "320193",
+        };
+        var stable = new InstitutionalHolder { Name = "Stable", Cik = "100" };
+        var missing = new InstitutionalHolder { Name = "CoverageGapFiler", Cik = "200" };
+        db.AddRange(stock, stable, missing);
+        db.AddRange(
+            Holding(stock, stable, Prior, 100),
+            Holding(stock, stable, Current, 110),
+            Holding(stock, missing, missingPrior ? Current : Prior, 900)
+        );
+        await db.SaveChangesAsync();
+        var repository = new InstitutionalHoldingRepository(db);
+
+        var coverage = await HoldingsComparisonCoverage.History(
+            repository,
+            stock,
+            [Prior, Current]
+        );
+        coverage[Current].ComparisonAvailable.Should().BeFalse();
+        coverage[Current].CanCompareHolder(stable.Id).Should().BeTrue();
+        coverage[Current].CanCompareHolder(missing.Id).Should().BeFalse();
+        var history = await Tools(db).GetInstitutionalOwnershipHistory("AAPL");
+        history.Should().Contain("unavailable (coverage)");
+        var movers = await Tools(db).GetTopInstitutionalBuyersSellers("AAPL", "2025-12-31");
+        movers.Should().Contain("Stable").And.NotContain("CoverageGapFiler");
+        movers.Should().Contain("no observed");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FiledElsewhere_ProvesEntryOrExit_WithoutInferringFromShareCount(bool entry)
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple",
+            Cik = "320193",
+        };
+        var other = new CommonStock
+        {
+            Ticker = "MSFT",
+            Name = "Microsoft",
+            Cik = "789019",
+        };
+        var holder = new InstitutionalHolder { Name = "Reporter", Cik = "100" };
+        var stable = new InstitutionalHolder { Name = "Stable", Cik = "200" };
+        db.AddRange(stock, other, holder, stable);
+        db.AddRange(
+            Holding(stock, stable, Prior, 100),
+            Holding(stock, stable, Current, 100),
+            Holding(stock, holder, entry ? Current : Prior, 900),
+            Holding(other, holder, entry ? Prior : Current, 0)
+        );
+        await db.SaveChangesAsync();
+        var coverage = await HoldingsComparisonCoverage.History(new(db), stock, [Prior, Current]);
+        coverage[Current].ComparisonAvailable.Should().BeTrue();
+        var movers = await Tools(db).GetTopInstitutionalBuyersSellers("AAPL", "2025-12-31");
+        movers.Should().Contain("Reporter");
+    }
+
+    [Fact]
+    public async Task Schedule13GDoesNotProvePrior13FFiling()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple",
+            Cik = "320193",
+        };
+        var holder = new InstitutionalHolder { Name = "Reporter", Cik = "100" };
+        db.AddRange(stock, holder);
+        var prior = Holding(stock, holder, Prior, 100);
+        prior.FilingType = FilingType.Schedule13G;
+        db.AddRange(prior, Holding(stock, holder, Current, 900));
+        await db.SaveChangesAsync();
+        var coverage = await HoldingsComparisonCoverage.History(new(db), stock, [Prior, Current]);
+        coverage[Current].MissingPreviousFilers.Should().Contain(holder.Id);
+    }
+
+    [Fact]
+    public async Task NonconsecutiveQuarters_WithholdComparisonEvenForTheSameFiler()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple",
+            Cik = "320193",
+        };
+        var holder = new InstitutionalHolder { Name = "Reporter", Cik = "100" };
+        db.AddRange(stock, holder);
+        var older = new DateOnly(2025, 6, 30);
+        db.AddRange(Holding(stock, holder, older, 100), Holding(stock, holder, Current, 110));
+        await db.SaveChangesAsync();
+        var coverage = await HoldingsComparisonCoverage.History(new(db), stock, [older, Current]);
+        coverage[Current].ComparisonAvailable.Should().BeFalse();
+        coverage[Current].CanCompareHolder(holder.Id).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UnchangedComparableQuarter_DoesNotClaimThePriorQuarterIsMissing()
+    {
+        await using var db = NewDb();
+        var stock = new CommonStock
+        {
+            Ticker = "AAPL",
+            Name = "Apple",
+            Cik = "320193",
+        };
+        var holder = new InstitutionalHolder { Name = "Reporter", Cik = "100" };
+        db.AddRange(stock, holder);
+        db.AddRange(Holding(stock, holder, Prior, 100), Holding(stock, holder, Current, 100));
+        await db.SaveChangesAsync();
+        var result = await Tools(db).GetTopInstitutionalBuyersSellers("AAPL", "2025-12-31");
+        result
+            .Should()
+            .Contain("No comparable quarter-over-quarter movement")
+            .And.NotContain("No prior quarter")
+            .And.NotContain("Comparison unavailable");
+    }
+
+    private static EquiblesFinancialDbContext NewDb()
+    {
+        var db = new EquiblesFinancialDbContext(
+            new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .EnableServiceProviderCaching(false)
+                .Options,
+            new IModuleConfiguration[]
+            {
+                new CommonStocksModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+                new HoldingsModuleConfiguration(),
+                new ErrorsModuleConfiguration(),
+            }
+        );
+        db.Database.EnsureCreated();
+        return db;
+    }
+
+    private static InstitutionalHolding Holding(
+        CommonStock stock,
+        InstitutionalHolder holder,
+        DateOnly date,
+        long shares
+    ) =>
+        new()
+        {
+            CommonStockId = stock.Id,
+            InstitutionalHolderId = holder.Id,
+            ReportDate = date,
+            FilingDate = date.AddDays(45),
+            FilingType = FilingType.Form13F,
+            Shares = shares,
+            Value = shares * 100,
+            ShareType = ShareType.Shares,
+            AccessionNumber = Guid.NewGuid().ToString("N"),
+        };
+
+    private static InstitutionalHoldingsTools Tools(EquiblesFinancialDbContext db) =>
+        new(
+            new(db),
+            new(db),
+            new(db),
+            new(db),
+            new StockCombinedQuarterService(new(db), new(db)),
+            new ErrorManager(new ErrorRepository(db)),
+            NullLogger<InstitutionalHoldingsTools>.Instance
+        );
+}


### PR DESCRIPTION
## Summary
Missing prior-quarter filings currently turn a holder's entire position into a reported purchase; missing filings on either side also become apparent ownership-history swings. Require observed 13F evidence in both consecutive quarters before publishing a comparison.

## Code changes
Retain reported totals and disclose unavailable history deltas. Share one symmetric filer-coverage guard between history and buyer/seller answers, accepting zero-share rows and filings in other stocks as filing evidence. Batch missing holder/date evidence into one read; real PostgreSQL tests verify that four- and twenty-quarter histories both use two holdings queries total.

Validation: independent review passed; 4,963 unit tests passed before the final no-movers wording correction, followed by 60 focused regression tests. Two PostgreSQL batching tests and the full Release build/format check pass. Full repository test run is in progress.

Final validation: full Release build, full formatter check, 4,964 unit tests and 2,881 PostgreSQL integration tests passed. Independent review and the fixes-only review are clear.
