### PR TITLE
fix(corporate-actions): preserve authoritative split corrections

### DIFF
--- a/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
+++ b/src/Equibles.CorporateActions.BusinessLogic/StockSplitCaptureManager.cs
@@ -92,14 +92,19 @@ public class StockSplitCaptureManager
                 changes++;
             }
             else if (
-                match.PriceSeriesTicker == null
-                || match.Numerator != split.Numerator
-                || match.Denominator != split.Denominator
+                split.Source >= match.Source
+                && (
+                    match.PriceSeriesTicker == null
+                    || match.Numerator != split.Numerator
+                    || match.Denominator != split.Denominator
+                    || match.Source != split.Source
+                )
             )
             {
                 match.PriceSeriesTicker = resolvedTicker;
                 match.Numerator = split.Numerator;
                 match.Denominator = split.Denominator;
+                match.Source = split.Source;
                 // Prices were adjusted for the old ratio — force a re-reconcile.
                 match.PriceAdjustmentAppliedTime = null;
                 changes++;

--- a/src/Equibles.CorporateActions.Data/Models/StockSplitSource.cs
+++ b/src/Equibles.CorporateActions.Data/Models/StockSplitSource.cs
@@ -4,6 +4,8 @@ namespace Equibles.CorporateActions.Data.Models;
 
 public enum StockSplitSource
 {
+    // Persisted values also define capture precedence: Manual > SecFiling > External > Yahoo.
+    // A lower-priority refresh must never undo a corrected action definition.
     [Display(Name = "Yahoo")]
     Yahoo,
 

--- a/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
+++ b/src/Equibles.Yahoo.HostedService/Services/YahooPriceImportService.cs
@@ -58,7 +58,8 @@ internal readonly record struct AppliedSplitBoundary(
 internal readonly record struct SplitBasisDefinition(
     DateOnly EffectiveDate,
     decimal Numerator,
-    decimal Denominator
+    decimal Denominator,
+    StockSplitSource Source = StockSplitSource.Yahoo
 );
 
 [Service]
@@ -1261,7 +1262,8 @@ public class YahooPriceImportService
                 .Select(split => new SplitBasisDefinition(
                     split.EffectiveDate,
                     split.Numerator,
-                    split.Denominator
+                    split.Denominator,
+                    split.Source
                 ))
                 .ToListAsync(cancellationToken);
             if (
@@ -1329,7 +1331,19 @@ public class YahooPriceImportService
         out IReadOnlyList<SplitBasisDefinition> resolved
     )
     {
-        var candidates = capturedBoundaries.Concat(responseBoundaries).ToList();
+        // A higher-priority captured source can correct Yahoo's event metadata. Its locked
+        // ratio still has to pass the fetched-price boundary check before anything is stored.
+        var correctedDates = capturedBoundaries
+            .Where(boundary => boundary.Source > StockSplitSource.Yahoo)
+            .Select(boundary => boundary.EffectiveDate)
+            .ToHashSet();
+        var candidates = capturedBoundaries
+            .Concat(
+                responseBoundaries.Where(boundary =>
+                    !correctedDates.Contains(boundary.EffectiveDate)
+                )
+            )
+            .ToList();
         var conflict = candidates
             .GroupBy(boundary => boundary.EffectiveDate)
             .Select(group => new

--- a/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
+++ b/tests/Equibles.IntegrationTests/Yahoo/YahooPriceImportServiceTests.cs
@@ -29,6 +29,57 @@ namespace Equibles.IntegrationTests.Yahoo;
 
 public class YahooPriceImportServiceTests : IDisposable
 {
+    [Fact]
+    public async Task Import_CorrectedReferenceSplit_RestatesHistoryDespiteStaleYahooRatio()
+    {
+        var stock = CreateStock("CORR", "Corrected Split");
+        await SeedStocks(stock);
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var after = UsMarketCalendar.PreviousTradingDay(today);
+        var before = UsMarketCalendar.PreviousTradingDay(after);
+        await SeedPrices(CreatePrice(stock, before, 0.01m), CreatePrice(stock, after, 625m));
+        _splitRepo.Add(
+            new StockSplit
+            {
+                CommonStockId = stock.Id,
+                PriceSeriesTicker = stock.Ticker,
+                EffectiveDate = after,
+                Numerator = 1m,
+                Denominator = 60000m,
+                Source = StockSplitSource.External,
+            }
+        );
+        await _splitRepo.SaveChanges();
+        var chart = CreateChartData((before, 0.01m), (after, 625m));
+        chart.Prices[0].Open = 0.01m;
+        chart.Prices[0].High = 0.015m;
+        chart.Prices[0].Low = 0.01m;
+        chart.Splits.Add(
+            new StockSplitEvent
+            {
+                Date = after,
+                Numerator = 1m,
+                Denominator = 2m,
+            }
+        );
+        _yahooClient
+            .GetChart(stock.Ticker, Arg.Any<DateOnly>(), Arg.Any<DateOnly>())
+            .Returns(chart);
+
+        await _service.Import(includeEnrichment: false, CancellationToken.None);
+
+        _priceRepo
+            .GetAll()
+            .OrderBy(price => price.Date)
+            .Select(price => price.Close)
+            .Should()
+            .Equal(600m, 625m);
+        var split = _splitRepo.GetAll().Single();
+        split.Denominator.Should().Be(60000m);
+        split.Source.Should().Be(StockSplitSource.External);
+        split.PriceAdjustmentAppliedTime.Should().NotBeNull();
+    }
+
     private readonly EquiblesFinancialDbContext _dbContext;
     private readonly DailyStockPriceRepository _priceRepo;
     private readonly CommonStockRepository _stockRepo;

--- a/tests/Equibles.UnitTests/CorporateActions/StockSplitCaptureManagerTests.cs
+++ b/tests/Equibles.UnitTests/CorporateActions/StockSplitCaptureManagerTests.cs
@@ -13,6 +13,75 @@ namespace Equibles.UnitTests.CorporateActions;
 
 public class StockSplitCaptureManagerTests
 {
+    [Theory]
+    [InlineData(StockSplitSource.Yahoo, StockSplitSource.External, true)]
+    [InlineData(StockSplitSource.External, StockSplitSource.Yahoo, false)]
+    [InlineData(StockSplitSource.SecFiling, StockSplitSource.External, false)]
+    [InlineData(StockSplitSource.Manual, StockSplitSource.SecFiling, false)]
+    [InlineData(StockSplitSource.Yahoo, StockSplitSource.Manual, true)]
+    public async Task Capture_SourcePrecedence_PreservesAuthoritativeRatio(
+        StockSplitSource storedSource,
+        StockSplitSource incomingSource,
+        bool replaces
+    )
+    {
+        await using var context = NewDb();
+        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "SPLT" };
+        var applied = new DateTime(2026, 8, 6, 0, 0, 0, DateTimeKind.Utc);
+        var existing = new StockSplit
+        {
+            CommonStockId = stock.Id,
+            PriceSeriesTicker = stock.Ticker,
+            EffectiveDate = new DateOnly(2025, 1, 29),
+            Numerator = 1m,
+            Denominator = 2m,
+            Source = storedSource,
+            PriceAdjustmentAppliedTime = applied,
+        };
+        context.AddRange(stock, existing);
+        await context.SaveChangesAsync();
+        var incoming = new CapturedSplit
+        {
+            EffectiveDate = existing.EffectiveDate,
+            Numerator = 1m,
+            Denominator = 60000m,
+            Source = incomingSource,
+        };
+
+        var changed = await NewManager(context).Capture(stock.Id, stock.Ticker, [incoming]);
+
+        changed.Should().Be(replaces ? 1 : 0);
+        context.ChangeTracker.Clear();
+        var actual = await context.Set<StockSplit>().SingleAsync();
+        actual.Denominator.Should().Be(replaces ? 60000m : 2m);
+        actual.Source.Should().Be(replaces ? incomingSource : storedSource);
+        actual.PriceAdjustmentAppliedTime.Should().Be(replaces ? null : applied);
+    }
+
+    [Fact]
+    public async Task Capture_SourceUpgradeWithoutRatioChange_RevalidatesAppliedMarker()
+    {
+        await using var context = NewDb();
+        var stock = new CommonStock { Id = Guid.NewGuid(), Ticker = "SPLT" };
+        context.Add(stock);
+        await context.SaveChangesAsync();
+        var manager = NewManager(context);
+        await manager.Capture(stock.Id, stock.Ticker, [Split()]);
+        var existing = await context.Set<StockSplit>().SingleAsync();
+        var applied = DateTime.UtcNow;
+        existing.PriceAdjustmentAppliedTime = applied;
+        await context.SaveChangesAsync();
+        var incoming = Split();
+        incoming.Source = StockSplitSource.External;
+
+        (await manager.Capture(stock.Id, stock.Ticker, [incoming])).Should().Be(1);
+        context.ChangeTracker.Clear();
+        existing = await context.Set<StockSplit>().SingleAsync();
+        existing.Source.Should().Be(StockSplitSource.External);
+        existing.PriceAdjustmentAppliedTime.Should().BeNull();
+        (await manager.Capture(stock.Id, stock.Ticker, [Split(20m)])).Should().Be(0);
+    }
+
     private static EquiblesFinancialDbContext NewDb()
     {
         var options = new DbContextOptionsBuilder<EquiblesFinancialDbContext>()


### PR DESCRIPTION
## Summary
A stale Yahoo split ratio could overwrite a corrected reference or filing ratio and prevent historical-price reconciliation. Capture now honors Manual > SecFiling > External > Yahoo, records the source that supplied a correction, and invalidates its applied marker consistently with PostgreSQL.

## Code changes
History replacement uses the locked higher-priority definition when Yahoo reports conflicting event metadata. The existing price-boundary validation and restatement still run before committing prices. Conflicting definitions at the same priority remain refused.

## Verification
- 4,971 unit tests passed; the 13 capture tests passed again after review fixes.
- All 67 Yahoo import tests passed, including a 1-for-60,000 correction against a stale 1-for-2 response.
- Independent full-diff review and fix review passed.
