### PR TITLE
fix(sec): cover the N-PORT fund-holder filing join

### DIFF
--- a/src/Equibles.Migrations/Migrations/20260909160010_CoverNportHolderCount.Designer.cs
+++ b/src/Equibles.Migrations/Migrations/20260909160010_CoverNportHolderCount.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Equibles.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Equibles.Migrations.Migrations
 {
     [DbContext(typeof(EquiblesFinancialDbContext))]
-    partial class EquiblesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260909160010_CoverNportHolderCount")]
+    partial class CoverNportHolderCount
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Equibles.Migrations/Migrations/20260909160010_CoverNportHolderCount.cs
+++ b/src/Equibles.Migrations/Migrations/20260909160010_CoverNportHolderCount.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Equibles.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class CoverNportHolderCount : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_NportHolding_CusipFiling",
+                table: "NportHolding",
+                column: "Cusip")
+                .Annotation("Npgsql:CreatedConcurrently", true)
+                .Annotation("Npgsql:IndexInclude", new[] { "NportFilingId" });
+
+            migrationBuilder.Sql("DROP INDEX CONCURRENTLY IF EXISTS \"IX_NportHolding_Cusip\";", suppressTransaction: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_NportHolding_Cusip",
+                table: "NportHolding",
+                column: "Cusip")
+                .Annotation("Npgsql:CreatedConcurrently", true);
+
+            migrationBuilder.Sql("DROP INDEX CONCURRENTLY IF EXISTS \"IX_NportHolding_CusipFiling\";", suppressTransaction: true);
+        }
+    }
+}

--- a/src/Equibles.Sec.Data/SecModuleConfiguration.cs
+++ b/src/Equibles.Sec.Data/SecModuleConfiguration.cs
@@ -67,7 +67,13 @@ public class SecModuleConfiguration : Equibles.Data.IFinancialModule
         builder.Entity<NCenFiling>();
         builder.Entity<NCenServiceProvider>();
         builder.Entity<NportFiling>();
-        builder.Entity<NportHolding>();
+        builder.Entity<NportHolding>(b =>
+        {
+            b.HasIndex(h => h.Cusip)
+                .HasDatabaseName("IX_NportHolding_CusipFiling")
+                .IncludeProperties(h => h.NportFilingId)
+                .IsCreatedConcurrently();
+        });
         builder.Entity<ProcessedNportFiling>();
         builder.Entity<TranscriptCheckStatus>();
     }

--- a/tests/Equibles.IntegrationTests/Holdings/NportHolderCountIndexPostgresTests.cs
+++ b/tests/Equibles.IntegrationTests/Holdings/NportHolderCountIndexPostgresTests.cs
@@ -1,0 +1,33 @@
+using Equibles.IntegrationTests.Helpers;
+using Microsoft.EntityFrameworkCore;
+
+namespace Equibles.IntegrationTests.Holdings;
+
+[Collection(ParadeDbCollection.Name)]
+public class NportHolderCountIndexPostgresTests(ParadeDbFixture fixture)
+{
+    [Fact]
+    public async Task MigratedDatabase_CoversCusipAndLatestFilingJoin()
+    {
+        await using var db = fixture.CreateDbContext();
+        var definition = await db
+            .Database.SqlQueryRaw<string>(
+                """
+                SELECT pg_get_indexdef(c.oid) AS "Value"
+                FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid
+                WHERE c.relname = 'IX_NportHolding_CusipFiling' AND i.indisvalid
+                """
+            )
+            .SingleAsync();
+        definition.Should().Contain("(\"Cusip\") INCLUDE (\"NportFilingId\")");
+        var oldIndex = await db
+            .Database.SqlQueryRaw<int>(
+                """
+                SELECT count(*)::int AS "Value" FROM pg_class
+                WHERE relname = 'IX_NportHolding_Cusip'
+                """
+            )
+            .SingleAsync();
+        oldIndex.Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary
Fund-holder counts join CUSIP-matched N-PORT holdings to each fund series’ latest filing. The bare CUSIP index requires a table read for every matched historical holding, producing timeouts under load.

## Code changes
Include NportFilingId in the CUSIP index under a new name. The generated migration creates its replacement concurrently before removing the old index concurrently; rollback preserves coverage the same way. Keep all existing identity and latest-filing selection rules. Add a real PostgreSQL migration test for the deployed index definition.

Validation: full Release build, formatter check and focused PostgreSQL migration test passed. Full repository tests passed (4,958 unit and 2,881 PostgreSQL integration), and independent review is clear. Production verification will compare the identical count query after the matching commercial migration deploys.

After including the merged ownership prerequisite: full Release build, formatter, 4,965 unit and 2,883 PostgreSQL integration tests passed.
