### PR TITLE
fix(holdings): cover stock-quarter exposure queries

### DIFF
--- a/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
+++ b/src/Equibles.Holdings.Data/HoldingsModuleConfiguration.cs
@@ -40,15 +40,22 @@ public class HoldingsModuleConfiguration : Equibles.Data.IFinancialModule
         // quarters and the heap fetch dominated cold load time. EF merges this
         // with the entity's `[Index(CommonStockId, ReportDate)]` attribute, so
         // there's a single btree on those columns with the INCLUDE list attached.
+        // Listing, filing-type and option filters must also be covered; otherwise the
+        // position totals and concentration history still fetch the entire stock's heap slice.
         builder
             .Entity<InstitutionalHolding>()
             .HasIndex(h => new { h.CommonStockId, h.ReportDate })
+            .HasDatabaseName("IX_InstitutionalHolding_StockQuarterExposure")
             .IncludeProperties(h => new
             {
                 h.InstitutionalHolderId,
                 h.Value,
                 h.Shares,
-            });
+                h.ListedTicker,
+                h.FilingType,
+                h.OptionType,
+            })
+            .IsCreatedConcurrently();
 
         // Partial covering index for the holder-rank aggregate on the single-holder /
         // single-stock page. That query needs only common-share 13F rows for one

--- a/src/Equibles.Migrations/Migrations/20260909152328_CoverStockQuarterExposure.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260909152328_CoverStockQuarterExposure.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260909152328_CoverStockQuarterExposure")]
+    partial class CoverStockQuarterExposure
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260909152328_CoverStockQuarterExposure.cs
+++ b/src/Equibles.Migrations/Migrations/20260909152328_CoverStockQuarterExposure.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class CoverStockQuarterExposure : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_StockQuarterExposure",
+                table: "InstitutionalHolding",
+                columns: new[] { "CommonStockId", "ReportDate" })
+                .Annotation("Npgsql:CreatedConcurrently", true)
+                .Annotation("Npgsql:IndexInclude", new[] { "InstitutionalHolderId", "Value", "Shares", "ListedTicker", "FilingType", "OptionType" });
+
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_InstitutionalHolding_CommonStockId_ReportDate\";",
+                suppressTransaction: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_InstitutionalHolding_CommonStockId_ReportDate",
+                table: "InstitutionalHolding",
+                columns: new[] { "CommonStockId", "ReportDate" })
+                .Annotation("Npgsql:CreatedConcurrently", true)
+                .Annotation("Npgsql:IndexInclude", new[] { "InstitutionalHolderId", "Value", "Shares" });
+
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS \"IX_InstitutionalHolding_StockQuarterExposure\";",
+                suppressTransaction: true);
+        }
+    }
+}

--- a/tests/Equibles.IntegrationTests/Holdings/HoldingsStockQuarterIndexPostgresTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/HoldingsStockQuarterIndexPostgresTests.cs
@@ -1,0 +1,37 @@
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+[Collection(ParadeDbCollection.Name)]
+public class HoldingsStockQuarterIndexPostgresTests(ParadeDbFixture fixture)
+{
+    [Fact]
+    public async Task MigratedDatabase_HasValidIndexCoveringStockQuarterFiltersAndAggregates()
+    {
+        await using var db = fixture.CreateDbContext();
+        var definition = await db
+            .Database.SqlQueryRaw<string>(
+                """
+                SELECT pg_get_indexdef(c.oid) AS "Value"
+                FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid
+                WHERE c.relname = 'IX_InstitutionalHolding_StockQuarterExposure' AND i.indisvalid
+                """
+            )
+            .SingleAsync();
+        definition
+            .Should()
+            .Contain(
+                "(\"CommonStockId\", \"ReportDate\") INCLUDE (\"InstitutionalHolderId\", \"Value\", \"Shares\", \"ListedTicker\", \"FilingType\", \"OptionType\")"
+            );
+        var oldIndex = await db
+            .Database.SqlQueryRaw<int>(
+                """
+                SELECT count(*)::int AS "Value" FROM pg_class
+                WHERE relname = 'IX_InstitutionalHolding_CommonStockId_ReportDate'
+                """
+            )
+            .SingleAsync();
+        oldIndex.Should().Be(0);
+    }
+}

--- a/tests/Equibles.UnitTests/Holdings/HoldingsStockQuarterExposureIndexTests.cs
+++ b/tests/Equibles.UnitTests/Holdings/HoldingsStockQuarterExposureIndexTests.cs
@@ -1,0 +1,44 @@
+using Equibles.CorporateActions.Data;
+using Equibles.Data;
+using Equibles.Holdings.Data;
+using Equibles.Holdings.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.UnitTests.Holdings;
+
+public class HoldingsStockQuarterExposureIndexTests
+{
+    [Fact]
+    public void StockQuarterQueries_CoverListingAndPositionFiltersWithoutHeapReads()
+    {
+        using var db = new EquiblesFinancialDbContext(
+            new DbContextOptionsBuilder<EquiblesFinancialDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options,
+            new IModuleConfiguration[]
+            {
+                new HoldingsModuleConfiguration(),
+                new CorporateActionsModuleConfiguration(),
+            }
+        );
+        var index = db
+            .Model.FindEntityType(typeof(InstitutionalHolding))
+            .GetIndexes()
+            .Single(i =>
+                i.Properties.Select(p => p.Name)
+                    .SequenceEqual(new[] { "CommonStockId", "ReportDate" })
+            );
+        index.GetDatabaseName().Should().Be("IX_InstitutionalHolding_StockQuarterExposure");
+        ((IReadOnlyList<string>)index.FindAnnotation("Npgsql:IndexInclude").Value)
+            .Should()
+            .BeEquivalentTo(
+                "InstitutionalHolderId",
+                "Value",
+                "Shares",
+                "ListedTicker",
+                "FilingType",
+                "OptionType"
+            );
+        index.FindAnnotation("Npgsql:CreatedConcurrently").Value.Should().Be(true);
+    }
+}


### PR DESCRIPTION
## Summary
Stock-quarter exposure queries still fetch holding rows from the table to apply listing, filing-type and option filters, even when their aggregate columns are indexed. Replace the stock-quarter index with one covering those filters and the holder/share/value aggregates.

## Code changes
Generate a financial migration with the replacement index under a new name. Build it concurrently before removing the previous index concurrently; rollback also retains coverage until its replacement exists. Add model-contract and real PostgreSQL migration tests that verify the valid deployed index contains every required column.

Validation: independent review, both focused tests, full Release build and formatter check passed. Full repository tests passed: 4,958 unit tests and 2,880 PostgreSQL integration tests. Production latency will be verified after rollout.
